### PR TITLE
not using cert on postgres

### DIFF
--- a/.github/helpers/.env-unit
+++ b/.github/helpers/.env-unit
@@ -5,7 +5,6 @@ POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres
 DATABASE_URL=postgis://postgres:postgres@db:5432/postgres
 REP_DATABASE_URL=postgis://postgres:postgres@db:5432/postgres
-POSTGRES_SSL_MODE=off
 EMAIL_HOST=TBD
 EMAIL_HOST_USER=TBD
 EMAIL_HOST_PASSWORD=TBD

--- a/.github/helpers/docker-compose.tst.yml
+++ b/.github/helpers/docker-compose.tst.yml
@@ -22,7 +22,6 @@ services:
       - POSTGRES_PASS=postgres
       - PGUSER=postgres
       - POSTGRES_HOST_AUTH_METHOD=trust
-      - POSTGRES_SSL_MODE=off
     ports:
       - "5433:5432"
 

--- a/development_tools/.env.example
+++ b/development_tools/.env.example
@@ -11,7 +11,6 @@ PGUSER=postgres
 POSTGRES_HOST_AUTH_METHOD=trust
 DATABASE_URL=postgis://postgres:postgres@db:5432/postgres
 REP_DATABASE_URL=postgis://postgres:postgres@db:5432/postgres
-POSTGRES_SSL_MODE=off
 EMAIL_HOST=TBD
 EMAIL_HOST_USER=TBD
 EMAIL_HOST_PASSWORD=TBD

--- a/development_tools/compose.yml
+++ b/development_tools/compose.yml
@@ -125,7 +125,7 @@ services:
       - "5432:5432"
     healthcheck:
       test: [ "CMD-SHELL", "su - postgres -c 'pg_isready -h db -U postgres'" ]
-      interval: 10s
+      interval: 3s
       timeout: 10s
       retries: 5
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -100,7 +100,6 @@ ENV PATH="$APP_PATH/.venv/bin:$PATH"
 
 COPY ./src/gunicorn_config.py /conf/gunicorn_config.py
 COPY --chown=hope:hope --from=dist-builder $APP_PATH/.venv $APP_PATH/.venv
-COPY --chown=hope:hope --from=certs /data/psql-cert.crt /certs/psql-cert.crt
 COPY ./src/data $APP_PATH/data
 USER hope
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,12 +1,3 @@
-FROM alpine:3.19.1 as curl
-RUN apk add curl openssl && mkdir /data
-FROM curl as waitforit
-RUN curl -o /data/waitforit -sSL https://github.com/maxcnunes/waitforit/releases/download/v2.4.1/waitforit-linux_amd64 \
-    && chmod +x /data/waitforit
-
-FROM curl as certs
-RUN curl -o /data/psql-cert-crt.crt -L https://www.microsoft.com/pkiops/certs/Microsoft%20RSA%20Root%20Certificate%20Authority%202017.crt && openssl x509 -in /data/psql-cert-crt.crt -out /data/psql-cert.crt
-
 # Base image
 FROM python:3.12.7-slim-bookworm as base
 ENV APP_PATH=/app
@@ -42,8 +33,6 @@ RUN apt-get update \
 ENV XDG_RUNTIME_DIR=/run/user/"${UID}"
 ENV DJANGO_SETTINGS_MODULE=hct_mis_api.config.settings
 WORKDIR $APP_PATH
-
-COPY --from=waitforit /data/waitforit /usr/local/bin/waitforit
 
 # Dist builder image
 FROM base as uv

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,23 +1,16 @@
 #!/bin/bash
 set -e
 
-wait_for_db() {
-  until pg_isready -h $1 -p 5432;
-  do echo "waiting for database ${1}"; sleep 2; done;
-}
-
 if [ $# -eq 0 ]; then
     exec gunicorn hct_mis_api.wsgi -c /conf/gunicorn_config.py
 else
   case "$1" in
     "dev")
-      wait_for_db db
       python manage.py collectstatic --no-input --no-default-ignore
       python manage.py migrate
       python manage.py runserver 0.0.0.0:8000
       ;;
     "cy")
-      wait_for_db db
       python manage.py collectstatic --no-input --no-default-ignore
       python manage.py migrate
       python manage.py initcypress --skip-drop

--- a/src/hct_mis_api/config/env.py
+++ b/src/hct_mis_api/config/env.py
@@ -135,7 +135,6 @@ DEFAULTS = {
     ),
     "SOCIAL_AUTH_REDIRECT_IS_HTTPS": (bool, True),
     "LOG_LEVEL": (str, "ERROR"),
-    "POSTGRES_SSL": (bool, False),
     "GIT_VERSION": (str, "UNKNOWN"),
     "EXCHANGE_RATE_CACHE_EXPIRY": (int, 60 * 60 * 24),
     "USE_DUMMY_EXCHANGE_RATES": (str, "no"),

--- a/src/hct_mis_api/config/settings.py
+++ b/src/hct_mis_api/config/settings.py
@@ -123,12 +123,6 @@ DATABASES = {
 }
 DATABASES["default"].update({"CONN_MAX_AGE": 60})
 
-if env("POSTGRES_SSL"):
-    DATABASES["default"]["OPTIONS"] = {
-        "sslmode": "verify-full",
-        "sslrootcert": "/certs/psql-cert.crt",
-    }
-
 # If app is not specified here it will use default db
 DATABASE_APPS_MAPPING: Dict[str, str] = {}
 


### PR DESCRIPTION
This pull request removes support for SSL mode in PostgreSQL configurations and simplifies related setup processes. Additionally, it adjusts database health check intervals and removes unused dependencies and scripts.

### Removal of PostgreSQL SSL mode:
* Removed the `POSTGRES_SSL_MODE` environment variable from various configuration files, including `.github/helpers/.env-unit`, `.github/helpers/docker-compose.tst.yml`, and `development_tools/.env.example`. [[1]](diffhunk://#diff-bd16a15d2ec42e95e59d63607376c7f8267082daf6e69b81be0d1611d1ca42daL8) [[2]](diffhunk://#diff-4dfb63e2ea8355ecace6be3bfe6bc23250f483e8f78cb0f11d1ecec782597244L25) [[3]](diffhunk://#diff-c1e4eb25bd12f9eac7dfd5256e255ed48aa90f92dadc950394bdf4aa60285edeL14)
* Deleted SSL-related settings in `src/hct_mis_api/config/env.py` and `src/hct_mis_api/config/settings.py`, including the `POSTGRES_SSL` environment variable and database options for SSL. [[1]](diffhunk://#diff-bbf4bb1271e3959329380b294bf07466ab881830ebb95905aadcc06268bf94f7L138) [[2]](diffhunk://#diff-0599a333b15e1ae0552f033fef8058ecdba9f2f4c1539b43758150ec3cd9e896L126-L131)

### Simplification of Docker setup:
* Removed the use of `waitforit` and SSL certificate-related stages from the `docker/Dockerfile`, along with associated dependencies. [[1]](diffhunk://#diff-f34da55ca08f1a30591d8b0b3e885bcc678537b2a9a4aadea4f190806b374ddcL1-L9) [[2]](diffhunk://#diff-f34da55ca08f1a30591d8b0b3e885bcc678537b2a9a4aadea4f190806b374ddcL46-L47)
* Deleted the `wait_for_db` function from `docker/entrypoint.sh`, simplifying the script by removing database readiness checks.

### Database health check adjustments:
* Updated the database health check interval in `development_tools/compose.yml` from 10 seconds to 3 seconds for faster responsiveness.