### PR TITLE
feature:upgrade kobotoolbox

### DIFF
--- a/deployment/kobo/values.yaml
+++ b/deployment/kobo/values.yaml
@@ -100,7 +100,7 @@ rediscache:
 
 kpi:
   subdomain: kf
-  image: kobotoolbox/kpi:2.021.47
+  image: kobotoolbox/kpi:2.022.24e
   ravenDsn:
     "" # Uses old raven_dsn # Check github.com (https://github.com/kobotoolbox/kpi/blob/master/kobo/settings/base.py)
     # you need to add ?verify_ssl=0 as a suffix
@@ -142,7 +142,7 @@ kpi:
 
 kobocat:
   subdomain: kc
-  image: kobotoolbox/kobocat:2.021.47
+  image: kobotoolbox/kobocat:2.022.24a
   ravenDsn: ""
   service:
     type: "ClusterIP"
@@ -167,7 +167,7 @@ kobocat:
 
 enketo:
   subdomain: ek
-  image: kobotoolbox/enketo-express-extra-widgets:3.0.4
+  image: kobotoolbox/enketo-express-extra-widgets:4.1.2
   service:
     type: "ClusterIP"
   ## resource requests/limits for the kobocat pods


### PR DESCRIPTION
Upgrades kobotoolbox:

kpi: 2.021.47 -> 2.022.24e

kobocat: 2.021.47 -> 2.022.24a

enketo-express-extra-widgets: 3.0.4 -> 4.1.2