### PR TITLE
Fix detecting duplicated individual without names

### DIFF
--- a/src/hct_mis_api/apps/household/models.py
+++ b/src/hct_mis_api/apps/household/models.py
@@ -1093,6 +1093,7 @@ class Individual(
             "given_name",
             "middle_name",
             "family_name",
+            "full_name",
             "sex",
             "birth_date",
             "phone_no",


### PR DESCRIPTION
[AB#219853](https://unicef.visualstudio.com/4e044e8d-bc28-4768-8074-f80ff6e4a0e5/_workitems/edit/219853)
This pull request includes a small change to the `get_hash_key` method in the `household` model. The change adds an additional field to the list of attributes used to generate the hash key.

* [`src/hct_mis_api/apps/household/models.py`](diffhunk://#diff-a963e15e1fccdd2cfc730654e4f56ef448cbc13e9b68a2e222635e076118682cR1096): Added the `full_name` attribute to the list of fields in the `get_hash_key` method.