### PR TITLE
Fix Payment Module - PP Status does not change to formula engine run

### DIFF
--- a/src/hope/apps/payment/api/views.py
+++ b/src/hope/apps/payment/api/views.py
@@ -905,7 +905,9 @@ class PaymentPlanViewSet(
                     raise ValidationError("Rule Engine run in progress")
                 payment_plan.background_action_status_steficon_run()
                 payment_plan.save()
-                payment_plan_apply_engine_rule.delay(str(payment_plan.pk), str(engine_rule.pk))
+                transaction.on_commit(
+                    lambda: payment_plan_apply_engine_rule.delay(str(payment_plan.pk), str(engine_rule.pk))
+                )
 
             log_create(
                 mapping=PaymentPlan.ACTIVITY_LOG_MAPPING,
@@ -1656,6 +1658,7 @@ class TargetPopulationViewSet(
             old_object=old_tp,
             new_object=tp,
         )
+        tp.refresh_from_db(fields=["background_action_status"])
         response_serializer = TargetPopulationDetailSerializer(tp, context={"request": request})
         return Response(
             data=response_serializer.data,

--- a/src/hope/apps/payment/api/views.py
+++ b/src/hope/apps/payment/api/views.py
@@ -915,6 +915,7 @@ class PaymentPlanViewSet(
                 old_object=old_payment_plan,
                 new_object=payment_plan,
             )
+            payment_plan.refresh_from_db(fields=["background_action_status"])
             response_serializer = PaymentPlanDetailSerializer(payment_plan, context={"request": request})
             return Response(
                 data=response_serializer.data,

--- a/tests/unit/apps/payment/test_payment_plan_views.py
+++ b/tests/unit/apps/payment/test_payment_plan_views.py
@@ -1615,6 +1615,7 @@ class TestTargetPopulationActions:
             resp_data = response.json()
             assert "id" in resp_data
             assert "TARGETING" in resp_data["steficon_rule_targeting"]["rule"]["type"]
+            assert "STEFICON_WAIT" in resp_data["status"]
 
     def test_apply_engine_formula_tp_validation_errors(self, create_user_role_with_permissions: Any) -> None:
         create_user_role_with_permissions(
@@ -2058,6 +2059,8 @@ class TestPaymentPlanActions:
             assert response.status_code == status.HTTP_200_OK
             resp_data = response.json()
             assert "id" in resp_data
+            self.pp.refresh_from_db(fields=["background_action_status"])
+            assert self.pp.background_action_status == "RULE_ENGINE_RUN"
             assert "RULE_ENGINE_RUN" in resp_data["background_action_status"]
 
     def test_apply_engine_formula_tp_validation_errors(self, create_user_role_with_permissions: Any) -> None:


### PR DESCRIPTION
[AB#277893](https://unicef.visualstudio.com/ICTD-HCT-MIS/_workitems/edit/277893): Payment Module - PP Status does not change to formula engine run, but remains at Locked when applying EF on Payment records