### PR TITLE
[177475] Grievance - System Generated Tickets - Search by Household ID doesn't work

### DIFF
--- a/backend/hct_mis_api/apps/payment/services/verification_plan_status_change_services.py
+++ b/backend/hct_mis_api/apps/payment/services/verification_plan_status_change_services.py
@@ -138,13 +138,14 @@ class VerificationPlanStatusChangeServices:
             return
 
         business_area = payment_verification_plan.payment_plan_obj.business_area
-        grievance_ticket_list = [
-            GrievanceTicket(
+        grievance_ticket_list = []
+        for verification in verifications:
+            grievance_ticket = GrievanceTicket(
                 category=GrievanceTicket.CATEGORY_PAYMENT_VERIFICATION,
                 business_area=business_area,
+                household_unicef_id=verification.payment_obj.household.unicef_id,
             )
-            for _ in list(range(verifications.count()))
-        ]
+            grievance_ticket_list.append(grievance_ticket)
         grievance_ticket_objs = GrievanceTicket.objects.bulk_create(grievance_ticket_list)
 
         ticket_payment_verification_details_list = []

--- a/backend/hct_mis_api/apps/registration_datahub/tasks/deduplicate.py
+++ b/backend/hct_mis_api/apps/registration_datahub/tasks/deduplicate.py
@@ -765,6 +765,7 @@ class HardDocumentDeduplication:
             admin2=admin_level_2,
             area=area,
             registration_data_import=registration_data_import,
+            household_unicef_id=household.unicef_id if household else None,
         )
         ticket_details = TicketNeedsAdjudicationDetails(
             ticket=ticket,

--- a/backend/hct_mis_api/apps/registration_datahub/tests/test_handling_documents_duplicates.py
+++ b/backend/hct_mis_api/apps/registration_datahub/tests/test_handling_documents_duplicates.py
@@ -209,6 +209,9 @@ class TestGoldenRecordDeduplication(BaseElasticSearchTestCase):
         self.assertEqual(ticket_details.possible_duplicates.count(), 2)
         self.assertEqual(ticket_details.is_multiple_duplicates_version, True)
 
+        self.household.refresh_from_db()
+        self.assertEqual(GrievanceTicket.objects.first().household_unicef_id, self.household.unicef_id)
+
     def test_hard_documents_deduplication_for_initially_valid(self) -> None:
         HardDocumentDeduplication().deduplicate(
             self.get_documents_query(

--- a/backend/hct_mis_api/apps/sanction_list/tasks/check_against_sanction_list_pre_merge.py
+++ b/backend/hct_mis_api/apps/sanction_list/tasks/check_against_sanction_list_pre_merge.py
@@ -125,6 +125,7 @@ class CheckAgainstSanctionListPreMergeTask:
                                 admin2=admin_level_2,
                                 area=area,
                                 registration_data_import=registration_data_import,
+                                household_unicef_id=household.unicef_id if household else "",
                             )
                             ticket_details = TicketSystemFlaggingDetails(
                                 ticket=ticket,

--- a/backend/hct_mis_api/apps/sanction_list/tests/test_check_against_sanction_list_pre_merge.py
+++ b/backend/hct_mis_api/apps/sanction_list/tests/test_check_against_sanction_list_pre_merge.py
@@ -144,3 +144,7 @@ class TestSanctionListPreMerge(BaseElasticSearchTestCase):
     def test_create_system_flag_tickets(self) -> None:
         CheckAgainstSanctionListPreMergeTask.execute()
         self.assertEqual(GrievanceTicket.objects.filter(category=GrievanceTicket.CATEGORY_SYSTEM_FLAGGING).count(), 3)
+
+        self.household.refresh_from_db()
+        for grievance_ticket in GrievanceTicket.objects.filter(category=GrievanceTicket.CATEGORY_SYSTEM_FLAGGING):
+            self.assertEqual(grievance_ticket.household_unicef_id, self.household.unicef_id)


### PR DESCRIPTION
[AB#177475](https://unicef.visualstudio.com/4e044e8d-bc28-4768-8074-f80ff6e4a0e5/_workitems/edit/177475)

when already on prod, script to run: `update_household_unicef_id()`