### PR TITLE
Fix: rdi import choices values

### DIFF
--- a/backend/hct_mis_api/apps/registration_datahub/tasks/rdi_create.py
+++ b/backend/hct_mis_api/apps/registration_datahub/tasks/rdi_create.py
@@ -56,6 +56,9 @@ class RdiBaseCreateTask:
     FLEX_FIELDS = serialize_flex_attributes()
 
     def _cast_value(self, value, header):
+        if isinstance(value, str):
+            value = value.strip()
+
         if value in (None, ""):
             return value
 
@@ -73,13 +76,13 @@ class RdiBaseCreateTask:
             choices = [x.get("value") for x in self.COMBINED_FIELDS[header]["choices"]]
 
             if value_type == TYPE_SELECT_MANY:
-                values = value.strip()
+                values = []
                 if "," in value:
-                    values = values.split(",")
+                    values = value.split(",")
                 elif ";" in value:
-                    values = values.split(";")
+                    values = value.split(";")
                 else:
-                    values = values.split(" ")
+                    values = value.split(" ")
                 valid_choices = []
                 for single_choice in values:
                     if isinstance(single_choice, str):


### PR DESCRIPTION
Bug ticket here https://unicef.visualstudio.com/ICTD-HCT-MIS/_workitems/edit/82205

The issue with front end not loading was that some Enum values were saved wrong to db during import: we had `FEMALE ` for one individual and `IDP ` for one household (extra spaces at the end), which caused graphql error since those were not correct values from choices lists. I simply added a `strip` call for all string values before proceeding with any other value modifications which seemed to fix the issue.