### PR TITLE
[245537] Handle permission check on REST endpoints based on a token presence (internal and external endpoints in one viewset)

### DIFF
--- a/src/hct_mis_api/apps/core/api/mixins.py
+++ b/src/hct_mis_api/apps/core/api/mixins.py
@@ -3,9 +3,12 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 from requests import Response, session
 from requests.adapters import HTTPAdapter
+from rest_framework.authentication import get_authorization_header
 from rest_framework.generics import get_object_or_404
 from urllib3 import Retry
 
+from hct_mis_api.api.auth import HOPEAuthentication, HOPEPermission
+from hct_mis_api.api.models import Grant
 from hct_mis_api.apps.core.models import BusinessArea
 from hct_mis_api.apps.core.utils import decode_id_string
 
@@ -102,3 +105,29 @@ class ActionMixin:
             return self.serializer_classes_by_action[self.action]
         else:
             return super().get_serializer_class()  # pragma: no cover
+
+
+class PermissionsMixin:
+    """ "
+    Mixin to allow using the same viewset for both internal and external endpoints.
+    If the request is authenticated with a token, it will use the HOPEPermission and check permission assigned to variable token_permission.
+    """
+
+    token_permission = Grant.API_READ_ONLY
+
+    def is_external_request(self) -> bool:
+        auth_header = get_authorization_header(self.request).split()
+        if auth_header and auth_header[0].lower() == "token".encode():
+            return True
+        return False
+
+    def get_authenticators(self) -> List[Any]:
+        if self.is_external_request():
+            self.authentication_classes = [HOPEAuthentication]
+        return super().get_authenticators()  # pragma: no cover
+
+    def get_permissions(self) -> Any:
+        if self.is_external_request():
+            self.permission_classes = [HOPEPermission]
+            self.permission = self.token_permission
+        return super().get_permissions()  # pragma: no cover

--- a/src/hct_mis_api/apps/geo/api/views.py
+++ b/src/hct_mis_api/apps/geo/api/views.py
@@ -14,7 +14,7 @@ from rest_framework_extensions.cache.decorators import cache_response
 
 from hct_mis_api.api.caches import etag_decorator
 from hct_mis_api.apps.account.api.permissions import GeoViewListPermission
-from hct_mis_api.apps.core.api.mixins import BusinessAreaMixin
+from hct_mis_api.apps.core.api.mixins import BusinessAreaMixin, PermissionsMixin
 from hct_mis_api.apps.geo.api.caches import AreaKeyConstructor
 from hct_mis_api.apps.geo.api.filters import AreaFilter
 from hct_mis_api.apps.geo.api.serializers import AreaListSerializer
@@ -25,11 +25,12 @@ logger = logging.getLogger(__name__)
 
 class AreaViewSet(
     BusinessAreaMixin,
+    PermissionsMixin,
     mixins.ListModelMixin,
     GenericViewSet,
 ):
     serializer_class = AreaListSerializer
-    permission_classes = [GeoViewListPermission]
+    permission_classes = [GeoViewListPermission]  # type: ignore
     filter_backends = (OrderingFilter, DjangoFilterBackend)
     filterset_class = AreaFilter
 

--- a/tests/unit/api/test_area.py
+++ b/tests/unit/api/test_area.py
@@ -1,0 +1,119 @@
+import base64
+
+from rest_framework.reverse import reverse
+
+from hct_mis_api.api.models import Grant
+from hct_mis_api.apps.account.fixtures import BusinessAreaFactory
+from hct_mis_api.apps.geo.fixtures import AreaFactory, AreaTypeFactory, CountryFactory
+from tests.unit.api.base import HOPEApiTestCase, token_grant_permission
+
+
+def id_to_base64(object_id: str, name: str) -> str:
+    return base64.b64encode(f"{name}:{str(object_id)}".encode()).decode()
+
+
+class APIAreaTests(HOPEApiTestCase):
+    databases = {"default"}
+    user_permissions = []
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        super().setUpTestData()
+        cls.url_list = reverse(
+            "api:geo:areas-list",
+            kwargs={
+                "business_area": cls.business_area.slug,
+            },
+        )
+
+    def test_list_business_area(self) -> None:
+        self.business_area_2 = BusinessAreaFactory(name="Afghanistan 2")
+        self.country_1 = CountryFactory(name="Afghanistan")
+        self.country_1.business_areas.set([self.business_area, self.business_area_2])
+        self.country_2 = CountryFactory(
+            name="Afghanistan 2",
+            short_name="Afg2",
+            iso_code2="A2",
+            iso_code3="AF2",
+            iso_num="2222",
+        )
+        self.country_2.business_areas.set([self.business_area])
+
+        self.area_type_1_afg = AreaTypeFactory(name="Area Type in Afg", country=self.country_1, area_level=1)
+        self.area_type_2_afg = AreaTypeFactory(name="Area Type 2 in Afg", country=self.country_1, area_level=2)
+        self.area_type_afg_2 = AreaTypeFactory(name="Area Type in Afg 2", country=self.country_2, area_level=1)
+
+        self.area_1_area_type_1 = AreaFactory(
+            name="Area 1 Area Type 1", area_type=self.area_type_1_afg, p_code="AREA1-ARTYPE1"
+        )
+        self.area_2_area_type_1 = AreaFactory(
+            name="Area 2 Area Type 1", area_type=self.area_type_1_afg, p_code="AREA2-ARTYPE1"
+        )
+        self.area_1_area_type_2 = AreaFactory(
+            name="Area 1 Area Type 2", area_type=self.area_type_2_afg, p_code="AREA1-ARTYPE2"
+        )
+        self.area_2_area_type_2 = AreaFactory(
+            name="Area 2 Area Type 2", area_type=self.area_type_2_afg, p_code="AREA2-ARTYPE2"
+        )
+        self.area_1_area_type_afg_2 = AreaFactory(
+            name="Area 1 Area Type Afg 2", area_type=self.area_type_afg_2, p_code="AREA1-ARTYPE-AFG2"
+        )
+        self.area_2_area_type_afg_2 = AreaFactory(
+            name="Area 2 Area Type Afg 2", area_type=self.area_type_afg_2, p_code="AREA2-ARTYPE-AFG2"
+        )
+
+        self.business_area_other = BusinessAreaFactory(name="Other")
+        self.country_other = CountryFactory(
+            name="Other Country",
+            short_name="Oth",
+            iso_code2="O",
+            iso_code3="OTH",
+            iso_num="111",
+        )
+        self.country_other.business_areas.set([self.business_area_other])
+        self.area_type_other = AreaTypeFactory(name="Area Type Other", country=self.country_other)
+        self.area_other = AreaFactory(name="Area Other", area_type=self.area_type_other, p_code="AREA-OTHER")
+
+        response = self.client.get(self.url_list)
+        assert response.status_code == 403
+        with token_grant_permission(self.token, Grant.API_READ_ONLY):
+            response = self.client.get(self.url_list)
+
+        self.assertEqual(response.status_code, 200)
+        response_json = response.json()["results"]
+        assert len(response_json) == 6
+        assert {
+            "id": id_to_base64(self.area_1_area_type_1.id, "Area"),
+            "name": self.area_1_area_type_1.name,
+            "p_code": self.area_1_area_type_1.p_code,
+        } in response_json
+        assert {
+            "id": id_to_base64(self.area_2_area_type_1.id, "Area"),
+            "name": self.area_2_area_type_1.name,
+            "p_code": self.area_2_area_type_1.p_code,
+        } in response_json
+        assert {
+            "id": id_to_base64(self.area_1_area_type_2.id, "Area"),
+            "name": self.area_1_area_type_2.name,
+            "p_code": self.area_1_area_type_2.p_code,
+        } in response_json
+        assert {
+            "id": id_to_base64(self.area_2_area_type_2.id, "Area"),
+            "name": self.area_2_area_type_2.name,
+            "p_code": self.area_2_area_type_2.p_code,
+        } in response_json
+        assert {
+            "id": id_to_base64(self.area_1_area_type_afg_2.id, "Area"),
+            "name": self.area_1_area_type_afg_2.name,
+            "p_code": self.area_1_area_type_afg_2.p_code,
+        } in response_json
+        assert {
+            "id": id_to_base64(self.area_2_area_type_afg_2.id, "Area"),
+            "name": self.area_2_area_type_afg_2.name,
+            "p_code": self.area_2_area_type_afg_2.p_code,
+        } in response_json
+        assert {
+            "id": id_to_base64(self.area_other.id, "Area"),
+            "name": self.area_other.name,
+            "p_code": self.area_other.p_code,
+        } not in response_json

--- a/tests/unit/api/test_area.py
+++ b/tests/unit/api/test_area.py
@@ -1,5 +1,6 @@
 import base64
 
+from rest_framework import status
 from rest_framework.reverse import reverse
 
 from hct_mis_api.api.models import Grant
@@ -75,11 +76,11 @@ class APIAreaTests(HOPEApiTestCase):
         self.area_other = AreaFactory(name="Area Other", area_type=self.area_type_other, p_code="AREA-OTHER")
 
         response = self.client.get(self.url_list)
-        assert response.status_code == 403
+        assert response.status_code == status.HTTP_403_FORBIDDEN
         with token_grant_permission(self.token, Grant.API_READ_ONLY):
             response = self.client.get(self.url_list)
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_json = response.json()["results"]
         assert len(response_json) == 6
         assert {

--- a/tests/unit/api/test_business_area.py
+++ b/tests/unit/api/test_business_area.py
@@ -1,3 +1,4 @@
+from rest_framework import status
 from rest_framework.reverse import reverse
 
 from hct_mis_api.api.models import Grant
@@ -35,10 +36,10 @@ class APIBusinessAreaTests(HOPEApiTestCase):
         business_area1.refresh_from_db()
         business_area2.refresh_from_db()
         response = self.client.get(self.list_url)
-        assert response.status_code == 403
+        assert response.status_code == status.HTTP_403_FORBIDDEN
         with token_grant_permission(self.token, Grant.API_READ_ONLY):
             response = self.client.get(self.list_url)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.json()["results"]), 3)
         self.assertIn(
             {


### PR DESCRIPTION
[AB#245537](https://unicef.visualstudio.com/4e044e8d-bc28-4768-8074-f80ff6e4a0e5/_workitems/edit/245537)