### PR TITLE
115385: Fix population disability

### DIFF
--- a/backend/hct_mis_api/apps/core/management/commands/fixpopulationdisability.py
+++ b/backend/hct_mis_api/apps/core/management/commands/fixpopulationdisability.py
@@ -13,14 +13,9 @@ class Command(BaseCommand):
             disability_certificate_picture__isnull=True
         ).exclude(
             disability_certificate_picture=''
-        )
+        ).update(disability=DISABLED)
 
-        for individual in qs:
-            individual.disability = DISABLED
-
-        Individual.objects.bulk_update(qs, ['disability'])
-
-        print(f"Fixed {qs.count()} object(s).")
+        print(f"Fixed {qs} object(s).")
 
     def handle(self, *args, **options):
         print("Starting Fix Population Disability")

--- a/backend/hct_mis_api/apps/registration_datahub/services/flex_registration_service.py
+++ b/backend/hct_mis_api/apps/registration_datahub/services/flex_registration_service.py
@@ -255,10 +255,11 @@ class FlexRegistrationService:
             last_registration_date=household.last_registration_date,
         )
         disability = individual_data.get("disability", "n")
+        disability_certificate_picture = individual_data.get("disability_certificate_picture")
         if disability == "y":
             individual_data["disability"] = DISABLED
         else:
-            individual_data["disability"] = NOT_DISABLED
+            individual_data["disability"] = DISABLED if disability_certificate_picture else NOT_DISABLED
 
         if relationship := individual_data.get("relationship"):
             individual_data["relationship"] = relationship.upper()
@@ -271,7 +272,7 @@ class FlexRegistrationService:
             if not phone_no.startswith("+380"):
                 individual_data["phone_no"] = f"+380{phone_no}"
 
-        if disability_certificate_picture := individual_data.get("disability_certificate_picture"):
+        if disability_certificate_picture:
             certificate_picture = f"CERTIFICATE_PICTURE_{uuid.uuid4()}"
             disability_certificate_picture = self._prepare_picture_from_base64(
                 disability_certificate_picture, certificate_picture


### PR DESCRIPTION
Added command `fixpopulationdisability`.
Update `Individual.disability` if `disability_certificate_picture` exists. 