### PR TITLE
Back merge Staging > dev

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -66,7 +66,7 @@ RUN --mount=type=cache,target=/root/.uv-cache \
     uv sync --cache-dir=/root/.uv-cache \
         --python=/usr/local/bin/python \
         --python-preference=system \
-        --no-editable --frozen --extra distribution --no-install-package hope
+        --no-editable --frozen --no-install-package hope
 COPY ./tests ./tests
 COPY ./src/data $APP_PATH/data
 COPY ./manage.py ./manage.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,7 +164,7 @@ docs = [
 
 [project]
 name = "hope"
-version = "3.2.5"
+version = "3.2.6"
 description = "HCT MIS is UNICEF's humanitarian cash transfer platform."
 authors = [
     { name = "Tivix" },
@@ -268,6 +268,7 @@ dependencies = [
     "django-fernet-fields>=0.6",
     "msoffcrypto-tool>=5.4.2",
     "pyzipper>=0.3.6",
+    "legacy-cgi>=2.6.3",
 ]
 requires-python = "==3.13.*"
 readme = "README.md"

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "3.2.5",
+  "version": "3.2.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/hct_mis_api/apps/payment/models/payment.py
+++ b/src/hct_mis_api/apps/payment/models/payment.py
@@ -219,6 +219,16 @@ class PaymentPlan(
         Status.DRAFT,
     )
 
+    HARD_CONFLICT_STATUSES = (
+        Status.LOCKED,
+        Status.LOCKED_FSP,
+        Status.IN_APPROVAL,
+        Status.IN_AUTHORIZATION,
+        Status.IN_REVIEW,
+        Status.ACCEPTED,
+        Status.FINISHED,
+    )
+
     CAN_RUN_ENGINE_FORMULA_FOR_ENTITLEMENT = (Status.LOCKED,)
     CAN_RUN_ENGINE_FORMULA_FOR_VULNERABILITY_SCORE = (
         Status.TP_LOCKED,

--- a/tests/unit/apps/payment/test_models.py
+++ b/tests/unit/apps/payment/test_models.py
@@ -620,18 +620,18 @@ class TestPaymentModel(TestCase):
             ],
         )
 
-    def test_manager_annotations_pp_no_conflicts_for_follow_up(self) -> None:
+    def test_manager_annotations_conflicts_for_follow_up(self) -> None:
         rdi = RegistrationDataImportFactory(business_area=self.business_area)
         program = RealProgramFactory(business_area=self.business_area)
         program_cycle = program.cycles.first()
         pp1 = PaymentPlanFactory(
             program_cycle=program_cycle,
+            is_follow_up=False,
             business_area=self.business_area,
-            status=PaymentPlan.Status.OPEN,
+            status=PaymentPlan.Status.FINISHED,
             created_by=self.user,
         )
-        # create follow up pp
-        pp2 = PaymentPlanFactory(
+        pp2_follow_up = PaymentPlanFactory(
             business_area=self.business_area,
             status=PaymentPlan.Status.LOCKED,
             is_follow_up=True,
@@ -649,39 +649,50 @@ class TestPaymentModel(TestCase):
         )
         p1 = PaymentFactory(
             parent=pp1,
-            conflicted=False,
+            is_follow_up=False,
             currency="PLN",
             household__registration_data_import=rdi,
             household__program=program,
+            status=Payment.STATUS_ERROR,
         )
         p2 = PaymentFactory(
-            parent=pp2,
+            parent=pp2_follow_up,
             household=p1.household,
-            conflicted=False,
-            is_follow_up=True,
-            source_payment=p1,
-            currency="PLN",
-        )
-        p3 = PaymentFactory(
-            parent=pp3,
-            household=p1.household,
-            conflicted=False,
             is_follow_up=True,
             source_payment=p1,
             currency="PLN",
         )
 
-        for _ in [pp1, pp2, pp3, p1, p2, p3]:
+        for _ in [pp1, pp2_follow_up, pp3, p1, p2]:
             _.refresh_from_db()  # update unicef_id from trigger
 
         p2_data = Payment.objects.filter(id=p2.id).values()[0]
         self.assertEqual(p2_data["payment_plan_hard_conflicted"], False)
-        self.assertEqual(p2_data["payment_plan_soft_conflicted"], True)
+        self.assertEqual(p2_data["payment_plan_soft_conflicted"], False)
+
+        p3 = PaymentFactory(
+            parent=pp3,
+            household=p1.household,
+            is_follow_up=False,
+            currency="PLN",
+        )
+        p3.refresh_from_db()  # update unicef_id from trigger
+        self.maxDiff = None
         p3_data = Payment.objects.filter(id=p3.id).values()[0]
-        self.assertEqual(p3_data["payment_plan_hard_conflicted"], False)
-        self.assertEqual(p3_data["payment_plan_soft_conflicted"], True)
-        self.assertEqual(p2_data["payment_plan_hard_conflicted_data"], [])
-        self.assertIsNotNone(p3_data["payment_plan_hard_conflicted_data"])
+        self.assertEqual(p3_data["payment_plan_hard_conflicted"], True)
+        self.assertEqual(p3_data["payment_plan_soft_conflicted"], False)
+        import json
+
+        data = {
+            "payment_id": str(p2.id),
+            "payment_plan_id": str(pp2_follow_up.id),
+            "payment_unicef_id": str(p2.unicef_id),
+            "payment_plan_status": "LOCKED",
+            "payment_plan_end_date": pp2_follow_up.program_cycle.end_date.isoformat(),
+            "payment_plan_unicef_id": str(pp2_follow_up.unicef_id),
+            "payment_plan_start_date": pp2_follow_up.program_cycle.start_date.isoformat(),
+        }
+        self.assertEqual(p3_data["payment_plan_hard_conflicted_data"], [json.dumps(data)])
 
 
 class TestPaymentPlanSplitModel(TestCase):

--- a/uv.lock
+++ b/uv.lock
@@ -1752,7 +1752,7 @@ wheels = [
 
 [[package]]
 name = "hope"
-version = "3.2.5"
+version = "3.2.6"
 source = { editable = "." }
 dependencies = [
     { name = "black" },
@@ -1822,6 +1822,7 @@ dependencies = [
     { name = "jedi" },
     { name = "jinja2" },
     { name = "jmespath" },
+    { name = "legacy-cgi" },
     { name = "markupsafe" },
     { name = "msoffcrypto-tool" },
     { name = "natural-keys" },
@@ -2004,6 +2005,7 @@ requires-dist = [
     { name = "jedi", specifier = ">=0.18.1,<1.0.0" },
     { name = "jinja2", specifier = ">=3.1.3,<4.0.0" },
     { name = "jmespath", specifier = ">=1.0.1,<2.0.0" },
+    { name = "legacy-cgi", specifier = ">=2.6.3" },
     { name = "markupsafe", specifier = ">=2.1.1,<3.0.0" },
     { name = "msoffcrypto-tool", specifier = ">=5.4.2" },
     { name = "natural-keys", specifier = ">=2.0.0,<3.0.0" },


### PR DESCRIPTION
add legacy-cgi
FYI
The cgi module was officially removed in Python 3.13 as part of PEP 594, which deprecated and removed older, outdated modules from the standard library.


