### PR TITLE
AB#226656 Error Cannot read properties of undefined Grievance ticket

### DIFF
--- a/src/frontend/src/components/grievances/LookUps/LookUpReassignRole/LookUpReassignRole.tsx
+++ b/src/frontend/src/components/grievances/LookUps/LookUpReassignRole/LookUpReassignRole.tsx
@@ -119,7 +119,7 @@ export function LookUpReassignRole({
   return (
     <Formik
       initialValues={{
-        selectedIndividual: individualData.individual,
+        selectedIndividual: individualData?.individual,
         selectedHousehold,
         role: individualRole.role,
       }}

--- a/src/frontend/src/components/grievances/ReassignMultipleRoleBox.tsx
+++ b/src/frontend/src/components/grievances/ReassignMultipleRoleBox.tsx
@@ -52,7 +52,6 @@ export function ReassignMultipleRoleBox({
       (el) =>
         el.role === IndividualRoleInHouseholdRole.Primary || el.role === 'HEAD',
     );
-
   const mappedReassignLookups = (): ReactElement => (
     <>
       {selectedIndividualsToReassign.map((selectedIndividualToReassign) => {
@@ -97,7 +96,7 @@ export function ReassignMultipleRoleBox({
                 ticket={ticket}
                 household={householdAndRole.household}
                 individualToReassign={selectedIndividualToReassign}
-                initialSelectedIndividualId={reassignDataDictByIndividualId[selectedIndividualToReassign.id].new_individual}
+                initialSelectedIndividualId={reassignDataDictByIndividualId[selectedIndividualToReassign.id]?.new_individual}
               />
             </Box>
           ));
@@ -137,7 +136,7 @@ export function ReassignMultipleRoleBox({
                   ticket={ticket}
                   household={household}
                   individualToReassign={selectedIndividualToReassign}
-                  initialSelectedIndividualId={reassignDataDictByIndividualId[selectedIndividualToReassign.id].new_individual}
+                  initialSelectedIndividualId={reassignDataDictByIndividualId[selectedIndividualToReassign.id]?.new_individual}
                 />
               </Box>
             )}


### PR DESCRIPTION
This pull request includes several changes to improve the robustness of the `LookUpReassignRole` and `ReassignMultipleRoleBox` components by adding optional chaining to handle potential undefined values. The most important changes are:

Enhancements to handle potential undefined values:

* [`src/frontend/src/components/grievances/LookUps/LookUpReassignRole/LookUpReassignRole.tsx`](diffhunk://#diff-b6665d25421d133a941cf8c1ccc66caec107660f7f558cb43552f8d9c583dacdL122-R122): Updated `initialValues` to use optional chaining for `individualData.individual` to prevent errors when `individualData` is undefined.
* [`src/frontend/src/components/grievances/ReassignMultipleRoleBox.tsx`](diffhunk://#diff-fb7edac7b51bcbc78db5bdc5b8d765cf7bc8d3a6a429e3be17c46af1a887c27cL100-R99): Added optional chaining for `reassignDataDictByIndividualId[selectedIndividualToReassign.id].new_individual` to handle cases where `reassignDataDictByIndividualId[selectedIndividualToReassign.id]` may be undefined. [[1]](diffhunk://#diff-fb7edac7b51bcbc78db5bdc5b8d765cf7bc8d3a6a429e3be17c46af1a887c27cL100-R99) [[2]](diffhunk://#diff-fb7edac7b51bcbc78db5bdc5b8d765cf7bc8d3a6a429e3be17c46af1a887c27cL140-R139)

Code cleanup:

* [`src/frontend/src/components/grievances/ReassignMultipleRoleBox.tsx`](diffhunk://#diff-fb7edac7b51bcbc78db5bdc5b8d765cf7bc8d3a6a429e3be17c46af1a887c27cL55): Removed an unnecessary blank line to improve code readability.