### PR TITLE
Individual page not accessible by Sudan CO

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,7 +141,7 @@ distribution = true
 
 [project]
 name = "hope"
-version = "2.12.0"
+version = "2.12.1"
 description = "HCT MIS is UNICEF's humanitarian cash transfer platform."
 authors = [
     { name = "Tivix" },

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/hct_mis_api/apps/periodic_data_update/api/views.py
+++ b/src/hct_mis_api/apps/periodic_data_update/api/views.py
@@ -9,6 +9,7 @@ from rest_framework import mixins, status
 from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError
 from rest_framework.filters import OrderingFilter
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.serializers import BaseSerializer
@@ -182,7 +183,7 @@ class PeriodicFieldViewSet(
     GenericViewSet,
 ):
     serializer_class = PeriodicFieldSerializer
-    permission_classes = [PDUViewListAndDetailsPermission]
+    permission_classes = [IsAuthenticated]
     filter_backends = (OrderingFilter,)
 
     def get_queryset(self) -> QuerySet:

--- a/tests/unit/apps/periodic_data_update/test_periodic_data_field_views.py
+++ b/tests/unit/apps/periodic_data_update/test_periodic_data_field_views.py
@@ -137,7 +137,7 @@ class TestPeriodicFieldViews:
 
             etag = response.headers["etag"]
             assert json.loads(cache.get(etag)[0].decode("utf8")) == response.json()
-            assert len(ctx.captured_queries) == 11
+            assert len(ctx.captured_queries) == 6
 
         # Test that reoccurring requests use cached data
         with CaptureQueriesContext(connection) as ctx:
@@ -146,7 +146,7 @@ class TestPeriodicFieldViews:
 
             etag_second_call = response.headers["etag"]
             assert json.loads(cache.get(response.headers["etag"])[0].decode("utf8")) == response.json()
-            assert len(ctx.captured_queries) == 5
+            assert len(ctx.captured_queries) == 0
 
             assert etag_second_call == etag
 
@@ -159,7 +159,7 @@ class TestPeriodicFieldViews:
 
             etag_call_after_update = response.headers["etag"]
             assert json.loads(cache.get(response.headers["etag"])[0].decode("utf8")) == response.json()
-            assert len(ctx.captured_queries) == 11
+            assert len(ctx.captured_queries) == 6
 
             assert etag_call_after_update != etag
 
@@ -170,7 +170,7 @@ class TestPeriodicFieldViews:
 
             etag_call_after_update_second_call = response.headers["etag"]
             assert json.loads(cache.get(response.headers["etag"])[0].decode("utf8")) == response.json()
-            assert len(ctx.captured_queries) == 5
+            assert len(ctx.captured_queries) == 0
 
             assert etag_call_after_update_second_call == etag_call_after_update
 
@@ -183,6 +183,6 @@ class TestPeriodicFieldViews:
 
             etag_call_after_update_2 = response.headers["etag"]
             assert json.loads(cache.get(response.headers["etag"])[0].decode("utf8")) == response.json()
-            assert len(ctx.captured_queries) == 11
+            assert len(ctx.captured_queries) == 6
 
             assert etag_call_after_update_2 != etag_call_after_update_second_call

--- a/tests/unit/apps/periodic_data_update/test_periodic_data_field_views.py
+++ b/tests/unit/apps/periodic_data_update/test_periodic_data_field_views.py
@@ -57,55 +57,6 @@ class TestPeriodicFieldViews:
             },
         )
 
-    @pytest.mark.parametrize(
-        "permissions, partner_permissions, access_to_program, expected_status",
-        [
-            ([], [], True, status.HTTP_403_FORBIDDEN),
-            ([Permissions.PDU_VIEW_LIST_AND_DETAILS], [], True, status.HTTP_200_OK),
-            ([], [Permissions.PDU_VIEW_LIST_AND_DETAILS], True, status.HTTP_200_OK),
-            (
-                [Permissions.PDU_VIEW_LIST_AND_DETAILS],
-                [Permissions.PDU_VIEW_LIST_AND_DETAILS],
-                True,
-                status.HTTP_200_OK,
-            ),
-            ([], [], False, status.HTTP_403_FORBIDDEN),
-            ([Permissions.PDU_VIEW_LIST_AND_DETAILS], [], False, status.HTTP_403_FORBIDDEN),
-            ([], [Permissions.PDU_VIEW_LIST_AND_DETAILS], False, status.HTTP_403_FORBIDDEN),
-            (
-                [Permissions.PDU_VIEW_LIST_AND_DETAILS],
-                [Permissions.PDU_VIEW_LIST_AND_DETAILS],
-                False,
-                status.HTTP_403_FORBIDDEN,
-            ),
-        ],
-    )
-    def test_list_periodic_fields_permission(
-        self,
-        permissions: list,
-        partner_permissions: list,
-        access_to_program: bool,
-        expected_status: str,
-        api_client: Callable,
-        afghanistan: BusinessAreaFactory,
-        create_user_role_with_permissions: Callable,
-        create_partner_role_with_permissions: Callable,
-        update_partner_access_to_program: Callable,
-        id_to_base64: Callable,
-    ) -> None:
-        self.set_up(api_client, afghanistan, id_to_base64)
-        create_user_role_with_permissions(
-            self.user,
-            permissions,
-            self.afghanistan,
-        )
-        create_partner_role_with_permissions(self.partner, partner_permissions, self.afghanistan)
-        if access_to_program:
-            update_partner_access_to_program(self.partner, self.program1)
-
-        response = self.client.get(self.url_list)
-        assert response.status_code == expected_status
-
     def test_list_periodic_fields(
         self,
         api_client: Callable,


### PR DESCRIPTION
[AB#219855](https://unicef.visualstudio.com/4e044e8d-bc28-4768-8074-f80ff6e4a0e5/_workitems/edit/219855)
This pull request includes updates to version numbers and changes to permission handling in the `PeriodicFieldViewSet`. The most important changes include updating the project version in multiple files and modifying the permission classes to use `IsAuthenticated`.

Version updates:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L144-R144): Updated project version from `2.12.0` to `2.12.1`.
* [`src/frontend/package.json`](diffhunk://#diff-12ee508ecc1901fe1a1d71ed459dba8454f3160983ee18b2c51b76ade45235d3L3-R3): Updated frontend version from `2.12.0` to `2.12.1`.

Permission handling:

* [`src/hct_mis_api/apps/periodic_data_update/api/views.py`](diffhunk://#diff-374927a698a6e0b3edf743f35d56ed83143bc5805762baccf494debbe0211165R12): Added `IsAuthenticated` import.
* [`src/hct_mis_api/apps/periodic_data_update/api/views.py`](diffhunk://#diff-374927a698a6e0b3edf743f35d56ed83143bc5805762baccf494debbe0211165L185-R186): Changed `permission_classes` from `PDUViewListAndDetailsPermission` to `IsAuthenticated` in `PeriodicFieldViewSet`.