### PR TITLE
Quick Fix for validate_file_with_template test

### DIFF
--- a/backend/hct_mis_api/apps/registration_datahub/mutations.py
+++ b/backend/hct_mis_api/apps/registration_datahub/mutations.py
@@ -1,3 +1,5 @@
+import operator
+
 import graphene
 import openpyxl
 from django.core.exceptions import ValidationError
@@ -244,6 +246,7 @@ class UploadImportDataXLSXFile(
         errors = cls.validate(file=file)
 
         if errors:
+            errors.sort(key=operator.itemgetter('row_number', 'header'))
             return UploadImportDataXLSXFile(None, errors)
 
         wb = openpyxl.load_workbook(file)

--- a/backend/hct_mis_api/apps/registration_datahub/tests/test_xlsx_upload_validators_methods.py
+++ b/backend/hct_mis_api/apps/registration_datahub/tests/test_xlsx_upload_validators_methods.py
@@ -1,3 +1,4 @@
+import operator
 from unittest import TestCase
 
 import openpyxl
@@ -266,6 +267,7 @@ class TestXLSXValidatorsMethods(TestCase):
         invalid_cols_file_path = f"{self.FILES_DIR_PATH}/invalid_cols.xlsx"
         with open(invalid_cols_file_path, "rb") as file:
             errors = UploadXLSXValidator.validate_file_with_template(file=file)
+            errors.sort(key=operator.itemgetter('row_number', 'header'))
             expected = [
                 {
                     "row_number": 1,


### PR DESCRIPTION
Added error output sorting by row_number and header to mutation and validate_file_with_template test cause it was randomly failing because order was changing between runs