### PR TITLE
143418_Sentry_still_deadlock_on_population_recalc

### DIFF
--- a/backend/hct_mis_api/apps/grievance/mutations_extras/data_change.py
+++ b/backend/hct_mis_api/apps/grievance/mutations_extras/data_change.py
@@ -713,7 +713,9 @@ def close_add_individual_grievance_ticket(grievance_ticket: GrievanceTicket, inf
         individual.save()
         if relationship_to_head_of_household == HEAD:
             household.head_of_household = individual
-            household_individuals = evaluate_qs(household.individuals.exclude(id=individual.id).select_for_update())
+            household_individuals = evaluate_qs(
+                household.individuals.exclude(id=individual.id).select_for_update().order_by("pk")
+            )
             household_individuals.update(relationship=RELATIONSHIP_UNKNOWN)
             household.save(update_fields=["head_of_household"])
         household.size += 1

--- a/backend/hct_mis_api/apps/household/celery_tasks.py
+++ b/backend/hct_mis_api/apps/household/celery_tasks.py
@@ -37,7 +37,8 @@ def recalculate_population_fields_chunk_task(households_ids: List[UUID]) -> None
                     Household.objects.filter(pk__in=households_ids)
                     .only("id", "collect_individual_data")
                     .prefetch_related("individuals")
-                    .select_for_update(of=("self",))
+                    .select_for_update(of=("self",), skip_locked=True)
+                    .order_by("pk")
                 ):
                     scope.set_tag("business_area", hh.business_area)
                     household, updated_fields = recalculate_data(hh, save=False)

--- a/backend/hct_mis_api/apps/household/services/household_recalculate_data.py
+++ b/backend/hct_mis_api/apps/household/services/household_recalculate_data.py
@@ -32,7 +32,7 @@ def recalculate_data(household: Household, save: bool = True) -> Tuple[Household
     individuals_to_update = []
     individuals_fields_to_update = []
 
-    for individual in household.individuals.all().select_for_update():
+    for individual in household.individuals.all().select_for_update().order_by("pk"):
         _individual, _fields_to_update = individual.recalculate_data(save=False)
         individuals_to_update.append(_individual)
         individuals_fields_to_update.extend(x for x in _fields_to_update if x not in individuals_fields_to_update)

--- a/backend/hct_mis_api/apps/household/services/household_withdraw.py
+++ b/backend/hct_mis_api/apps/household/services/household_withdraw.py
@@ -15,14 +15,14 @@ class HouseholdWithdraw:
     def withdraw(self, tag: Optional[Any] = None) -> None:
         self.household.withdraw(tag)
 
-        for individual in self.household.individuals.select_for_update().filter(duplicate=False):
+        for individual in self.household.individuals.select_for_update().filter(duplicate=False).order_by("pk"):
             individual.withdraw()
 
     @transaction.atomic
     def unwithdraw(self) -> None:
         self.household.unwithdraw()
 
-        for individual in self.household.individuals.select_for_update().filter(duplicate=False):
+        for individual in self.household.individuals.select_for_update().filter(duplicate=False).order_by("pk"):
             individual.unwithdraw()
 
     def change_tickets_status(self, tickets: Iterable) -> None:

--- a/backend/hct_mis_api/apps/registration_datahub/tasks/deduplicate.py
+++ b/backend/hct_mis_api/apps/registration_datahub/tasks/deduplicate.py
@@ -586,7 +586,9 @@ class DeduplicateTask:
         wait_until_es_healthy()
         cls.set_thresholds(registration_data_import.business_area)
         individuals = evaluate_qs(
-            Individual.objects.filter(registration_data_import=registration_data_import).select_for_update()
+            Individual.objects.filter(registration_data_import=registration_data_import)
+            .select_for_update()
+            .order_by("pk")
         )
 
         (
@@ -613,7 +615,7 @@ class DeduplicateTask:
         wait_until_es_healthy()
         cls.set_thresholds(business_area)
 
-        evaluate_qs(individuals.select_for_update())
+        evaluate_qs(individuals.select_for_update().order_by("pk"))
 
         to_bulk_update_results = []
         for individual in individuals:
@@ -840,6 +842,7 @@ class DeduplicateTask:
             new_documents.exclude(status=Document.STATUS_VALID)
             .select_related("individual")
             .select_for_update(of=("self", "individual"))
+            .order_by("pk")
         )
         documents_numbers = [x.document_number for x in documents_to_dedup]
         new_document_signatures = [f"{d.type_id}--{d.document_number}" for d in documents_to_dedup]

--- a/backend/hct_mis_api/apps/sanction_list/tasks/check_against_sanction_list_pre_merge.py
+++ b/backend/hct_mis_api/apps/sanction_list/tasks/check_against_sanction_list_pre_merge.py
@@ -142,7 +142,9 @@ class CheckAgainstSanctionListPreMergeTask:
         cache.set("sanction_list_last_check", timezone.now(), None)
 
         possible_matches_individuals = evaluate_qs(
-            Individual.objects.filter(id__in=possible_matches, sanction_list_possible_match=False).select_for_update()
+            Individual.objects.filter(id__in=possible_matches, sanction_list_possible_match=False)
+            .select_for_update()
+            .order_by("pk")
         )
         possible_matches_individuals.update(sanction_list_possible_match=True)
 
@@ -150,6 +152,7 @@ class CheckAgainstSanctionListPreMergeTask:
             Individual.objects.exclude(id__in=possible_matches)
             .filter(sanction_list_possible_match=True)
             .select_for_update()
+            .order_by("pk")
         )
         not_possible_matches_individuals.update(sanction_list_possible_match=False)
 


### PR DESCRIPTION
added select_for_update ordering and skip_locked=True on recalculate_population_fields_chunk_task