### PR TITLE
Fix Excluded Target Population Entries still appear in Target Population

### DIFF
--- a/src/hct_mis_api/apps/targeting/services/targeting_service.py
+++ b/src/hct_mis_api/apps/targeting/services/targeting_service.py
@@ -44,7 +44,8 @@ class TargetingCriteriaQueryingBase:
         return " OR ".join(rules_string).strip()
 
     def get_basic_query(self) -> Q:
-        return Q(withdrawn=False) & ~Q(unicef_id__in=self.get_excluded_household_ids())
+        key_filter = "unicef_id__in" if not self.is_social_worker_program else "individuals__unicef_id__in"
+        return Q(withdrawn=False) & ~Q(**{key_filter: self.get_excluded_household_ids()})
 
     def apply_targeting_criteria_exclusion_flags(self) -> Q:
         return self.apply_flag_exclude_if_active_adjudication_ticket() & self.apply_flag_exclude_if_on_sanction_list()

--- a/tests/unit/apps/payment/test_payment_plan_services.py
+++ b/tests/unit/apps/payment/test_payment_plan_services.py
@@ -306,7 +306,7 @@ class TestPaymentPlanServices(APITestCase):
         self.assertEqual(pp.total_households_count, 0)
         self.assertEqual(pp.total_individuals_count, 0)
         self.assertEqual(pp.payment_items.count(), 0)
-        with self.assertNumQueries(98):
+        with self.assertNumQueries(99):
             prepare_payment_plan_task.delay(str(pp.id))
         pp.refresh_from_db()
         self.assertEqual(pp.status, PaymentPlan.Status.TP_OPEN)
@@ -746,7 +746,7 @@ class TestPaymentPlanServices(APITestCase):
         self.assertEqual(pp.total_households_count, 0)
         self.assertEqual(pp.total_individuals_count, 0)
         self.assertEqual(pp.payment_items.count(), 0)
-        with self.assertNumQueries(71):
+        with self.assertNumQueries(72):
             prepare_payment_plan_task.delay(str(pp.id))
         pp.refresh_from_db()
         self.assertEqual(pp.status, PaymentPlan.Status.TP_OPEN)

--- a/tests/unit/apps/targeting/test_individual_block_filters.py
+++ b/tests/unit/apps/targeting/test_individual_block_filters.py
@@ -15,7 +15,11 @@ from extras.test_utils.factories.payment import (
 )
 from extras.test_utils.factories.program import ProgramFactory
 
-from hct_mis_api.apps.core.models import FlexibleAttribute, PeriodicFieldData
+from hct_mis_api.apps.core.models import (
+    DataCollectingType,
+    FlexibleAttribute,
+    PeriodicFieldData,
+)
 from hct_mis_api.apps.household.models import (
     FEMALE,
     MALE,
@@ -367,3 +371,32 @@ class TestIndividualBlockFilter(TestCase):
         query = query.filter(payment_plan.get_query())
         self.assertEqual(query.count(), 1)
         self.assertEqual(query.first().unicef_id, self.household_1_indiv.unicef_id)
+
+    def test_exclude_by_ids(self) -> None:
+        payment_plan = PaymentPlanFactory(program_cycle=self.program_cycle, created_by=self.user)
+
+        empty_basic_query = payment_plan.get_basic_query()
+        self.assertEqual(str(empty_basic_query), "(AND: ('withdrawn', False), (NOT (AND: ('unicef_id__in', []))))")
+
+        payment_plan.excluded_ids = "HH-1, HH-2"
+        payment_plan.save()
+        payment_plan.refresh_from_db()
+
+        basic_query_1 = payment_plan.get_basic_query()
+        self.assertFalse(payment_plan.is_social_worker_program)
+        self.assertEqual(
+            str(basic_query_1), "(AND: ('withdrawn', False), (NOT (AND: ('unicef_id__in', ['HH-1', 'HH-2']))))"
+        )
+
+        self.program.data_collecting_type.type = DataCollectingType.Type.SOCIAL
+        self.program.data_collecting_type.save()
+        payment_plan.excluded_ids = "IND_01, IND-02"
+        payment_plan.save()
+        payment_plan.refresh_from_db()
+
+        self.assertTrue(payment_plan.is_social_worker_program)
+        basic_query_2 = payment_plan.get_basic_query()
+        self.assertEqual(
+            str(basic_query_2),
+            "(AND: ('withdrawn', False), (NOT (AND: ('individuals__unicef_id__in', ['IND_01', 'IND-02']))))",
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -1752,7 +1752,7 @@ wheels = [
 
 [[package]]
 name = "hope"
-version = "3.4.1"
+version = "3.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "black" },


### PR DESCRIPTION
[AB#271185](https://unicef.visualstudio.com/ICTD-HCT-MIS/_workitems/edit/271185): Haiti: Excluded Target Population Entries still appear in Target Population