### PR TITLE
[hotfix] 216567 deduplication key error when deduplicating records

### DIFF
--- a/backend/hct_mis_api/apps/registration_datahub/tasks/deduplicate.py
+++ b/backend/hct_mis_api/apps/registration_datahub/tasks/deduplicate.py
@@ -746,7 +746,6 @@ class HardDocumentDeduplication:
                     possible_duplicates_individuals_id_set.add(str(new_document.individual_id))
 
                 elif new_document_signature in new_document_signatures_duplicated_in_batch:
-
                     if is_duplicated_document_number_for_individual:
                         # do not create ticket for the same Individual with the same doc number
                         new_document.status = Document.STATUS_VALID

--- a/backend/hct_mis_api/apps/registration_datahub/tasks/deduplicate.py
+++ b/backend/hct_mis_api/apps/registration_datahub/tasks/deduplicate.py
@@ -673,7 +673,6 @@ class HardDocumentDeduplication:
                 .select_related("individual", "type")
                 .select_for_update(of=("self",))  # no need to lock individuals
                 .order_by("pk")
-                .distinct()
             )
 
             documents_numbers = []

--- a/backend/hct_mis_api/apps/registration_datahub/tests/test_handling_documents_duplicates.py
+++ b/backend/hct_mis_api/apps/registration_datahub/tests/test_handling_documents_duplicates.py
@@ -8,7 +8,10 @@ from django.test.utils import CaptureQueriesContext
 from hct_mis_api.apps.core.base_test_case import BaseElasticSearchTestCase
 from hct_mis_api.apps.core.models import BusinessArea
 from hct_mis_api.apps.geo import models as geo_models
-from hct_mis_api.apps.grievance.models import GrievanceTicket
+from hct_mis_api.apps.grievance.models import (
+    GrievanceTicket,
+    TicketNeedsAdjudicationDetails,
+)
 from hct_mis_api.apps.household.fixtures import (
     DocumentTypeFactory,
     create_household_and_individuals,
@@ -28,8 +31,6 @@ from hct_mis_api.apps.registration_datahub.tasks.deduplicate import (
     HardDocumentDeduplication,
 )
 from hct_mis_api.apps.utils.models import MergeStatusModel
-
-from hct_mis_api.apps.grievance.models import TicketNeedsAdjudicationDetails
 
 
 class TestGoldenRecordDeduplication(BaseElasticSearchTestCase):
@@ -537,16 +538,16 @@ class TestGoldenRecordDeduplication(BaseElasticSearchTestCase):
         d1 = Document.objects.create(
             country=self.country,
             type=self.dt,
-            document_number="222", # different doc number
-            individual=self.individuals[2], # different Individual
+            document_number="222",  # different doc number
+            individual=self.individuals[2],  # different Individual
             program=self.program,
             rdi_merge_status=MergeStatusModel.MERGED,
         )
         d2 = Document.objects.create(
             country=self.country,
             type=self.dt,
-            document_number="111", # the same doc number
-            individual=self.individuals[3], # different Individual
+            document_number="111",  # the same doc number
+            individual=self.individuals[3],  # different Individual
             program=self.program,
             rdi_merge_status=MergeStatusModel.MERGED,
         )
@@ -560,9 +561,7 @@ class TestGoldenRecordDeduplication(BaseElasticSearchTestCase):
         ticket_details = TicketNeedsAdjudicationDetails.objects.first()
         self.assertIsNotNone(ticket_details.golden_records_individual)
         self.assertEqual(ticket_details.possible_duplicates.all().count(), 1)
-        self.assertNotEqual(
-            ticket_details.golden_records_individual, ticket_details.possible_duplicates.first()
-        )
+        self.assertNotEqual(ticket_details.golden_records_individual, ticket_details.possible_duplicates.first())
 
         passport.refresh_from_db()
         self.assertEqual(passport.status, Document.STATUS_VALID)


### PR DESCRIPTION
[AB#216567](https://unicef.visualstudio.com/4e044e8d-bc28-4768-8074-f80ff6e4a0e5/_workitems/edit/216567)

Need to run
backend/hct_mis_api/apps/registration_datahub/celery_tasks.py
deduplicate_documents()

after merge to fix staging/prod existing RDIs

https://monitoring.hope.unicef.org/organizations/hope/issues/5737/events/6b9cd0f4b154403bacf4c3854ee1080d/
https://monitoring.hope.unicef.org/organizations/hope/issues/5737/events/51f25b6024fb4ab287a11c9f3da93dc8/?project=4