### PR TITLE
[180445] Disable editing DCT for programs that already have households

### DIFF
--- a/backend/hct_mis_api/apps/program/tests/test_update_program.py
+++ b/backend/hct_mis_api/apps/program/tests/test_update_program.py
@@ -136,9 +136,6 @@ class TestUpdateProgram(APITestCase):
         self.create_user_role_with_permissions(user, [Permissions.PROGRAMME_UPDATE], self.business_area)
         data_collecting_type = DataCollectingType.objects.get(code="full_collection")
         data_collecting_type.limit_to.add(self.business_area)
-        pr = Program.objects.get(id=self.program.id)
-        self.assertEqual(pr.status, Program.DRAFT)
-        self.assertEqual(self.program.status, Program.DRAFT)
         create_household(household_args={"program": self.program})
 
         self.snapshot_graphql_request(


### PR DESCRIPTION
[AB#180445](https://unicef.visualstudio.com/4e044e8d-bc28-4768-8074-f80ff6e4a0e5/_workitems/edit/180445)