### PR TITLE
Upd Export PaymentPlan XLSX with auth code

### DIFF
--- a/src/hct_mis_api/apps/payment/models/payment.py
+++ b/src/hct_mis_api/apps/payment/models/payment.py
@@ -707,8 +707,8 @@ class PaymentPlan(
             financial_service_provider__payment_gateway_id__isnull=False,
         ).exists()
 
-        all_sent_to_fsp = not self.eligible_payments.exclude(status=Payment.STATUS_SENT_TO_FSP).exists()
-        return has_fsp_with_api and all_sent_to_fsp
+        has_sent_to_fsp_payment = self.eligible_payments.filter(status=Payment.STATUS_SENT_TO_FSP).exists()
+        return has_fsp_with_api and has_sent_to_fsp_payment
 
     @property
     def fsp_communication_channel(self) -> str:

--- a/src/hct_mis_api/apps/payment/schema.py
+++ b/src/hct_mis_api/apps/payment/schema.py
@@ -751,14 +751,14 @@ class PaymentPlanNode(BaseNodePermissionMixin, AdminUrlNodeMixin, DjangoObjectTy
     @classmethod
     def resolve_can_export_xlsx(cls, parent: PaymentPlan, info: Any) -> bool:
         if parent.status in [PaymentPlan.Status.ACCEPTED, PaymentPlan.Status.FINISHED]:
-            if parent.fsp_communication_channel == "API":
+            if parent.fsp_communication_channel == FinancialServiceProvider.COMMUNICATION_CHANNEL_API:
                 if not info.context.user.has_permission(
                     Permissions.PM_DOWNLOAD_FSP_AUTH_CODE.value, parent.business_area
                 ):
                     return False
                 return parent.can_create_xlsx_with_fsp_auth_code
 
-            if parent.fsp_communication_channel == "XLSX":
+            if parent.fsp_communication_channel == FinancialServiceProvider.COMMUNICATION_CHANNEL_XLSX:
                 if not info.context.user.has_permission(Permissions.PM_EXPORT_XLSX_FOR_FSP.value, parent.business_area):
                     return False
                 return cls._has_fsp_delivery_mechanism_xlsx_template(parent)
@@ -768,14 +768,14 @@ class PaymentPlanNode(BaseNodePermissionMixin, AdminUrlNodeMixin, DjangoObjectTy
     @staticmethod
     def resolve_can_download_xlsx(parent: PaymentPlan, info: Any) -> bool:
         if parent.status in [PaymentPlan.Status.ACCEPTED, PaymentPlan.Status.FINISHED]:
-            if parent.fsp_communication_channel == "API":
+            if parent.fsp_communication_channel == FinancialServiceProvider.COMMUNICATION_CHANNEL_API:
                 if not info.context.user.has_permission(
                     Permissions.PM_DOWNLOAD_FSP_AUTH_CODE.value, parent.business_area
                 ):
                     return False
                 return parent.has_export_file
 
-            if parent.fsp_communication_channel == "XLSX":
+            if parent.fsp_communication_channel == FinancialServiceProvider.COMMUNICATION_CHANNEL_XLSX:
                 if not info.context.user.has_permission(
                     Permissions.PM_DOWNLOAD_XLSX_FOR_FSP.value, parent.business_area
                 ):
@@ -787,7 +787,7 @@ class PaymentPlanNode(BaseNodePermissionMixin, AdminUrlNodeMixin, DjangoObjectTy
     @staticmethod
     def resolve_can_send_xlsx_password(parent: PaymentPlan, info: Any) -> bool:
         if parent.status in [PaymentPlan.Status.ACCEPTED, PaymentPlan.Status.FINISHED]:
-            if parent.fsp_communication_channel == "API":
+            if parent.fsp_communication_channel == FinancialServiceProvider.COMMUNICATION_CHANNEL_API:
                 if not info.context.user.has_permission(Permissions.PM_SEND_XLSX_PASSWORD.value, parent.business_area):
                     return False
                 return parent.has_export_file

--- a/tests/unit/apps/payment/snapshots/snap_test_all_payment_plan_queries.py
+++ b/tests/unit/apps/payment/snapshots/snap_test_all_payment_plan_queries.py
@@ -987,9 +987,9 @@ snapshots['TestPaymentPlanQueries::test_payment_plan_filter_total_households_cou
 snapshots['TestPaymentPlanQueries::test_payment_plans_export_download_properties_0_with_permission_api 1'] = {
     'data': {
         'paymentPlan': {
-            'canCreateXlsxWithFspAuthCode': True,
+            'canCreateXlsxWithFspAuthCode': False,
             'canDownloadXlsx': False,
-            'canExportXlsx': True,
+            'canExportXlsx': False,
             'canSendToPaymentGateway': False,
             'canSendXlsxPassword': False,
             'fspCommunicationChannel': 'API',
@@ -1002,7 +1002,7 @@ snapshots['TestPaymentPlanQueries::test_payment_plans_export_download_properties
 snapshots['TestPaymentPlanQueries::test_payment_plans_export_download_properties_1_without_permission_api 1'] = {
     'data': {
         'paymentPlan': {
-            'canCreateXlsxWithFspAuthCode': True,
+            'canCreateXlsxWithFspAuthCode': False,
             'canDownloadXlsx': False,
             'canExportXlsx': False,
             'canSendToPaymentGateway': False,


### PR DESCRIPTION
[AB#236467](https://unicef.visualstudio.com/ICTD-HCT-MIS/_workitems/edit/236467): Enable 'Auth codes' file export when records are at 'Transferred to FSP' and keep the file enabled until exported once