### PR TITLE
Fixed test download path

### DIFF
--- a/tests/selenium/programme_population/test_periodic_data_templates.py
+++ b/tests/selenium/programme_population/test_periodic_data_templates.py
@@ -292,10 +292,9 @@ class TestPeriodicDataTemplates:
 
         pageIndividuals.getDownloadBtn(periodic_data_update_template.pk).click()
         periodic_data_update_template.refresh_from_db()
-        user_path = os.path.expanduser("~")
         assert (
             pageIndividuals.check_file_exists(
-                os.path.join(user_path, "Downloads", periodic_data_update_template.file.file.name)
+                os.path.join(settings.DOWNLOAD_DIRECTORY, periodic_data_update_template.file.file.name)
             )
             is True
         )


### PR DESCRIPTION
This pull request includes a small but important change to the `test_periodic_data_template_create_and_download` method in the `tests/selenium/programme_population/test_periodic_data_templates.py` file. The change updates the directory path used for checking the existence of the downloaded file.

* [`tests/selenium/programme_population/test_periodic_data_templates.py`](diffhunk://#diff-b3cece820e14cf1ea4149a4492cfbd96fbba7283e5a264a6ccf86c271bcc2821L295-R297): Modified the `test_periodic_data_template_create_and_download` method to use `settings.DOWNLOAD_DIRECTORY` instead of the user's home directory for checking the downloaded file path.