### PR TITLE
Fix Grievance validate flex fields value with date type

### DIFF
--- a/tests/unit/apps/grievance/test_services_utils.py
+++ b/tests/unit/apps/grievance/test_services_utils.py
@@ -15,6 +15,7 @@ from hct_mis_api.apps.account.fixtures import (
 )
 from hct_mis_api.apps.core.fixtures import create_afghanistan
 from hct_mis_api.apps.core.models import BusinessArea
+from hct_mis_api.apps.core.models import FlexibleAttribute as Core_FlexibleAttribute
 from hct_mis_api.apps.core.utils import encode_id_base64_required
 from hct_mis_api.apps.geo.fixtures import AreaFactory, AreaTypeFactory, CountryFactory
 from hct_mis_api.apps.grievance.fixtures import (
@@ -139,6 +140,21 @@ class TestGrievanceUtils(TestCase):
         with pytest.raises(ValueError) as e:
             verify_flex_fields({"key": "value"}, "individuals")
             assert str(e.value) == "key is not a correct `flex field"
+
+    def test_verify_flex_fields_with_date_type(self) -> None:
+        national_id_issue_date_i_f = Core_FlexibleAttribute(
+            type=Core_FlexibleAttribute.DATE,
+            name="national_id_issue_date_i_f",
+            associated_with=Core_FlexibleAttribute.ASSOCIATED_WITH_INDIVIDUAL,
+            label={"English(EN)": "value123"},
+        )
+        national_id_issue_date_i_f.save()
+
+        verify_flex_fields({"national_id_issue_date_i_f": "2025-01-15"}, "individuals")
+
+        with pytest.raises(ValueError) as e:
+            verify_flex_fields({"national_id_issue_date_i_f": "invalid"}, "individuals")
+            assert str(e.value) == "time data 'invalid' does not match format '%Y-%m-%d'"
 
     def test_handle_role(self) -> None:
         create_afghanistan()


### PR DESCRIPTION
[AB#229457](https://unicef.visualstudio.com/ICTD-HCT-MIS/_workitems/edit/229457): Flexible field of date type cannot be updated through Grievance ticket
