### PR TITLE
Fixes to managers for mergable models

### DIFF
--- a/src/frontend/src/containers/tables/rdi/ImportedHouseholdsTable/ImportedHouseholdTableRow.tsx
+++ b/src/frontend/src/containers/tables/rdi/ImportedHouseholdsTable/ImportedHouseholdTableRow.tsx
@@ -57,7 +57,7 @@ export function ImportedHouseholdTableRow({
       </TableCell>
       <TableCell align="left">
         <StyledLink onClick={() => handleClick()}>
-          {isMerged ? household.unicefId : household.importId}
+          {household.unicefId}
         </StyledLink>
       </TableCell>
       <AnonTableCell>{household?.headOfHousehold?.fullName}</AnonTableCell>

--- a/src/frontend/src/containers/tables/rdi/ImportedIndividualsTable/ImportedIndividualsTableRow.tsx
+++ b/src/frontend/src/containers/tables/rdi/ImportedIndividualsTable/ImportedIndividualsTableRow.tsx
@@ -20,7 +20,6 @@ interface ImportedIndividualsTableRowProps {
 export function ImportedIndividualsTableRow({
   individual,
   choices,
-  isMerged,
   rdi,
 }: ImportedIndividualsTableRowProps): ReactElement {
   const navigate = useNavigate();

--- a/src/frontend/src/containers/tables/rdi/ImportedIndividualsTable/ImportedIndividualsTableRow.tsx
+++ b/src/frontend/src/containers/tables/rdi/ImportedIndividualsTable/ImportedIndividualsTableRow.tsx
@@ -56,7 +56,7 @@ export function ImportedIndividualsTableRow({
     >
       <TableCell align="left">
         <BlackLink to={individualDetailsPath}>
-          {isMerged ? individual.unicefId : individual.importId}
+          {individual.unicefId}
         </BlackLink>
       </TableCell>
       <AnonTableCell>{individual.fullName}</AnonTableCell>

--- a/src/hct_mis_api/apps/account/permissions.py
+++ b/src/hct_mis_api/apps/account/permissions.py
@@ -378,9 +378,12 @@ class BaseNodePermissionMixin:
             raise PermissionDenied("Permission Denied")
 
     @classmethod
-    def get_node(cls, info: Any, object_id: str) -> Optional[Model]:
+    def get_node(cls, info: Any, object_id: str, **kwargs: Any) -> Optional[Model]:
         try:
-            object_instance = cls._meta.model.objects.get(pk=object_id)
+            if "get_object_queryset" in kwargs:
+                object_instance = kwargs.get("get_object_queryset").get(pk=object_id)
+            else:
+                object_instance = cls.get_queryset(cls._meta.model.objects, info).get(pk=object_id)
             cls.check_node_permission(info, object_instance)
         except cls._meta.model.DoesNotExist:
             object_instance = None

--- a/src/hct_mis_api/apps/utils/models.py
+++ b/src/hct_mis_api/apps/utils/models.py
@@ -152,9 +152,7 @@ class SoftDeletableRepresentationMergeStatusModel(MergeStatusModel):
     class Meta:
         abstract = True
 
-    # objects = SoftDeletableRepresentationMergedManager(_emit_deprecation_warnings=True)
-    # now we use 'rdi_merge_status' field for filtering
-    objects = SoftDeletableRepresentationManager()
+    objects = SoftDeletableRepresentationMergedManager(_emit_deprecation_warnings=True)
     all_merge_status_objects = SoftDeletableRepresentationManager()
     available_objects = SoftDeletableRepresentationMergedManager()
     all_objects = models.Manager()


### PR DESCRIPTION
This pull request includes several changes aimed at improving the handling of merge status objects in the `household` schema and permissions. The most important changes include modifications to the `get_node` method, updates to various resolve methods to use `all_merge_status_objects`, and adjustments to the `SoftDeletableRepresentationMergeStatusModel`.

### Improvements to handling merge status objects:

* [`src/hct_mis_api/apps/account/permissions.py`](diffhunk://#diff-526f5cc032a7ec5d81b4342d2d3eb2fda6679d8c61c8c7dcead12956814c0362L381-R386): Updated the `get_node` method to accept additional keyword arguments and use `get_object_queryset` if provided.
* [`src/hct_mis_api/apps/household/schema.py`](diffhunk://#diff-7e14e32a1e8c53a8b829295bd9f9ca07a017b67fd263ffab4737d33062d21ba7R268-R278): Added the `get_node` method to the `IndividualNode` and `Household` classes to use `all_merge_status_objects` for querying. [[1]](diffhunk://#diff-7e14e32a1e8c53a8b829295bd9f9ca07a017b67fd263ffab4737d33062d21ba7R268-R278) [[2]](diffhunk://#diff-7e14e32a1e8c53a8b829295bd9f9ca07a017b67fd263ffab4737d33062d21ba7R587-R590)
* [`src/hct_mis_api/apps/household/schema.py`](diffhunk://#diff-7e14e32a1e8c53a8b829295bd9f9ca07a017b67fd263ffab4737d33062d21ba7L285-R299): Updated various resolve methods to use `all_merge_status_objects` for querying related objects, ensuring consistent handling of merge status. [[1]](diffhunk://#diff-7e14e32a1e8c53a8b829295bd9f9ca07a017b67fd263ffab4737d33062d21ba7L285-R299) [[2]](diffhunk://#diff-7e14e32a1e8c53a8b829295bd9f9ca07a017b67fd263ffab4737d33062d21ba7L484-R496) [[3]](diffhunk://#diff-7e14e32a1e8c53a8b829295bd9f9ca07a017b67fd263ffab4737d33062d21ba7L709-R719) [[4]](diffhunk://#diff-7e14e32a1e8c53a8b829295bd9f9ca07a017b67fd263ffab4737d33062d21ba7L765-R775)

### Adjustments to model managers:

* [`src/hct_mis_api/apps/utils/models.py`](diffhunk://#diff-607bdb5f35fc8b82dac634783afe44f1650f2f8a6e72f677dfa19cacb844ab31L155-R155): Changed the `SoftDeletableRepresentationMergeStatusModel` to use `SoftDeletableRepresentationMergedManager` for the `objects` manager, ensuring proper filtering by `rdi_merge_status`.

### Minor changes:

* [`src/frontend/src/containers/tables/rdi/ImportedHouseholdsTable/ImportedHouseholdTableRow.tsx`](diffhunk://#diff-375fee15caf48a95618bcd5c3c1a092e866178905b9584c7369cad0cd1b9cc63L60-R60): Simplified the display logic for household IDs in the `ImportedHouseholdTableRow` component.
* [`src/hct_mis_api/apps/household/schema.py`](diffhunk://#diff-7e14e32a1e8c53a8b829295bd9f9ca07a017b67fd263ffab4737d33062d21ba7R8): Added the `Model` import to the schema file.