### PR TITLE
[HOT FIX] Unicef Partner BA list

### DIFF
--- a/backend/hct_mis_api/apps/account/models.py
+++ b/backend/hct_mis_api/apps/account/models.py
@@ -317,7 +317,7 @@ class User(AbstractUser, NaturalKeyModel, UUIDModel):
             list(
                 set(
                     [perm for perms in all_partner_roles_permissions_list for perm in perms]
-                    + [perm for perms in all_user_roles_permissions_list for perm in perms]
+                    + [perm for perms in all_user_roles_permissions_list if perms for perm in perms]
                 )
             )
             if has_program_access


### PR DESCRIPTION
[AB#185076](https://dev.azure.com/unicef/ICTD-HCT-MIS/_workitems/edit/185076): User still has access to BA even after deleting BA role from admin portal

http://20.71.8.160/sentry/hope-dev/issues/42/?query=is%3Aunresolved%20%27NoneType%27%20object%20is%20not%20iterable