### PR TITLE
Hotfix/ab#233352 edit document on social worker object

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,7 +132,7 @@ distribution = true
 
 [project]
 name = "hope"
-version = "3.0.0"
+version = "3.0.1"
 description = "HCT MIS is UNICEF's humanitarian cash transfer platform."
 authors = [
     { name = "Tivix" },

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/frontend/src/__generated__/graphql.tsx
+++ b/src/frontend/src/__generated__/graphql.tsx
@@ -8912,7 +8912,7 @@ export type AllEditHouseholdFieldsQuery = { __typename?: 'Query', allEditHouseho
 export type AllEditPeopleFieldsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type AllEditPeopleFieldsQuery = { __typename?: 'Query', allEditPeopleFieldsAttributes?: Array<{ __typename?: 'FieldAttributeNode', id?: string | null, type?: string | null, name?: string | null, required?: boolean | null, labelEn?: string | null, hint?: string | null, isFlexField?: boolean | null, labels?: Array<{ __typename?: 'LabelNode', language?: string | null, label?: string | null } | null> | null, choices?: Array<{ __typename?: 'CoreFieldChoiceObject', labelEn?: string | null, value?: string | null, admin?: string | null, listName?: string | null, labels?: Array<{ __typename?: 'LabelNode', label?: string | null, language?: string | null } | null> | null } | null> | null } | null> | null };
+export type AllEditPeopleFieldsQuery = { __typename?: 'Query', allEditPeopleFieldsAttributes?: Array<{ __typename?: 'FieldAttributeNode', id?: string | null, type?: string | null, name?: string | null, required?: boolean | null, labelEn?: string | null, hint?: string | null, isFlexField?: boolean | null, labels?: Array<{ __typename?: 'LabelNode', language?: string | null, label?: string | null } | null> | null, choices?: Array<{ __typename?: 'CoreFieldChoiceObject', labelEn?: string | null, value?: string | null, admin?: string | null, listName?: string | null, labels?: Array<{ __typename?: 'LabelNode', label?: string | null, language?: string | null } | null> | null } | null> | null } | null> | null, countriesChoices?: Array<{ __typename?: 'ChoiceObject', name?: string | null, value?: string | null } | null> | null, documentTypeChoices?: Array<{ __typename?: 'ChoiceObject', name?: string | null, value?: string | null } | null> | null, identityTypeChoices?: Array<{ __typename?: 'ChoiceObject', name?: string | null, value?: string | null } | null> | null };
 
 export type AllHouseholdsFlexFieldsAttributesQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -15392,6 +15392,18 @@ export const AllEditPeopleFieldsDocument = gql`
       listName
     }
     isFlexField
+  }
+  countriesChoices {
+    name
+    value
+  }
+  documentTypeChoices {
+    name
+    value
+  }
+  identityTypeChoices {
+    name
+    value
   }
 }
     `;

--- a/src/frontend/src/apollo/queries/core/attributes/AllEditPeopleFieldsAttributes.ts
+++ b/src/frontend/src/apollo/queries/core/attributes/AllEditPeopleFieldsAttributes.ts
@@ -25,5 +25,17 @@ export const AllEditPeopleFieldsAttributes = gql`
       }
       isFlexField
     }
+    countriesChoices {
+      name
+      value
+    }
+    documentTypeChoices {
+      name
+      value
+    }
+    identityTypeChoices {
+      name
+      value
+    }
   }
 `;

--- a/src/frontend/src/components/grievances/EditPeopleDataChange/EditPeopleDataChange.tsx
+++ b/src/frontend/src/components/grievances/EditPeopleDataChange/EditPeopleDataChange.tsx
@@ -1,4 +1,4 @@
-import { Button, Grid, Typography } from '@mui/material';
+import { Box, Button, Grid, Typography } from '@mui/material';
 import { AddCircleOutline } from '@mui/icons-material';
 import { useLocation } from 'react-router-dom';
 import { FieldArray } from 'formik';
@@ -13,6 +13,8 @@ import {
 import { LoadingComponent } from '@core/LoadingComponent';
 import { Title } from '@core/Title';
 import { EditPeopleDataChangeFieldRow } from './EditPeopleDataChangeFieldRow';
+import { ExistingDocumentFieldArray } from '@components/grievances/EditIndividualDataChange/ExistingDocumentFieldArray';
+import { NewDocumentFieldArray } from '@components/grievances/EditIndividualDataChange/NewDocumentFieldArray';
 
 const BoxWithBorders = styled.div`
   border-bottom: 1px solid ${({ theme }) => theme.hctPalette.lighterGray};
@@ -122,6 +124,26 @@ export function EditPeopleDataChange({
           </Grid>
         </BoxWithBorders>
       )}
+      <BoxWithBorders>
+        <Box mt={3}>
+          <Title>
+            <Typography variant="h6">{t('Documents')}</Typography>
+          </Title>
+          <ExistingDocumentFieldArray
+            values={values}
+            setFieldValue={setFieldValue}
+            individual={fullIndividual.individual}
+            addIndividualFieldsData={editPeopleFieldsData}
+          />
+          {!isEditTicket && (
+            <NewDocumentFieldArray
+              values={values}
+              addIndividualFieldsData={editPeopleFieldsData}
+              setFieldValue={setFieldValue}
+            />
+          )}
+        </Box>
+      </BoxWithBorders>
     </>
   );
 }


### PR DESCRIPTION
This pull request includes several changes to the frontend and project configuration files, primarily to add new document-related fields and update version numbers. The most important changes are summarized below:

### Version Updates:
* Updated the project version in `pyproject.toml` from 3.0.0 to 3.0.1.
* Updated the frontend package version in `package.json` from 3.0.0 to 3.0.1.

### GraphQL Schema Updates:
* Added new fields (`countriesChoices`, `documentTypeChoices`, `identityTypeChoices`) to the `AllEditPeopleFieldsQuery` type in `graphql.tsx`.
* Updated the GraphQL query `AllEditPeopleFieldsDocument` to include the new fields in `graphql.tsx`.
* Updated the GraphQL query `AllEditPeopleFieldsAttributes` to include the new fields in `AllEditPeopleFieldsAttributes.ts`.

### Component Updates:
* Added imports for `ExistingDocumentFieldArray` and `NewDocumentFieldArray` in `EditPeopleDataChange.tsx`.
* Added a new section to display and edit document fields in the `EditPeopleDataChange` component.