### PR TITLE
TP fix filtering if answer is NO

### DIFF
--- a/development_tools/local_selenium_init.sh
+++ b/development_tools/local_selenium_init.sh
@@ -37,7 +37,7 @@ export CACHE_LOCATION=redis://localhost:6379/1
 export USE_DUMMY_EXCHANGE_RATES=yes
 export ELASTICSEARCH_HOST=http://localhost:9200
 export CELERY_TASK_ALWAYS_EAGER=true
-# export LIBRARY_PATHS=true
+export LIBRARY_PATHS=true
 SCRIPT_DIR=$(realpath "$(dirname $0)")
 MAIN_DIR=$(realpath $SCRIPT_DIR/..)
 echo "SCRIPT_DIR: $SCRIPT_DIR"

--- a/src/hct_mis_api/apps/targeting/models.py
+++ b/src/hct_mis_api/apps/targeting/models.py
@@ -607,16 +607,17 @@ class TargetingCollectorBlockRuleFilter(TimeStampedUUIDModel, TargetingCriteriaF
 
         collectors_ind_query = Individual.objects.filter(
             pk__in=list(collector_primary_qs),
-            delivery_mechanisms_data__is_valid=True,
         )
         # If argument is Yes
         if argument:
             individuals_with_field_query = collectors_ind_query.filter(
-                delivery_mechanisms_data__data__has_key=self.field_name
+                delivery_mechanisms_data__data__has_key=self.field_name,
+                delivery_mechanisms_data__is_valid=True,
             )
         # If argument is No
         else:
             individuals_with_field_query = collectors_ind_query.exclude(
-                delivery_mechanisms_data__data__has_key=self.field_name
+                delivery_mechanisms_data__data__has_key=self.field_name,
+                delivery_mechanisms_data__is_valid=True,
             )
         return Q(pk__in=list(individuals_with_field_query.values_list("household_id", flat=True)))

--- a/src/hct_mis_api/apps/targeting/models.py
+++ b/src/hct_mis_api/apps/targeting/models.py
@@ -609,7 +609,7 @@ class TargetingCollectorBlockRuleFilter(TimeStampedUUIDModel, TargetingCriteriaF
             pk__in=list(collector_primary_qs),
         )
         # If argument is Yes
-        if argument:
+        if argument.lower() == "yes":
             individuals_with_field_query = collectors_ind_query.filter(
                 delivery_mechanisms_data__data__has_key=self.field_name,
                 delivery_mechanisms_data__is_valid=True,

--- a/tests/selenium/conftest.py
+++ b/tests/selenium/conftest.py
@@ -561,7 +561,6 @@ def create_super_user(business_area: BusinessArea) -> User:
     country = Country.objects.get(name="Afghanistan")
     business_area.countries.add(country)
     user = UserFactory.create(
-        pk="4196c2c5-c2dd-48d2-887f-3a9d39e78916",
         is_superuser=True,
         is_staff=True,
         username="superuser",

--- a/tests/selenium/conftest.py
+++ b/tests/selenium/conftest.py
@@ -17,7 +17,7 @@ from selenium import webdriver
 from selenium.webdriver import Chrome
 from selenium.webdriver.chrome.options import Options
 
-from hct_mis_api.apps.account.fixtures import RoleFactory, UserFactory
+from hct_mis_api.apps.account.fixtures import RoleFactory
 from hct_mis_api.apps.account.models import Partner, Role, User, UserRole
 from hct_mis_api.apps.account.permissions import Permissions
 from hct_mis_api.apps.core.models import (
@@ -549,10 +549,8 @@ def change_super_user(business_area: BusinessArea) -> None:
 @pytest.fixture(autouse=True)
 def create_super_user(business_area: BusinessArea) -> User:
     Partner.objects.get_or_create(name="TEST")
-    Partner.objects.get_or_create(name="UNICEF")
+    partner, _ = Partner.objects.get_or_create(name="UNICEF")
     Partner.objects.get_or_create(name="UNHCR")
-
-    partner = Partner.objects.get(name="UNICEF")
 
     permission_list = [role.value for role in Permissions]
 
@@ -560,13 +558,16 @@ def create_super_user(business_area: BusinessArea) -> User:
     call_command("loaddata", f"{settings.PROJECT_ROOT}/apps/geo/fixtures/data_small.json", verbosity=0)
     country = Country.objects.get(name="Afghanistan")
     business_area.countries.add(country)
-    user = UserFactory.create(
-        is_superuser=True,
-        is_staff=True,
-        username="superuser",
-        password="testtest2",
-        email="test@example.com",
-        partner=partner,
+    user, _ = User.objects.get_or_create(
+        pk="4196c2c5-c2dd-48d2-887f-3a9d39e78916",
+        defaults={
+            "is_superuser":True,
+            "is_staff": True,
+            "username": "superuser",
+            "password": "testtest2",
+            "email": "test@example.com",
+            "partner": partner
+        }
     )
     UserRole.objects.create(
         user=user,

--- a/tests/selenium/conftest.py
+++ b/tests/selenium/conftest.py
@@ -17,7 +17,7 @@ from selenium import webdriver
 from selenium.webdriver import Chrome
 from selenium.webdriver.chrome.options import Options
 
-from hct_mis_api.apps.account.fixtures import RoleFactory
+from hct_mis_api.apps.account.fixtures import RoleFactory, UserFactory
 from hct_mis_api.apps.account.models import Partner, Role, User, UserRole
 from hct_mis_api.apps.account.permissions import Permissions
 from hct_mis_api.apps.core.models import (
@@ -558,17 +558,17 @@ def create_super_user(business_area: BusinessArea) -> User:
     call_command("loaddata", f"{settings.PROJECT_ROOT}/apps/geo/fixtures/data_small.json", verbosity=0)
     country = Country.objects.get(name="Afghanistan")
     business_area.countries.add(country)
-    user, _ = User.objects.get_or_create(
-        pk="4196c2c5-c2dd-48d2-887f-3a9d39e78916",
-        defaults={
-            "is_superuser": True,
-            "is_staff": True,
-            "username": "superuser",
-            "password": "testtest2",
-            "email": "test@example.com",
-            "partner": partner,
-        },
-    )
+
+    if not (user := User.objects.filter(pk="4196c2c5-c2dd-48d2-887f-3a9d39e78916").first()):
+        user = UserFactory(
+            pk="4196c2c5-c2dd-48d2-887f-3a9d39e78916",
+            is_superuser=True,
+            is_staff=True,
+            username="superuser",
+            password="testtest2",
+            email="test@example.com",
+            partner=partner,
+        )
     UserRole.objects.create(
         user=user,
         role=Role.objects.get(name="Role"),

--- a/tests/selenium/conftest.py
+++ b/tests/selenium/conftest.py
@@ -561,13 +561,13 @@ def create_super_user(business_area: BusinessArea) -> User:
     user, _ = User.objects.get_or_create(
         pk="4196c2c5-c2dd-48d2-887f-3a9d39e78916",
         defaults={
-            "is_superuser":True,
+            "is_superuser": True,
             "is_staff": True,
             "username": "superuser",
             "password": "testtest2",
             "email": "test@example.com",
-            "partner": partner
-        }
+            "partner": partner,
+        },
     )
     UserRole.objects.create(
         user=user,

--- a/tests/unit/apps/targeting/snapshots/snap_test_copy_target_population_mutation.py
+++ b/tests/unit/apps/targeting/snapshots/snap_test_copy_target_population_mutation.py
@@ -57,7 +57,7 @@ snapshots['TestCopyTargetPopulationMutation::test_copy_target_0_with_permission 
                                     'collectorBlockFilters': [
                                         {
                                             'arguments': [
-                                                True
+                                                'Yes'
                                             ],
                                             'fieldName': 'delivery_data_field__random_name'
                                         }

--- a/tests/unit/apps/targeting/snapshots/snap_test_create_target_population_mutation.py
+++ b/tests/unit/apps/targeting/snapshots/snap_test_create_target_population_mutation.py
@@ -354,7 +354,7 @@ snapshots['TestCreateTargetPopulationMutation::test_create_mutation_with_collect
                                     'collectorBlockFilters': [
                                         {
                                             'arguments': [
-                                                False
+                                                'No'
                                             ],
                                             'fieldName': 'mobile_phone_number__cash_over_the_counter',
                                             'labelEn': 'Mobile Phone Number Cash Over The Counter (UT Name Delivery Mechanism)'

--- a/tests/unit/apps/targeting/test_copy_target_population_mutation.py
+++ b/tests/unit/apps/targeting/test_copy_target_population_mutation.py
@@ -128,7 +128,7 @@ class TestCopyTargetPopulationMutation(APITestCase):
             collector_block_filters=col_block,
             comparison_method="EQUALS",
             field_name="delivery_data_field__random_name",
-            arguments=[True],
+            arguments=["Yes"],
         )
 
         cls.empty_target_population_1 = TargetPopulation(

--- a/tests/unit/apps/targeting/test_create_target_population_mutation.py
+++ b/tests/unit/apps/targeting/test_create_target_population_mutation.py
@@ -472,7 +472,7 @@ class TestCreateTargetPopulationMutation(APITestCase):
                                     "collectorBlockFilters": [
                                         {
                                             "comparisonMethod": "EQUALS",
-                                            "arguments": [False],
+                                            "arguments": ["No"],
                                             "fieldName": "mobile_phone_number__cash_over_the_counter",
                                             "flexFieldClassification": "NOT_FLEX_FIELD",
                                         },
@@ -511,7 +511,7 @@ class TestCreateTargetPopulationMutation(APITestCase):
                                     "collectorBlockFilters": [
                                         {
                                             "comparisonMethod": "EQUALS",
-                                            "arguments": [False],
+                                            "arguments": ["No"],
                                             "fieldName": "mobile_phone_number__cash_over_the_counter",
                                             "flexFieldClassification": "NOT_FLEX_FIELD",
                                         },

--- a/tests/unit/apps/targeting/test_individual_block_filters.py
+++ b/tests/unit/apps/targeting/test_individual_block_filters.py
@@ -401,7 +401,7 @@ class TestIndividualBlockFilter(TestCase):
             collector_block_filters=col_block,
             comparison_method="EQUALS",
             field_name="delivery_data_field__random_name",
-            arguments=[True],
+            arguments=["Yes"],
         )
         collectors_filters_block = TargetingCollectorRuleFilterBlockBase(collector_block_filters=[collector_filter])
         tcr = TargetingCriteriaRuleQueryingBase(

--- a/tests/unit/apps/targeting/test_targeting_criteria_rule_filter.py
+++ b/tests/unit/apps/targeting/test_targeting_criteria_rule_filter.py
@@ -333,7 +333,7 @@ class TargetingCriteriaRuleFilterTestCase(TestCase):
             collector_block_filters=col_block,
             comparison_method="EQUALS",
             field_name="delivery_data_field__random_name",
-            arguments=[True],
+            arguments=["Yes"],
         )
         query = rule_filter.get_query()
         queryset = self.get_households_queryset().filter(query).distinct()
@@ -361,7 +361,7 @@ class TargetingCriteriaRuleFilterTestCase(TestCase):
             collector_block_filters=col_block,
             comparison_method="EQUALS",
             field_name="delivery_data_field__random_name",
-            arguments=[False],
+            arguments=["No"],
         )
         query = rule_filter.get_query()
         queryset = self.get_households_queryset().filter(query).distinct()


### PR DESCRIPTION
Filter by collector's fields:

  **if answer _YES_ > Delivery mechanism data (Wallet) must be VALID and have FIELD in the data json
  if answer _NO_ > exclude all collectors with valid Delivery mechanism data (Wallet) that has the field**
  
  Example: 
  `api/unicorn/payment/deliverymechanismdata`
![Screenshot 2024-11-27 at 10 10 08 AM](https://github.com/user-attachments/assets/af258737-1116-41a3-9a0c-f3f43dded5bc)
