### PR TITLE
Fixes // Payment Module - Supporting document

### DIFF
--- a/src/hct_mis_api/apps/payment/api/views.py
+++ b/src/hct_mis_api/apps/payment/api/views.py
@@ -201,6 +201,7 @@ class PaymentPlanSupportingDocumentViewSet(
 
     def create(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         payment_plan = get_object_or_404(PaymentPlan, id=decode_id_string(kwargs.get("payment_plan_id")))
+        request.data["created_by"] = request.user.pk
         serializer = self.get_serializer(data=request.data, context={"payment_plan": payment_plan})
         if serializer.is_valid():
             serializer.save(payment_plan=payment_plan)


### PR DESCRIPTION
[AB#217941](https://unicef.visualstudio.com/ICTD-HCT-MIS/_workitems/edit/217941): Payment Module - Not saving user at 'created by' when uploading supporting document