### PR TITLE
Fix/cant open some grievance tickets

### DIFF
--- a/frontend/src/components/Grievances/RequestedHouseholdDataChangeTable.tsx
+++ b/frontend/src/components/Grievances/RequestedHouseholdDataChangeTable.tsx
@@ -167,7 +167,7 @@ export function RequestedHouseholdDataChangeTable({
   const householdData = {
     ...ticket.householdDataUpdateTicketDetails.householdData,
   };
-  const flexFields = householdData.flex_fields;
+  const flexFields = householdData.flex_fields || {};
   delete householdData.flex_fields;
   const entries = Object.entries(householdData);
   const entriesFlexFields = Object.entries(flexFields);


### PR DESCRIPTION
https://unicef.visualstudio.com/ICTD-HCT-MIS/_workitems/edit/81423

This is a bit of a guess fix, but I noticed that the grievances that fail to open do not have 'flex_fields' value in householdDataUpdateTicketDetails dict and on front end we did not have a fallback for it before calling `Object.entries`.
Once this is on dev, I will test to see if grievances listed in the story, open successfully.