### PR TITLE
[187732] Block possibility to remove primary collector role without reassigning to another individual

### DIFF
--- a/backend/hct_mis_api/apps/grievance/tests/services/data_change/test_change_individual_role.py
+++ b/backend/hct_mis_api/apps/grievance/tests/services/data_change/test_change_individual_role.py
@@ -1,3 +1,4 @@
+from django.core.exceptions import ValidationError
 from django.test import TestCase
 
 from hct_mis_api.apps.account.fixtures import BusinessAreaFactory, UserFactory
@@ -12,6 +13,7 @@ from hct_mis_api.apps.grievance.services.data_change.individual_data_update_serv
 )
 from hct_mis_api.apps.household.fixtures import HouseholdFactory, IndividualFactory
 from hct_mis_api.apps.household.models import (
+    ROLE_ALTERNATE,
     ROLE_NO_ROLE,
     ROLE_PRIMARY,
     IndividualRoleInHousehold,
@@ -32,12 +34,12 @@ class TestChangeIndividualRole(BaseElasticSearchTestCase, TestCase):
         household.registration_data_import.imported_by.save()
         household.registration_data_import.save()
 
-        individual = IndividualFactory(household=household, business_area=business_area, program=program)
-        household.head_of_household = individual
+        cls.individual_hoh = IndividualFactory(household=household, business_area=business_area, program=program)
+        household.head_of_household = cls.individual_hoh
         household.save()
         IndividualRoleInHousehold.objects.create(
             role=ROLE_PRIMARY,
-            individual=individual,
+            individual=cls.individual_hoh,
             household=household,
         )
 
@@ -49,12 +51,6 @@ class TestChangeIndividualRole(BaseElasticSearchTestCase, TestCase):
             business_area=business_area,
             status=GrievanceTicket.STATUS_FOR_APPROVAL,
         )
-
-        TicketIndividualDataUpdateDetailsFactory(
-            ticket=cls.ticket,
-            individual=cls.individual,
-            individual_data={"role": {"value": ROLE_PRIMARY, "approve_status": True}},
-        )
         super().setUpTestData()
 
     def test_change_role_from_none_to_alternate(self) -> None:
@@ -63,16 +59,146 @@ class TestChangeIndividualRole(BaseElasticSearchTestCase, TestCase):
             individual=self.individual,
             household=self.individual.household,
         )
+        TicketIndividualDataUpdateDetailsFactory(
+            ticket=self.ticket,
+            individual=self.individual,
+            individual_data={"role": {"value": ROLE_ALTERNATE, "approve_status": True}},
+        )
 
         service = IndividualDataUpdateService(self.ticket, self.ticket.individual_data_update_ticket_details)
         service.close(UserFactory())
 
         role = IndividualRoleInHousehold.objects.get(household=self.individual.household, individual=self.individual)
-        self.assertEqual(role.role, ROLE_PRIMARY)
+        self.assertEqual(role.role, ROLE_ALTERNATE)
 
     def test_change_role_to_alternate(self) -> None:
+        TicketIndividualDataUpdateDetailsFactory(
+            ticket=self.ticket,
+            individual=self.individual,
+            individual_data={"role": {"value": ROLE_ALTERNATE, "approve_status": True}},
+        )
+        service = IndividualDataUpdateService(self.ticket, self.ticket.individual_data_update_ticket_details)
+        service.close(UserFactory())
+
+        role = IndividualRoleInHousehold.objects.get(household=self.individual.household, individual=self.individual)
+        self.assertEqual(role.role, ROLE_ALTERNATE)
+
+    def test_change_role_from_alternate_to_none(self) -> None:
+        IndividualRoleInHousehold.objects.create(
+            role=ROLE_ALTERNATE,
+            individual=self.individual,
+            household=self.individual.household,
+        )
+        TicketIndividualDataUpdateDetailsFactory(
+            ticket=self.ticket,
+            individual=self.individual,
+            individual_data={"role": {"value": ROLE_NO_ROLE, "approve_status": True}},
+        )
+
+        service = IndividualDataUpdateService(self.ticket, self.ticket.individual_data_update_ticket_details)
+        service.close(UserFactory())
+
+        role = IndividualRoleInHousehold.objects.filter(
+            household=self.individual.household, individual=self.individual
+        ).first()
+        self.assertIsNone(role)
+
+    def test_change_role_from_none_to_primary(self) -> None:
+        IndividualRoleInHousehold.objects.create(
+            role=ROLE_NO_ROLE,
+            individual=self.individual,
+            household=self.individual.household,
+        )
+        TicketIndividualDataUpdateDetailsFactory(
+            ticket=self.ticket,
+            individual=self.individual,
+            individual_data={"role": {"value": ROLE_PRIMARY, "approve_status": True}},
+        )
+
         service = IndividualDataUpdateService(self.ticket, self.ticket.individual_data_update_ticket_details)
         service.close(UserFactory())
 
         role = IndividualRoleInHousehold.objects.get(household=self.individual.household, individual=self.individual)
         self.assertEqual(role.role, ROLE_PRIMARY)
+
+        previous_role = IndividualRoleInHousehold.objects.filter(
+            household=self.individual.household, individual=self.individual_hoh
+        ).first()
+        self.assertIsNone(previous_role)  # previous primary collector does not have a role anymore
+
+    def test_change_role_to_primary(self) -> None:
+        TicketIndividualDataUpdateDetailsFactory(
+            ticket=self.ticket,
+            individual=self.individual,
+            individual_data={"role": {"value": ROLE_PRIMARY, "approve_status": True}},
+        )
+
+        service = IndividualDataUpdateService(self.ticket, self.ticket.individual_data_update_ticket_details)
+        service.close(UserFactory())
+
+        role = IndividualRoleInHousehold.objects.get(household=self.individual.household, individual=self.individual)
+        self.assertEqual(role.role, ROLE_PRIMARY)
+
+        previous_role = IndividualRoleInHousehold.objects.filter(
+            household=self.individual.household, individual=self.individual_hoh
+        ).first()
+        self.assertIsNone(previous_role)  # previous primary collector does not have a role anymore
+
+    def test_change_role_from_alternate_to_primary(self) -> None:
+        IndividualRoleInHousehold.objects.create(
+            role=ROLE_ALTERNATE,
+            individual=self.individual,
+            household=self.individual.household,
+        )
+        TicketIndividualDataUpdateDetailsFactory(
+            ticket=self.ticket,
+            individual=self.individual,
+            individual_data={"role": {"value": ROLE_PRIMARY, "approve_status": True}},
+        )
+
+        service = IndividualDataUpdateService(self.ticket, self.ticket.individual_data_update_ticket_details)
+        service.close(UserFactory())
+
+        role = IndividualRoleInHousehold.objects.get(household=self.individual.household, individual=self.individual)
+        self.assertEqual(role.role, ROLE_PRIMARY)
+
+        previous_role = IndividualRoleInHousehold.objects.filter(
+            household=self.individual.household, individual=self.individual_hoh
+        ).first()
+        self.assertIsNone(previous_role)
+
+    def test_change_role_from_primary_to_alternate(self) -> None:
+        TicketIndividualDataUpdateDetailsFactory(
+            ticket=self.ticket,
+            individual=self.individual_hoh,
+            individual_data={"role": {"value": ROLE_ALTERNATE, "approve_status": True}},
+        )
+        with self.assertRaises(ValidationError) as e:
+            service = IndividualDataUpdateService(self.ticket, self.ticket.individual_data_update_ticket_details)
+            service.close(UserFactory())
+        self.assertEqual(
+            e.exception.messages[0], "Ticket cannot be closed, primary collector role has to be reassigned"
+        )
+
+        role = IndividualRoleInHousehold.objects.get(
+            household=self.individual.household, individual=self.individual_hoh
+        )
+        self.assertEqual(role.role, ROLE_PRIMARY)  # still with primary role
+
+    def test_change_role_from_primary_to_none(self) -> None:
+        TicketIndividualDataUpdateDetailsFactory(
+            ticket=self.ticket,
+            individual=self.individual_hoh,
+            individual_data={"role": {"value": ROLE_NO_ROLE, "approve_status": True}},
+        )
+        with self.assertRaises(ValidationError) as e:
+            service = IndividualDataUpdateService(self.ticket, self.ticket.individual_data_update_ticket_details)
+            service.close(UserFactory())
+        self.assertEqual(
+            e.exception.messages[0], "Ticket cannot be closed, primary collector role has to be reassigned"
+        )
+
+        role = IndividualRoleInHousehold.objects.get(
+            household=self.individual.household, individual=self.individual_hoh
+        )
+        self.assertEqual(role.role, ROLE_PRIMARY)  # still with primary role


### PR DESCRIPTION
[AB#187732](https://unicef.visualstudio.com/4e044e8d-bc28-4768-8074-f80ff6e4a0e5/_workitems/edit/187732)