### PR TITLE
ExchangeRates: deserialize historical exchange rates on demand

### DIFF
--- a/backend/hct_mis_api/apps/core/exchange_rates/api.py
+++ b/backend/hct_mis_api/apps/core/exchange_rates/api.py
@@ -12,6 +12,8 @@ logger = logging.getLogger(__name__)
 
 
 class ExchangeRateAPI:
+    CACHE_KEY = "exchange_rates"
+
     def __init__(self, api_key: str = None, api_url: str = None):
         self.api_key = api_key or os.getenv("EXCHANGE_RATES_API_KEY")
         self.api_url = api_url or os.getenv(
@@ -30,7 +32,7 @@ class ExchangeRateAPI:
         params = {}
 
         if settings.EXCHANGE_RATE_CACHE_EXPIRY > 0:
-            cached_response = cache.get("exchange_rates")
+            cached_response = cache.get(self.CACHE_KEY)
             if cached_response is not None:
                 return cached_response
         if with_history is True:
@@ -44,5 +46,5 @@ class ExchangeRateAPI:
             raise
         response_json = response.json()
         if settings.EXCHANGE_RATE_CACHE_EXPIRY > 0:
-            cache.set("exchange_rates", response_json, settings.EXCHANGE_RATE_CACHE_EXPIRY)
+            cache.set(self.CACHE_KEY, response_json, settings.EXCHANGE_RATE_CACHE_EXPIRY)
         return response_json

--- a/backend/hct_mis_api/apps/core/exchange_rates/models.py
+++ b/backend/hct_mis_api/apps/core/exchange_rates/models.py
@@ -49,13 +49,12 @@ class SingleExchangeRate:
             past_xrates = [past_xrates]
         else:
             past_xrates.reverse()
-
-        self.historical_exchange_rates = [HistoryExchangeRate(**past_xrate) for past_xrate in past_xrates]
+        self.historical_exchange_rates = past_xrates
 
     def __repr__(self):
         return f"SingleExchangeRate(currency_code: {self.currency_code}, ratio: {self.ratio}, x_rate: {self.x_rate})"
 
-    def get_exchange_rate_by_dispersion_date(self, dispersion_date: datetime) -> Optional[float]:
+    def get_exchange_rate_by_dispersion_date(self, dispersion_date: Optional[datetime]) -> Optional[float]:
         today = timezone.now()
 
         dispersion_date_is_not_provided = dispersion_date is None
@@ -69,7 +68,8 @@ class SingleExchangeRate:
         if dispersion_date_is_in_current_date_range:
             return self.x_rate * self.ratio
 
-        for historical_exchange_rate in self.historical_exchange_rates:
+        for historical_exchange_rate_raw_data in self.historical_exchange_rates:
+            historical_exchange_rate = HistoryExchangeRate(**historical_exchange_rate_raw_data)
             if historical_exchange_rate.is_valid_for_provided_dispersion_date(dispersion_date):
                 return historical_exchange_rate.past_xrate * historical_exchange_rate.past_ratio
 

--- a/backend/hct_mis_api/apps/core/tests/test_exchange_rates.py
+++ b/backend/hct_mis_api/apps/core/tests/test_exchange_rates.py
@@ -174,10 +174,28 @@ class TestExchangeRates(TestCase):
         self.assertEqual(3, len(xeu.historical_exchange_rates))
 
         xeu_second_historical_rate = xeu.historical_exchange_rates[1]
-        self.assertEqual(datetime(1998, 2, 1, 0, 0), xeu_second_historical_rate.valid_from)
-        self.assertEqual(datetime(1998, 2, 28, 0, 0), xeu_second_historical_rate.valid_to)
-        self.assertEqual(0.926, xeu_second_historical_rate.past_xrate)
-        self.assertEqual(1, xeu_second_historical_rate.past_ratio)
+        self.assertEqual(
+            xeu_second_historical_rate,
+            {
+                "VALID_FROM": "01-FEB-98",
+                "VALID_TO": "28-FEB-98",
+                "PAST_XRATE": ".926",
+                "PAST_RATIO": "1",
+            },
+        )
+
+        # dispersion_date not provided, return current rate
+        self.assertEqual(xeu.get_exchange_rate_by_dispersion_date(dispersion_date=None), xeu.x_rate * xeu.ratio)
+        # dispersion_date from current valid date range, return current rate
+        self.assertEqual(
+            xeu.get_exchange_rate_by_dispersion_date(dispersion_date=datetime(1998, 12, 15, 0, 0)),
+            xeu.x_rate * xeu.ratio,
+        )
+        # dispersion_date from past valid date range, return past rate
+        self.assertEqual(
+            xeu.get_exchange_rate_by_dispersion_date(dispersion_date=datetime(1998, 2, 15, 0, 0)),
+            float(xeu_second_historical_rate["PAST_XRATE"]) * float(xeu_second_historical_rate["PAST_RATIO"]),
+        )
 
         self.assertEqual("CUP1", cup1.currency_code)
         self.assertEqual(1.0, cup1.ratio)


### PR DESCRIPTION
PaymentPlan create/update took up to 6-8 seconds because of ExchangeRates deserialisation.
Even if ExchangeRates data is taken from cache, deserialisation time from JSON to SingleExchangeRate objects is time consuming because for each currency (up to 170 different currencies) all historical rates data is deserialised at once.

There is a double loop:

 raw_exchange_rate["CURRENCY_CODE"]: SingleExchangeRate(**raw_exchange_rate)
            for raw_exchange_rate in raw_exchange_rates
            
 where in SingleExchangeRate.__init__:
 
self.historical_exchange_rates = [HistoryExchangeRate(**past_xrate) for past_xrate in past_xrates]

This creates up to 50 000 python objects (depends on historical data volume)


My fix is to prepare historical exchange rates data on demand for each currency.