### PR TITLE
[FIX] Fix gf url

### DIFF
--- a/backend/hct_mis_api/apps/grievance/notifications.py
+++ b/backend/hct_mis_api/apps/grievance/notifications.py
@@ -44,7 +44,7 @@ class GrievanceNotification:
         context = {
             "first_name": user_recipient.first_name,
             "last_name": user_recipient.last_name,
-            "ticket_url": f'{protocol}://{settings.FRONTEND_HOST}/{self.grievance_ticket.business_area.slug}/grievance-and-feedback/{encode_id_base64(self.grievance_ticket.id, "GrievanceTicket")}',
+            "ticket_url": f'{protocol}://{settings.FRONTEND_HOST}/{self.grievance_ticket.business_area.slug}/grievance/tickets/{self.grievance_ticket.grievance_type_to_string()}-generated/{encode_id_base64(self.grievance_ticket.id, "GrievanceTicket")}',
             "ticket_id": self.grievance_ticket.unicef_id,
             "ticket_category": self.grievance_ticket.get_category_display(),
         }


### PR DESCRIPTION
```
If category is user generated:
 “ticket_url”: f’{protocol}://{settings.FRONTEND_HOST}/{self.grievance_ticket.business_area.slug}/grievance/tickets/user-generated/{encode_id_base64(self.grievance_ticket.id, “GrievanceTicket”)}

If category is system generated:
 “ticket_url”: f’{protocol}://{settings.FRONTEND_HOST}/{self.grievance_ticket.business_area.slug}/grievance/tickets/system-generated/{encode_id_base64(self.grievance_ticket.id, “GrievanceTicket”)}'
```