### PR TITLE
long running enrolment fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,7 +137,7 @@ distribution = true
 
 [project]
 name = "hope"
-version = "2.14.0"
+version = "2.14.1"
 description = "HCT MIS is UNICEF's humanitarian cash transfer platform."
 authors = [
     { name = "Tivix" },

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "2.14.0",
+  "version": "2.14.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/hct_mis_api/apps/household/celery_tasks.py
+++ b/src/hct_mis_api/apps/household/celery_tasks.py
@@ -225,10 +225,12 @@ def enroll_households_to_program_task(households_ids: List, program_for_enroll_i
         program_for_enroll = Program.objects.get(id=program_for_enroll_id)
         enroll_households_to_program(households, program_for_enroll, user_id)
         populate_index(
-            Individual.objects.filter(program=program_for_enroll),
+            Individual.objects.filter(household__copied_from_id__in=households_ids, program=program_for_enroll),
             get_individual_doc(program_for_enroll.business_area.slug),
         )
-        populate_index(Household.objects.filter(program=program_for_enroll), HouseholdDocument)
+        populate_index(
+            Household.objects.filter(copied_from_id__in=households_ids, program=program_for_enroll), HouseholdDocument
+        )
     finally:
         cache.delete(cache_key)
 


### PR DESCRIPTION
This pull request includes changes to update the version numbers in the project files and to improve the enrollment task in the `celery_tasks.py` file. The most important changes include version updates in `pyproject.toml` and `package.json`, and modifications to the `enroll_households_to_program_task` function to ensure proper indexing.

Version updates:
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L140-R140): Updated the project version from `2.14.0` to `2.14.1`.
* [`src/frontend/package.json`](diffhunk://#diff-12ee508ecc1901fe1a1d71ed459dba8454f3160983ee18b2c51b76ade45235d3L3-R3): Updated the frontend version from `2.14.0` to `2.14.1`.

Function improvements:
* [`src/hct_mis_api/apps/household/celery_tasks.py`](diffhunk://#diff-9703b23598a202a8bb469b04c3587828c55887afa2c61eb751529c2fd7c26e9aL228-R233): Modified the `populate_index` in `enroll_households_to_program_task` function to filter `Individual` and `Household` objects by `copied_from_id` and `program` in order to speed up the indexing.