### PR TITLE
STG // Fix create PaymentVerificationSummary after PG sync

### DIFF
--- a/src/hct_mis_api/apps/payment/services/payment_gateway.py
+++ b/src/hct_mis_api/apps/payment/services/payment_gateway.py
@@ -557,6 +557,8 @@ class PaymentGatewayService:
                             self.update_payment(payment, pg_payment_records, instruction, payment_plan, exchange_rate)
 
                 if payment_plan.is_reconciled:
+                    payment_plan.status_finished()
+                    payment_plan.save()
                     for instruction in payment_instructions:
                         self.change_payment_instruction_status(PaymentInstructionStatus.FINALIZED, instruction)
 


### PR DESCRIPTION
[AB#238963](https://unicef.visualstudio.com/ICTD-HCT-MIS/_workitems/edit/238963): Payment Verification - Cannot create Payment verification plan