### PR TITLE
Add `--skip-drop` to `initdemo` command

### DIFF
--- a/backend/hct_mis_api/apps/core/management/commands/initdemo.py
+++ b/backend/hct_mis_api/apps/core/management/commands/initdemo.py
@@ -9,10 +9,18 @@ from hct_mis_api.apps.registration_datahub.management.commands.fix_unicef_id_imp
 
 
 class Command(BaseCommand):
-    def handle(self, *args, **options):
-        self._drop_databases()
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--skip-drop",
+            action="store_true",
+            default=False,
+            help="Skip migrating - just reload the data",
+        )
 
-        call_command("migratealldb")
+    def handle(self, *args, **options):
+        if options["skip_drop"] is False:
+            self._drop_databases()
+            call_command("migratealldb")
 
         call_command("flush", "--noinput")
         call_command("flush", "--noinput", database="cash_assist_datahub_mis")


### PR DESCRIPTION
Now it can be run like this:
```
docker-compose run --rm backend ./manage.py initdemo --skip-drop
```
And the only output would be:
```
➜  hct-mis git:(initdemo) ✗ docker-compose run --rm backend ./manage.py initdemo --skip-drop
Creating hct-mis_backend_run ... done
Installed 1329 object(s) from 1 fixture(s)
Installed 37 object(s) from 1 fixture(s)
Installed 981 object(s) from 1 fixture(s)
Installed 1 object(s) from 1 fixture(s)
Installed 2020 object(s) from 1 fixture(s)
Installed 2 object(s) from 1 fixture(s)
Installed 2022 object(s) from 1 fixture(s)
Installed 9 object(s) (of 10) from 1 fixture(s)
Deleting index 'households'
Deleting index 'individuals'
Deleting index 'importedindividuals'
Creating index 'households'
Creating index 'individuals'
Creating index 'importedindividuals'
Indexing 6 'Individual' objects
Indexing 6 'ImportedIndividual' objects
Indexing 2 'Household' objects
```

There is no need to drop DB if we want to only reload data for example.