### PR TITLE
STG // Payment Verification - Add validation that PVP can be finished only if reconciliation is finalized

### DIFF
--- a/src/hct_mis_api/apps/payment/services/verification_plan_status_change_services.py
+++ b/src/hct_mis_api/apps/payment/services/verification_plan_status_change_services.py
@@ -10,6 +10,7 @@ from hct_mis_api.apps.grievance.models import (
 from hct_mis_api.apps.grievance.notifications import GrievanceNotification
 from hct_mis_api.apps.household.models import Individual
 from hct_mis_api.apps.payment.models import PaymentVerification, PaymentVerificationPlan
+from hct_mis_api.apps.utils.exceptions import log_and_raise
 
 
 class VerificationPlanStatusChangeServices:
@@ -121,6 +122,9 @@ class VerificationPlanStatusChangeServices:
             raise error
 
     def finish(self) -> PaymentVerificationPlan:
+        if not self.payment_verification_plan.payment_plan.is_reconciled:
+            log_and_raise("You can finish only if reconciliation is finalized")
+
         self.payment_verification_plan.status = PaymentVerificationPlan.STATUS_FINISHED
         self.payment_verification_plan.completion_date = timezone.now()
         self.payment_verification_plan.save()


### PR DESCRIPTION
[AB#272498](https://unicef.visualstudio.com/ICTD-HCT-MIS/_workitems/edit/272498): Payment Verification - Add validation that PVP can be finished only if reconciliation is finalized