### PR TITLE
AB#254781 Fix validation on xlsx template delivery mechanisms

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,7 +132,7 @@ distribution = true
 
 [project]
 name = "hope"
-version = "3.1.12"
+version = "3.1.13"
 description = "HCT MIS is UNICEF's humanitarian cash transfer platform."
 authors = [
     { name = "Tivix" },

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "3.1.12",
+  "version": "3.1.13",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/hct_mis_api/apps/payment/admin.py
+++ b/src/hct_mis_api/apps/payment/admin.py
@@ -391,7 +391,7 @@ class FspXlsxTemplatePerDeliveryMechanismForm(forms.ModelForm):
 
         error_message = f"Delivery Mechanism {delivery_mechanism} is not supported by Financial Service Provider {financial_service_provider}"
         # to work both in inline and standalone
-        if delivery_mechanisms := self.data.get("delivery_mechanisms"):
+        if delivery_mechanisms := self.data.getlist("delivery_mechanisms"):
             if delivery_mechanism and str(delivery_mechanism.id) not in delivery_mechanisms:
                 raise ValidationError(error_message)
         else:

--- a/tests/unit/apps/grievance/test_model_validation.py
+++ b/tests/unit/apps/grievance/test_model_validation.py
@@ -1,4 +1,5 @@
 from django.core.exceptions import ValidationError
+from django.http import QueryDict
 from django.test import TestCase
 
 from hct_mis_api.apps.account.fixtures import UserFactory
@@ -109,7 +110,11 @@ class TestFspXlsxTemplatePerDeliveryMechanismValidation(TestCase):
             "delivery_mechanism": self.dm_transfer_to_account.id,
             "xlsx_template": fsp_xls_template.id,
         }
-        form = FspXlsxTemplatePerDeliveryMechanismForm(data=form_data_standalone)
+        form_data_standalone_query_dict = QueryDict(mutable=True)
+        for key, value in form_data_standalone.items():
+            form_data_standalone_query_dict[key] = value
+
+        form = FspXlsxTemplatePerDeliveryMechanismForm(data=form_data_standalone_query_dict)
         self.assertTrue(form.is_valid())
         form.clean()
 
@@ -120,7 +125,15 @@ class TestFspXlsxTemplatePerDeliveryMechanismValidation(TestCase):
             "xlsx_template": fsp_xls_template.id,
             "delivery_mechanisms": [str(self.dm_transfer_to_account.id)],
         }
-        form = FspXlsxTemplatePerDeliveryMechanismForm(data=form_data_inline)
+
+        form_data_inline_query_dict = QueryDict(mutable=True)
+        for key, value in form_data_inline.items():
+            if isinstance(value, list):
+                form_data_inline_query_dict.setlist(key, value)
+                continue
+            form_data_inline_query_dict[key] = value
+        form = FspXlsxTemplatePerDeliveryMechanismForm(data=form_data_inline_query_dict)
+        print(form.errors)
         self.assertTrue(form.is_valid())
         form.clean()
 
@@ -128,7 +141,7 @@ class TestFspXlsxTemplatePerDeliveryMechanismValidation(TestCase):
         fsp_xls_template.core_fields = []
         fsp_xls_template.save()
 
-        form = FspXlsxTemplatePerDeliveryMechanismForm(data=form_data_standalone)
+        form = FspXlsxTemplatePerDeliveryMechanismForm(data=form_data_standalone_query_dict)
         self.assertFalse(form.is_valid())
         with self.assertRaisesMessage(
             ValidationError,
@@ -146,7 +159,7 @@ class TestFspXlsxTemplatePerDeliveryMechanismValidation(TestCase):
 
         # test delivery mechanism not supported
         fsp.delivery_mechanisms.remove(self.dm_transfer_to_account)
-        form = FspXlsxTemplatePerDeliveryMechanismForm(data=form_data_standalone)
+        form = FspXlsxTemplatePerDeliveryMechanismForm(data=form_data_standalone_query_dict)
         self.assertFalse(form.is_valid())
         with self.assertRaisesMessage(
             ValidationError,
@@ -161,7 +174,10 @@ class TestFspXlsxTemplatePerDeliveryMechanismValidation(TestCase):
             "xlsx_template": fsp_xls_template.id,
             "delivery_mechanisms": ["12313213123"],
         }
-        form = FspXlsxTemplatePerDeliveryMechanismForm(data=form_data_inline)
+        form_data_inline_query_dict = QueryDict(mutable=True)
+        for key, value in form_data_inline.items():
+            form_data_inline_query_dict[key] = value
+        form = FspXlsxTemplatePerDeliveryMechanismForm(data=form_data_inline_query_dict)
         self.assertFalse(form.is_valid())
         with self.assertRaisesMessage(
             ValidationError,


### PR DESCRIPTION
This pull request includes a small change to the `clean` method in `src/hct_mis_api/apps/payment/admin.py`. The change ensures compatibility with handling multiple delivery mechanisms by using `getlist` instead of `get` when accessing `self.data`.