### PR TITLE
[182671] Change account holder name to be not required

### DIFF
--- a/backend/hct_mis_api/apps/core/field_attributes/core_fields_attributes.py
+++ b/backend/hct_mis_api/apps/core/field_attributes/core_fields_attributes.py
@@ -1760,7 +1760,7 @@ CORE_FIELDS_ATTRIBUTES = [
         "lookup": "account_holder_name",
         "label": {"English(EN)": "Account holder name"},
         "hint": "",
-        "required": True,
+        "required": False,
         "choices": [],
         "associated_with": _INDIVIDUAL,
         "xlsx_field": "account_holder_name_i_c",

--- a/backend/hct_mis_api/apps/registration_datahub/tests/test_kobo_validators_methods.py
+++ b/backend/hct_mis_api/apps/registration_datahub/tests/test_kobo_validators_methods.py
@@ -609,10 +609,6 @@ class TestKoboSaveValidatorsMethods(TestCase):
         result = validator.validate_everything(self.INVALID_JSON, business_area)
         result.sort(key=itemgetter("header"))
         expected = [
-            {
-                "header": "account_holder_name_i_c",
-                "message": "Missing individual required field account_holder_name_i_c",
-            },
             {"header": "admin1_h_c", "message": "Invalid choice SO25 for field admin1_h_c"},
             {"header": "admin2_h_c", "message": "Invalid choice SO2502 for field admin2_h_c"},
             {


### PR DESCRIPTION
[AB#182671](https://unicef.visualstudio.com/4e044e8d-bc28-4768-8074-f80ff6e4a0e5/_workitems/edit/182671)
Change account holder name field to not required