### PR TITLE
Fix pending trigger events issue

### DIFF
--- a/backend/hct_mis_api/apps/household/migrations/0127_migration.py
+++ b/backend/hct_mis_api/apps/household/migrations/0127_migration.py
@@ -37,14 +37,4 @@ class Migration(migrations.Migration):
             field=models.BooleanField(default=False),
         ),
         migrations.RunPython(update_each_phone_numbers_validity, migrations.RunPython.noop),
-        migrations.AlterField(
-            model_name="individual",
-            name="phone_no_alternative_valid",
-            field=models.BooleanField(default=False, db_index=True),
-        ),
-        migrations.AlterField(
-            model_name="individual",
-            name="phone_no_valid",
-            field=models.BooleanField(default=False, db_index=True),
-        ),
     ]

--- a/backend/hct_mis_api/apps/household/migrations/0128_migration.py
+++ b/backend/hct_mis_api/apps/household/migrations/0128_migration.py
@@ -1,0 +1,23 @@
+# Hand-written
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("household", "0127_migration"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="individual",
+            name="phone_no_alternative_valid",
+            field=models.BooleanField(default=False, db_index=True),
+        ),
+        migrations.AlterField(
+            model_name="individual",
+            name="phone_no_valid",
+            field=models.BooleanField(default=False, db_index=True),
+        ),
+    ]

--- a/backend/hct_mis_api/apps/household/migrations/0129_migration.py
+++ b/backend/hct_mis_api/apps/household/migrations/0129_migration.py
@@ -31,28 +31,33 @@ def populate_partner_and_country(apps, schema_editor):
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('account', '0043_migration'),
-        ('geo', '0007_migration'),
-        ('household', '0127_migration'),
+        ("account", "0043_migration"),
+        ("geo", "0007_migration"),
+        ("household", "0128_migration"),
     ]
 
     operations = [
         migrations.AddField(
-            model_name='individualidentity',
-            name='country',
-            field=models.ForeignKey(null=True, on_delete=django.db.models.deletion.PROTECT, to='geo.country'),
+            model_name="individualidentity",
+            name="country",
+            field=models.ForeignKey(null=True, on_delete=django.db.models.deletion.PROTECT, to="geo.country"),
         ),
         migrations.AddField(
-            model_name='individualidentity',
-            name='partner',
-            field=models.ForeignKey(null=True, on_delete=django.db.models.deletion.PROTECT, related_name='individual_identities', to='account.partner'),
+            model_name="individualidentity",
+            name="partner",
+            field=models.ForeignKey(
+                null=True,
+                on_delete=django.db.models.deletion.PROTECT,
+                related_name="individual_identities",
+                to="account.partner",
+            ),
         ),
         migrations.RunPython(populate_partner_and_country, migrations.RunPython.noop),
         migrations.RemoveField(
-            model_name='individualidentity',
-            name='agency',
+            model_name="individualidentity",
+            name="agency",
         ),
         migrations.DeleteModel(
-            name='Agency',
+            name="Agency",
         ),
     ]


### PR DESCRIPTION
Since there are issues like this https://excubo.unicef.io/sentry/hct-mis-dev/issues/12256/?query=is%3Aunresolved
```
ObjectInUse: cannot CREATE INDEX "household_individual" because it has pending trigger events
```
Maybe we could try splitting the adding of columns with db index to first adding it, then calculating it's value, then adding the index. This may be caused by the trigger that we have:
```
        migrations.RunSQL(
            sql='''
                  CREATE TRIGGER vector_column_trigger
                  BEFORE INSERT OR UPDATE OF observed_disability, full_name, vector_column
                  ON household_individual
                  FOR EACH ROW EXECUTE PROCEDURE
                  tsvector_update_trigger(
                    vector_column, 'pg_catalog.english', observed_disability, full_name
                  );

                  UPDATE household_individual SET vector_column = NULL;
                ''',

            reverse_sql='''
                  DROP TRIGGER IF EXISTS vector_column_trigger
                  ON household_individual;
                '''
        ),
```