### PR TITLE
Fix celery recalculate_population_fields_task

### DIFF
--- a/backend/hct_mis_api/apps/household/celery_tasks.py
+++ b/backend/hct_mis_api/apps/household/celery_tasks.py
@@ -63,7 +63,7 @@ def recalculate_population_fields_task(household_ids: Optional[List[str]] = None
         .filter(collect_individual_data__in=(COLLECT_TYPE_FULL, COLLECT_TYPE_PARTIAL))
         .order_by("pk")
     )
-    if queryset.count() > 0:
+    if queryset.exists():
         paginator = Paginator(queryset, config.RECALCULATE_POPULATION_FIELDS_CHUNK)
 
         for page_number in paginator.page_range:


### PR DESCRIPTION
AB#[145801](https://dev.azure.com/unicef/ICTD-HCT-MIS/_workitems/edit/145801)

when query set is empty  Paginator return 1st page with empty list 
just FYI