### PR TITLE
Fix KeyError when getting cached BA id

### DIFF
--- a/backend/hct_mis_api/apps/core/filters.py
+++ b/backend/hct_mis_api/apps/core/filters.py
@@ -8,6 +8,7 @@ from dateutil.parser import parse
 from django_filters import Filter
 
 from hct_mis_api.apps.core.utils import cached_business_areas_slug_id_dict
+from hct_mis_api.apps.core.models import BusinessArea
 
 
 def _clean_data_for_range_field(value, field):
@@ -177,5 +178,10 @@ class BusinessAreaSlugFilter(Filter):
     field_class = CharField
 
     def filter(self, qs, business_area_slug):
-        business_area_id = cached_business_areas_slug_id_dict()[business_area_slug]
+        cached_dict = cached_business_areas_slug_id_dict()
+        business_area_id = (
+            cached_dict[business_area_slug]
+            if business_area_slug in cached_dict
+            else BusinessArea.objects.get(slug=business_area_slug).id
+        )
         return qs.filter(business_area_id=business_area_id)


### PR DESCRIPTION
[AB#126151](https://unicef.visualstudio.com/4e044e8d-bc28-4768-8074-f80ff6e4a0e5/_workitems/edit/126151)

This was observed on Sentry:
https://excubo.unicef.io/sentry/hct-mis-trn/issues/11044/?query=is%3Aunresolved

![image](https://user-images.githubusercontent.com/91740028/185567591-bb03546a-6b1e-49cb-b13c-6afef7e81ecd.png)

This if-else should take the best of both worlds - caching for speedup and direct reference to BA id when the key is not present in the cached dict.