### PR TITLE
303284: Add deduplication engine reference PK to Individual model and…

### DIFF
--- a/src/hope/api/endpoints/rdi/lax.py
+++ b/src/hope/api/endpoints/rdi/lax.py
@@ -348,6 +348,7 @@ class CreateLaxIndividuals(CreateLaxBaseView, PhotoMixin):
             self._programme_code,
         )
         validated_data = dict(serializer.validated_data)
+        validated_data["deduplication_engine_reference_pk"] = external_individual_id
         validated_data["flex_fields"] = populate_pdu_with_null_values(
             self._rdi_program, validated_data.get("flex_fields")
         )

--- a/src/hope/api/endpoints/rdi/lax.py
+++ b/src/hope/api/endpoints/rdi/lax.py
@@ -45,6 +45,7 @@ from hope.models import (
     FinancialInstitution,
     FlexibleAttribute,
     Grant,
+    Individual,
     IndividualRoleInHousehold,
     PendingAccount,
     PendingDocument,
@@ -136,7 +137,7 @@ class IndividualSerializer(serializers.ModelSerializer):
     accounts = AccountLaxSerializer(many=True, required=False)
     photo = serializers.CharField(allow_blank=True, required=False)
     disability_certificate_picture = serializers.CharField(allow_null=True, allow_blank=True, required=False)
-    individual_id = serializers.CharField(required=True)
+    individual_id = serializers.CharField(required=True, max_length=255, trim_whitespace=True)
     disability = DisabilityChoiceField(choices=DISABILITY_CHOICES, required=False, allow_blank=True)
     sex = serializers.ChoiceField(SEX_CHOICE, allow_blank=False, default=NOT_COLLECTED)
 
@@ -157,7 +158,26 @@ class IndividualSerializer(serializers.ModelSerializer):
             "program",
             "rdi_merge_status",
             "is_removed",
+            "deduplication_engine_reference_pk",
         ]
+
+    def validate_individual_id(self, value: str) -> str:
+        normalized_value = value.strip()
+        if not normalized_value:
+            raise serializers.ValidationError("This field may not be blank.")
+
+        program = self.context.get("program")
+        if (
+            program
+            and Individual.all_objects.filter(
+                program=program,
+                is_removed=False,
+                deduplication_engine_reference_pk=normalized_value,
+            ).exists()
+        ):
+            raise serializers.ValidationError("An individual with this individual_id already exists in this program.")
+
+        return normalized_value
 
 
 class HandleFlexFieldsMixin:
@@ -446,6 +466,7 @@ class CreateLaxIndividuals(CreateLaxBaseView, PhotoMixin):
     @atomic
     def post(self, request: Request, business_area: "BusinessArea", rdi: RegistrationDataImport) -> Response:
         individual_id_mapping = {}
+        seen_individual_ids = set()
         total_individuals = 0
         total_errors = 0
         results = []
@@ -458,9 +479,18 @@ class CreateLaxIndividuals(CreateLaxBaseView, PhotoMixin):
                 self.handle_individual_flex_fields(
                     cast("dict[Any, Any]", individual_raw_data), reserved_fields={"documents", "accounts"}
                 )
-                serializer = IndividualSerializer(data=individual_raw_data)
+                serializer = IndividualSerializer(
+                    data=individual_raw_data,
+                    context={"program": self.selected_rdi.program},
+                )
 
                 if serializer.is_valid():
+                    normalized_individual_id = serializer.validated_data["individual_id"]
+                    if normalized_individual_id in seen_individual_ids:
+                        results.append({"individual_id": ["Duplicate individual_id in request payload."]})
+                        total_errors += 1
+                        continue
+                    seen_individual_ids.add(normalized_individual_id)
                     pk = self._prepare_individual(serializer)
                     results.append({"pk": pk})
                 else:

--- a/src/hope/apps/household/migrations/0034_migration.py
+++ b/src/hope/apps/household/migrations/0034_migration.py
@@ -75,4 +75,12 @@ class Migration(migrations.Migration):
                 name="unique_for_ba_name_and_admin_area",
             ),
         ),
+        migrations.AddConstraint(
+            model_name="individual",
+            constraint=models.UniqueConstraint(
+                condition=models.Q(("is_removed", False), ("deduplication_engine_reference_pk__isnull", False)),
+                fields=("program", "deduplication_engine_reference_pk"),
+                name="dedup_ref_pk_unique_in_program",
+            ),
+        ),
     ]

--- a/src/hope/apps/household/migrations/0039_migration.py
+++ b/src/hope/apps/household/migrations/0039_migration.py
@@ -7,14 +7,17 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.AddField(
+        migrations.RemoveConstraint(
             model_name="individual",
-            name="deduplication_engine_reference_pk",
-            field=models.CharField(
-                blank=True,
-                help_text="Reference pk used for biometric deduplication engine communication [sys]",
-                max_length=255,
-                null=True,
+            name="dedup_ref_pk_unique_in_program",
+        ),
+        migrations.AddConstraint(
+            model_name="individual",
+            constraint=models.UniqueConstraint(
+                condition=models.Q(("is_removed", False), ("deduplication_engine_reference_pk__isnull", False))
+                & ~models.Q(("deduplication_engine_reference_pk", "")),
+                fields=("program", "deduplication_engine_reference_pk"),
+                name="dedup_ref_pk_unique_in_program",
             ),
         ),
     ]

--- a/src/hope/apps/household/migrations/0039_migration.py
+++ b/src/hope/apps/household/migrations/0039_migration.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("household", "0038_migration"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="individual",
+            name="deduplication_engine_reference_pk",
+            field=models.CharField(
+                blank=True,
+                help_text="Reference pk used for biometric deduplication engine communication [sys]",
+                max_length=255,
+                null=True,
+            ),
+        ),
+    ]

--- a/src/hope/apps/registration_data/api/views.py
+++ b/src/hope/apps/registration_data/api/views.py
@@ -178,6 +178,9 @@ class RegistrationDataImportViewSet(
         individuals_to_remove = list(
             Individual.all_objects.filter(registration_data_import=rdi).values_list("id", flat=True)
         )
+        individuals_to_report = list(
+            Individual.all_objects.filter(registration_data_import=rdi).only("id", "deduplication_engine_reference_pk")
+        )
         households_to_remove = list(
             Household.all_objects.filter(registration_data_import=rdi).values_list("id", flat=True)
         )
@@ -200,7 +203,7 @@ class RegistrationDataImportViewSet(
         if rdi.program.biometric_deduplication_enabled:
             BiometricDeduplicationService().report_individuals_status(
                 rdi.program,
-                [str(_id) for _id in individuals_to_remove],
+                individuals_to_report,
                 BiometricDeduplicationService.INDIVIDUALS_REFUSED,
             )
 
@@ -234,6 +237,9 @@ class RegistrationDataImportViewSet(
         individuals_to_remove = list(
             Individual.all_objects.filter(registration_data_import=rdi).values_list("id", flat=True)
         )
+        individuals_to_report = list(
+            Individual.all_objects.filter(registration_data_import=rdi).only("id", "deduplication_engine_reference_pk")
+        )
         households_to_remove = list(
             Household.all_objects.filter(registration_data_import=rdi).values_list("id", flat=True)
         )
@@ -256,7 +262,7 @@ class RegistrationDataImportViewSet(
         if rdi.program.biometric_deduplication_enabled:
             BiometricDeduplicationService().report_individuals_status(
                 rdi.program,
-                [str(_id) for _id in individuals_to_remove],
+                individuals_to_report,
                 BiometricDeduplicationService.INDIVIDUALS_REFUSED,
             )
 

--- a/src/hope/apps/registration_data/services/biometric_deduplication.py
+++ b/src/hope/apps/registration_data/services/biometric_deduplication.py
@@ -1,6 +1,6 @@
+from collections.abc import Iterable
 import logging
 from typing import cast
-from collections.abc import Iterable
 
 from django.conf import settings
 from django.db import transaction
@@ -371,12 +371,15 @@ class BiometricDeduplicationService:
                 pending_individuals = PendingIndividual.objects.filter(registration_data_import__in=rdis).only(
                     "id", "deduplication_engine_reference_pk"
                 )
-                target_reference_pks = [self._reference_pk_for_individual(individual) for individual in pending_individuals]
+                target_reference_pks = [
+                    self._reference_pk_for_individual(individual) for individual in pending_individuals
+                ]
                 all_program_individuals = Individual.all_objects.filter(program=program, is_removed=False).only(
                     "id", "deduplication_engine_reference_pk"
                 )
                 reference_to_individual_id = {
-                    self._reference_pk_for_individual(individual): str(individual.pk) for individual in all_program_individuals
+                    self._reference_pk_for_individual(individual): str(individual.pk)
+                    for individual in all_program_individuals
                 }
 
                 data = self.get_deduplication_set_results(program, target_reference_pks)

--- a/src/hope/apps/registration_data/services/biometric_deduplication.py
+++ b/src/hope/apps/registration_data/services/biometric_deduplication.py
@@ -47,6 +47,18 @@ class BiometricDeduplicationService:
     def __init__(self) -> None:
         self.api = DeduplicationEngineAPI()
 
+    @staticmethod
+    def _reference_pk_for_individual(individual: Individual | PendingIndividual) -> str:
+        return individual.deduplication_engine_reference_pk or str(individual.id)
+
+    @staticmethod
+    def _resolve_individual_id_from_reference(
+        reference_pk: str | None, reference_to_individual_id: dict[str, str]
+    ) -> str | None:
+        if reference_pk is None:
+            return None
+        return reference_to_individual_id.get(reference_pk, reference_pk)
+
     def create_deduplication_set(self, program: Program) -> None:
         notification_url = reverse(
             "api:registration-data:registration-data-imports-webhook-deduplication",
@@ -73,7 +85,7 @@ class BiometricDeduplicationService:
         individuals = (
             Individual.all_objects.filter(is_removed=False, registration_data_import=rdi)
             .exclude(Q(photo="") | Q(withdrawn=True) | Q(duplicate=True))
-            .only("id", "photo")
+            .only("id", "photo", "deduplication_engine_reference_pk")
         )
 
         if not individuals.exists():
@@ -82,7 +94,10 @@ class BiometricDeduplicationService:
             return
 
         images = [
-            DeduplicationImage(reference_pk=str(individual.id), filename=individual.photo.name)
+            DeduplicationImage(
+                reference_pk=self._reference_pk_for_individual(individual),
+                filename=individual.photo.name,
+            )
             for individual in individuals
         ]
 
@@ -358,13 +373,30 @@ class BiometricDeduplicationService:
                         "pk", flat=True
                     )
                 ]
+
+                reference_to_individual_id: dict[str, str] = {}
+                for pk, dedup_reference_pk in PendingIndividual.objects.filter(
+                    registration_data_import__in=rdis
+                ).values_list(
+                    "pk", "deduplication_engine_reference_pk"
+                ):
+                    reference_pk = dedup_reference_pk or str(pk)
+                    individual_ids.append(reference_pk)
+                    reference_to_individual_id[reference_pk] = str(pk)
+
                 data = self.get_deduplication_set_results(program, individual_ids)
                 similarity_pairs = [
                     SimilarityPair(
                         score=item["score"],
                         status_code=item["status_code"],
-                        first=item["first"]["reference_pk"] or None,
-                        second=item["second"]["reference_pk"] or None,
+                        first=self._resolve_individual_id_from_reference(
+                            (item.get("first") or {}).get("reference_pk"),
+                            reference_to_individual_id,
+                        ),
+                        second=self._resolve_individual_id_from_reference(
+                            (item.get("second") or {}).get("reference_pk"),
+                            reference_to_individual_id,
+                        ),
                     )
                     for item in data
                     if str(item["status_code"])
@@ -397,10 +429,19 @@ class BiometricDeduplicationService:
         if not bool(flag_state("BIOMETRIC_DEDUPLICATION_REPORT_INDIVIDUALS_STATUS")):  # pragma no cover
             return
 
+        id_to_reference_pk = {
+            str(individual_id): dedup_reference_pk or str(individual_id)
+            for individual_id, dedup_reference_pk in Individual.all_objects.filter(
+                program=program,
+                id__in=individual_ids,
+            ).values_list("id", "deduplication_engine_reference_pk")
+        }
+        target_reference_pks = [id_to_reference_pk.get(str(individual_id), str(individual_id)) for individual_id in individual_ids]
+
         try:
             self.api.report_individuals_status(
                 program.unicef_id,
-                {"action": action, "targets": individual_ids},
+                {"action": action, "targets": target_reference_pks},
             )
         except DeduplicationEngineAPI.DeduplicationEngineAPIError:  # pragma no cover
             logging.exception(f"RDI {action}, error while sending Individuals status to Deduplication Engine")

--- a/src/hope/apps/registration_data/services/biometric_deduplication.py
+++ b/src/hope/apps/registration_data/services/biometric_deduplication.py
@@ -372,7 +372,8 @@ class BiometricDeduplicationService:
                     "id", "deduplication_engine_reference_pk"
                 )
                 reference_to_individual_id = {
-                    self._reference_pk_for_individual(individual): str(individual.pk) for individual in pending_individuals
+                    self._reference_pk_for_individual(individual): str(individual.pk)
+                    for individual in pending_individuals
                 }
 
                 data = self.get_deduplication_set_results(program, list(reference_to_individual_id))
@@ -426,8 +427,7 @@ class BiometricDeduplicationService:
             individuals = individuals.only("id", "deduplication_engine_reference_pk")
 
         id_to_reference_pk = {
-            str(individual.pk): self._reference_pk_for_individual(individual)
-            for individual in individuals
+            str(individual.pk): self._reference_pk_for_individual(individual) for individual in individuals
         }
         target_reference_pks = list(id_to_reference_pk.values())
 

--- a/src/hope/apps/registration_data/services/biometric_deduplication.py
+++ b/src/hope/apps/registration_data/services/biometric_deduplication.py
@@ -371,12 +371,15 @@ class BiometricDeduplicationService:
                 pending_individuals = PendingIndividual.objects.filter(registration_data_import__in=rdis).only(
                     "id", "deduplication_engine_reference_pk"
                 )
+                target_reference_pks = [self._reference_pk_for_individual(individual) for individual in pending_individuals]
+                all_program_individuals = Individual.all_objects.filter(program=program, is_removed=False).only(
+                    "id", "deduplication_engine_reference_pk"
+                )
                 reference_to_individual_id = {
-                    self._reference_pk_for_individual(individual): str(individual.pk)
-                    for individual in pending_individuals
+                    self._reference_pk_for_individual(individual): str(individual.pk) for individual in all_program_individuals
                 }
 
-                data = self.get_deduplication_set_results(program, list(reference_to_individual_id))
+                data = self.get_deduplication_set_results(program, target_reference_pks)
                 similarity_pairs = [
                     SimilarityPair(
                         score=item["score"],

--- a/src/hope/apps/registration_data/services/biometric_deduplication.py
+++ b/src/hope/apps/registration_data/services/biometric_deduplication.py
@@ -1,5 +1,6 @@
 import logging
 from typing import cast
+from collections.abc import Iterable
 
 from django.conf import settings
 from django.db import transaction
@@ -367,24 +368,14 @@ class BiometricDeduplicationService:
 
         if deduplication_set_data.state == self.DEDUP_STATE_READY:
             try:
-                individual_ids = [
-                    str(pk)
-                    for pk in PendingIndividual.objects.filter(registration_data_import__in=rdis).values_list(
-                        "pk", flat=True
-                    )
-                ]
+                pending_individuals = PendingIndividual.objects.filter(registration_data_import__in=rdis).only(
+                    "id", "deduplication_engine_reference_pk"
+                )
+                reference_to_individual_id = {
+                    self._reference_pk_for_individual(individual): str(individual.pk) for individual in pending_individuals
+                }
 
-                reference_to_individual_id: dict[str, str] = {}
-                for pk, dedup_reference_pk in PendingIndividual.objects.filter(
-                    registration_data_import__in=rdis
-                ).values_list(
-                    "pk", "deduplication_engine_reference_pk"
-                ):
-                    reference_pk = dedup_reference_pk or str(pk)
-                    individual_ids.append(reference_pk)
-                    reference_to_individual_id[reference_pk] = str(pk)
-
-                data = self.get_deduplication_set_results(program, individual_ids)
+                data = self.get_deduplication_set_results(program, list(reference_to_individual_id))
                 similarity_pairs = [
                     SimilarityPair(
                         score=item["score"],
@@ -425,18 +416,20 @@ class BiometricDeduplicationService:
         false_positive_pair = IgnoredFilenamesPair(first=individual1_photo, second=individual2_photo)
         self.api.report_false_positive_duplicate(false_positive_pair, program.unicef_id)
 
-    def report_individuals_status(self, program: Program, individual_ids: list[str], action: str) -> None:
+    def report_individuals_status(
+        self, program: Program, individuals: QuerySet[Individual] | Iterable[Individual], action: str
+    ) -> None:
         if not bool(flag_state("BIOMETRIC_DEDUPLICATION_REPORT_INDIVIDUALS_STATUS")):  # pragma no cover
             return
 
+        if isinstance(individuals, QuerySet):
+            individuals = individuals.only("id", "deduplication_engine_reference_pk")
+
         id_to_reference_pk = {
-            str(individual_id): dedup_reference_pk or str(individual_id)
-            for individual_id, dedup_reference_pk in Individual.all_objects.filter(
-                program=program,
-                id__in=individual_ids,
-            ).values_list("id", "deduplication_engine_reference_pk")
+            str(individual.pk): self._reference_pk_for_individual(individual)
+            for individual in individuals
         }
-        target_reference_pks = [id_to_reference_pk.get(str(individual_id), str(individual_id)) for individual_id in individual_ids]
+        target_reference_pks = list(id_to_reference_pk.values())
 
         try:
             self.api.report_individuals_status(

--- a/src/hope/apps/registration_data/tasks/rdi_merge.py
+++ b/src/hope/apps/registration_data/tasks/rdi_merge.py
@@ -111,9 +111,13 @@ class RdiMergeTask:
             dedupe_service = BiometricDeduplicationService()
             dedupe_service.create_grievance_tickets_for_duplicates(obj_hct)
             dedupe_service.update_rdis_deduplication_statistics(obj_hct.program, exclude_rdi=obj_hct)
+            individuals_to_report = Individual.all_objects.filter(
+                program=obj_hct.program,
+                id__in=individuals_to_merge_ids,
+            )
             dedupe_service.report_individuals_status(
                 obj_hct.program,
-                [str(_id) for _id in individuals_to_merge_ids],
+                individuals_to_report,
                 BiometricDeduplicationService.INDIVIDUALS_MERGED,
             )
 

--- a/src/hope/models/individual.py
+++ b/src/hope/models/individual.py
@@ -603,6 +603,11 @@ class Individual(
                 condition=Q(is_removed=False) & Q(originating_id__isnull=False),
                 name="originating_id_ind_unique_constraint",
             ),
+            UniqueConstraint(
+                fields=["program", "deduplication_engine_reference_pk"],
+                condition=Q(is_removed=False) & Q(deduplication_engine_reference_pk__isnull=False),
+                name="dedup_ref_pk_unique_in_program",
+            ),
         ]
         permissions = (("update_individual_iban", "Can update individual IBAN"),)
 

--- a/src/hope/models/individual.py
+++ b/src/hope/models/individual.py
@@ -605,7 +605,9 @@ class Individual(
             ),
             UniqueConstraint(
                 fields=["program", "deduplication_engine_reference_pk"],
-                condition=Q(is_removed=False) & Q(deduplication_engine_reference_pk__isnull=False),
+                condition=Q(is_removed=False)
+                & Q(deduplication_engine_reference_pk__isnull=False)
+                & ~Q(deduplication_engine_reference_pk=""),
                 name="dedup_ref_pk_unique_in_program",
             ),
         ]

--- a/src/hope/models/individual.py
+++ b/src/hope/models/individual.py
@@ -135,6 +135,7 @@ class Individual(
             "who_answers_alt_phone",
             "detail_id",
             "program_registration_id",
+            "deduplication_engine_reference_pk",
             "payment_delivery_phone_no",
         ]
     )
@@ -401,6 +402,12 @@ class Individual(
         verbose_name=_("Beneficiary Program Registration Id"),
         help_text="Beneficiary Program Registration ID [sys]",
         db_collation="und-ci-det",
+    )
+    deduplication_engine_reference_pk = models.CharField(
+        max_length=255,
+        blank=True,
+        null=True,
+        help_text="Reference pk used for biometric deduplication engine communication [sys]",
     )
     age_at_registration = models.PositiveSmallIntegerField(null=True, blank=True, help_text="Age at registration [sys]")
     origin_unicef_id = models.CharField(max_length=100, blank=True, null=True, help_text="Original unicef_id [sys]")

--- a/tests/unit/api/test_lax_individuals.py
+++ b/tests/unit/api/test_lax_individuals.py
@@ -144,13 +144,14 @@ def test_create_single_individual_success(lax_api_client, lax_push_url, document
     assert response.data["errors"] == 0
     assert "IND001" in response.data["individual_id_mapping"]
 
-    individual = PendingIndividual.objects.get(unicef_id=list(response.data["individual_id_mapping"].values())[0])
-    assert individual.full_name == "John Doe"
-    assert individual.given_name == "John"
-    assert individual.family_name == "Doe"
-    assert individual.observed_disability == ["NONE"]
-    assert individual.marital_status == "SINGLE"
-    assert individual.originating_id == "AUR#123#123"
+        individual = PendingIndividual.objects.get(unicef_id=list(response.data["individual_id_mapping"].values())[0])
+        assert individual.full_name == "John Doe"
+        assert individual.given_name == "John"
+        assert individual.family_name == "Doe"
+        assert individual.observed_disability == ["NONE"]
+        assert individual.marital_status == "SINGLE"
+        assert individual.originating_id == "AUR#123#123"
+        assert individual.deduplication_engine_reference_pk == "IND001"
 
 
 def test_create_single_individual_account_with_explicit_fi(

--- a/tests/unit/api/test_lax_individuals.py
+++ b/tests/unit/api/test_lax_individuals.py
@@ -144,14 +144,14 @@ def test_create_single_individual_success(lax_api_client, lax_push_url, document
     assert response.data["errors"] == 0
     assert "IND001" in response.data["individual_id_mapping"]
 
-        individual = PendingIndividual.objects.get(unicef_id=list(response.data["individual_id_mapping"].values())[0])
-        assert individual.full_name == "John Doe"
-        assert individual.given_name == "John"
-        assert individual.family_name == "Doe"
-        assert individual.observed_disability == ["NONE"]
-        assert individual.marital_status == "SINGLE"
-        assert individual.originating_id == "AUR#123#123"
-        assert individual.deduplication_engine_reference_pk == "IND001"
+    individual = PendingIndividual.objects.get(unicef_id=list(response.data["individual_id_mapping"].values())[0])
+    assert individual.full_name == "John Doe"
+    assert individual.given_name == "John"
+    assert individual.family_name == "Doe"
+    assert individual.observed_disability == ["NONE"]
+    assert individual.marital_status == "SINGLE"
+    assert individual.originating_id == "AUR#123#123"
+    assert individual.deduplication_engine_reference_pk == "IND001"
 
 
 def test_create_single_individual_account_with_explicit_fi(

--- a/tests/unit/apps/registration_data/test_biometric_deduplication_service.py
+++ b/tests/unit/apps/registration_data/test_biometric_deduplication_service.py
@@ -1219,3 +1219,25 @@ def test_report_withdrawn_uses_deduplication_engine_reference_pk(
         program.unicef_id,
         {"action": "refused", "targets": ["EXT-IND-999"]},
     )
+
+
+@patch("hope.apps.registration_data.api.deduplication_engine.DeduplicationEngineAPI.report_individuals_status")
+def test_report_withdrawn_with_iterable_uses_deduplication_engine_reference_pk(
+    mock_report_withdrawn: mock.Mock, biometric_deduplication_context: dict[str, object]
+) -> None:
+    program = biometric_deduplication_context["program"]
+    individual = IndividualFactory(
+        program=program,
+        business_area=program.business_area,
+        deduplication_engine_reference_pk="EXT-IND-123",
+    )
+    service = BiometricDeduplicationService()
+    service.report_individuals_status(
+        program,
+        [individual],
+        "refused",
+    )
+    mock_report_withdrawn.assert_called_once_with(
+        program.unicef_id,
+        {"action": "refused", "targets": ["EXT-IND-123"]},
+    )

--- a/tests/unit/apps/registration_data/test_biometric_deduplication_service.py
+++ b/tests/unit/apps/registration_data/test_biometric_deduplication_service.py
@@ -804,6 +804,72 @@ def test_fetch_biometric_deduplication_results_maps_reference_pk_to_internal_id(
     )
 
 
+def test_fetch_biometric_deduplication_results_maps_reference_pk_to_merged_and_pending_individuals(
+    biometric_deduplication_context: dict[str, object],
+) -> None:
+    program = biometric_deduplication_context["program"]
+    user = biometric_deduplication_context["user"]
+    merged_rdi = RegistrationDataImportFactory(
+        status=RegistrationDataImport.IN_REVIEW,
+        program=program,
+        business_area=program.business_area,
+        imported_by=user,
+        deduplication_engine_status=RegistrationDataImport.DEDUP_ENGINE_FINISHED,
+    )
+    in_progress_rdi = RegistrationDataImportFactory(
+        status=RegistrationDataImport.IN_REVIEW,
+        program=program,
+        business_area=program.business_area,
+        imported_by=user,
+        deduplication_engine_status=RegistrationDataImport.DEDUP_ENGINE_IN_PROGRESS,
+    )
+    merged_individual = IndividualFactory(
+        registration_data_import=merged_rdi,
+        program=program,
+        business_area=program.business_area,
+        deduplication_engine_reference_pk="EXT-JAN",
+        rdi_merge_status=MergeStatusModel.MERGED,
+    )
+    pending_individual = PendingIndividualFactory(
+        registration_data_import=in_progress_rdi,
+        program=program,
+        business_area=program.business_area,
+        deduplication_engine_reference_pk="EXT-JAN2",
+    )
+
+    service = BiometricDeduplicationService()
+    service.get_deduplication_set = mock.Mock(return_value=DeduplicationSetData(state="Ready"))
+    service.get_deduplication_set_results = mock.Mock(
+        return_value=[
+            {
+                "first": {"reference_pk": "EXT-JAN"},
+                "second": {"reference_pk": "EXT-JAN2"},
+                "score": 0.91,
+                "status_code": "200",
+            }
+        ]
+    )
+    service.store_similarity_pairs = mock.Mock()
+    service.store_rdis_deduplication_statistics = mock.Mock()
+    service.mark_rdis_as_deduplicated = mock.Mock()
+
+    service.fetch_biometric_deduplication_results_and_process(program)
+
+    service.get_deduplication_set.assert_called_once_with(program)
+    assert service.get_deduplication_set_results.call_args.args[1] == ["EXT-JAN2"]
+    service.store_similarity_pairs.assert_called_once_with(
+        program,
+        [
+            SimilarityPair(
+                score=0.91,
+                status_code="200",
+                first=str(merged_individual.id),
+                second=str(pending_individual.id),
+            )
+        ],
+    )
+
+
 def test_fetch_biometric_deduplication_results_and_process_error(
     biometric_deduplication_context: dict[str, object],
 ) -> None:

--- a/tests/unit/apps/registration_data/test_biometric_deduplication_service.py
+++ b/tests/unit/apps/registration_data/test_biometric_deduplication_service.py
@@ -1154,11 +1154,19 @@ def test_report_false_positive_duplicate(
 @patch("hope.apps.registration_data.api.deduplication_engine.DeduplicationEngineAPI.report_individuals_status")
 def test_report_withdrawn(mock_report_withdrawn: mock.Mock, biometric_deduplication_context: dict[str, object]) -> None:
     program = biometric_deduplication_context["program"]
+    individual = IndividualFactory(
+        program=program,
+        business_area=program.business_area,
+    )
     service = BiometricDeduplicationService()
-    service.report_individuals_status(program, ["abc"], "refused")
+    service.report_individuals_status(
+        program,
+        Individual.all_objects.filter(id=individual.id),
+        "refused",
+    )
     mock_report_withdrawn.assert_called_once_with(
         program.unicef_id,
-        {"action": "refused", "targets": ["abc"]},
+        {"action": "refused", "targets": [str(individual.id)]},
     )
 
 
@@ -1201,7 +1209,11 @@ def test_report_withdrawn_uses_deduplication_engine_reference_pk(
         deduplication_engine_reference_pk="EXT-IND-999",
     )
     service = BiometricDeduplicationService()
-    service.report_individuals_status(program, [str(individual.id)], "refused")
+    service.report_individuals_status(
+        program,
+        Individual.all_objects.filter(id=individual.id),
+        "refused",
+    )
     mock_report_withdrawn.assert_called_once_with(
         program.unicef_id,
         {"action": "refused", "targets": ["EXT-IND-999"]},

--- a/tests/unit/apps/registration_data/test_biometric_deduplication_service.py
+++ b/tests/unit/apps/registration_data/test_biometric_deduplication_service.py
@@ -150,6 +150,35 @@ def test_upload_individuals_success(
 
 
 @patch("hope.apps.registration_data.api.deduplication_engine.DeduplicationEngineAPI.bulk_upload_images")
+def test_upload_individuals_uses_deduplication_engine_reference_pk(
+    mock_bulk_upload_images: mock.Mock, biometric_deduplication_context: dict[str, object]
+) -> None:
+    program = biometric_deduplication_context["program"]
+    user = biometric_deduplication_context["user"]
+    rdi = RegistrationDataImportFactory(
+        program=program,
+        business_area=program.business_area,
+        imported_by=user,
+        deduplication_engine_status=RegistrationDataImport.DEDUP_ENGINE_PENDING,
+    )
+    IndividualFactory(
+        registration_data_import=rdi,
+        program=program,
+        business_area=program.business_area,
+        photo="some_photo.jpg",
+        deduplication_engine_reference_pk="EXT-IND-123",
+    )
+
+    service = BiometricDeduplicationService()
+    service.upload_individuals(program, rdi)
+
+    mock_bulk_upload_images.assert_called_once_with(
+        program.unicef_id,
+        [DeduplicationImage(reference_pk="EXT-IND-123", filename="some_photo.jpg")],
+    )
+
+
+@patch("hope.apps.registration_data.api.deduplication_engine.DeduplicationEngineAPI.bulk_upload_images")
 def test_upload_individuals_failure(
     mock_bulk_upload_images: mock.Mock, biometric_deduplication_context: dict[str, object]
 ) -> None:
@@ -703,22 +732,29 @@ def test_fetch_biometric_deduplication_results_and_process_success(
     )
 
 
-def test_fetch_biometric_deduplication_results_and_process_for_rdi_success(
+def test_fetch_biometric_deduplication_results_maps_reference_pk_to_internal_id(
     biometric_deduplication_context: dict[str, object],
 ) -> None:
     program = biometric_deduplication_context["program"]
     user = biometric_deduplication_context["user"]
     rdi = RegistrationDataImportFactory(
+        status=RegistrationDataImport.IN_REVIEW,
         program=program,
         business_area=program.business_area,
         imported_by=user,
-        status=RegistrationDataImport.IN_REVIEW,
-        deduplication_engine_status=RegistrationDataImport.DEDUP_ENGINE_PROCESSING,
+        deduplication_engine_status=RegistrationDataImport.DEDUP_ENGINE_IN_PROGRESS,
     )
-    individual = PendingIndividualFactory(
+    pending_1 = PendingIndividualFactory(
+        registration_data_import=rdi,
         program=program,
         business_area=program.business_area,
+        deduplication_engine_reference_pk="EXT-1",
+    )
+    pending_2 = PendingIndividualFactory(
         registration_data_import=rdi,
+        program=program,
+        business_area=program.business_area,
+        deduplication_engine_reference_pk="EXT-2",
     )
 
     service = BiometricDeduplicationService()
@@ -726,10 +762,10 @@ def test_fetch_biometric_deduplication_results_and_process_for_rdi_success(
     service.get_deduplication_set_results = mock.Mock(
         return_value=[
             {
-                "first": {"reference_pk": str(individual.id)},
-                "second": {"reference_pk": None},
-                "score": 0.0,
-                "status_code": "412",
+                "first": {"reference_pk": "EXT-1"},
+                "second": {"reference_pk": "EXT-2"},
+                "score": 0.91,
+                "status_code": "200",
             }
         ]
     )
@@ -740,8 +776,12 @@ def test_fetch_biometric_deduplication_results_and_process_for_rdi_success(
     service.fetch_biometric_deduplication_results_and_process(program, rdi)
 
     service.get_deduplication_set.assert_called_once_with(program)
-    service.get_deduplication_set_results.assert_called_once_with(program, [str(individual.id)])
-    expected_rdis = RegistrationDataImport.objects.filter(id=rdi.id)
+    sent_refs = service.get_deduplication_set_results.call_args.args[1]
+    assert "EXT-1" in sent_refs
+    assert "EXT-2" in sent_refs
+    expected_rdis = RegistrationDataImport.objects.filter(
+        id=rdi.id,
+    )
     service.store_rdis_deduplication_statistics.assert_called_once()
     assert set(service.store_rdis_deduplication_statistics.call_args.args[0].values_list("id", flat=True)) == set(
         expected_rdis.values_list("id", flat=True)
@@ -754,10 +794,10 @@ def test_fetch_biometric_deduplication_results_and_process_for_rdi_success(
         program,
         [
             SimilarityPair(
-                score=0.0,
-                status_code="412",
-                first=str(individual.id),
-                second=None,
+                score=0.91,
+                status_code="200",
+                first=str(pending_1.id),
+                second=str(pending_2.id),
             )
         ],
     )
@@ -1148,3 +1188,21 @@ def test_mark_rdis_as_pending_invalidates_cache(biometric_deduplication_context:
 
     new_version = get_or_create_cache_key(version_key, 0)
     assert new_version > initial_version
+
+
+@patch("hope.apps.registration_data.api.deduplication_engine.DeduplicationEngineAPI.report_individuals_status")
+def test_report_withdrawn_uses_deduplication_engine_reference_pk(
+    mock_report_withdrawn: mock.Mock, biometric_deduplication_context: dict[str, object]
+) -> None:
+    program = biometric_deduplication_context["program"]
+    individual = IndividualFactory(
+        program=program,
+        business_area=program.business_area,
+        deduplication_engine_reference_pk="EXT-IND-999",
+    )
+    service = BiometricDeduplicationService()
+    service.report_individuals_status(program, [str(individual.id)], "refused")
+    mock_report_withdrawn.assert_called_once_with(
+        program.unicef_id,
+        {"action": "refused", "targets": ["EXT-IND-999"]},
+    )

--- a/tests/unit/apps/registration_data/test_biometric_deduplication_service.py
+++ b/tests/unit/apps/registration_data/test_biometric_deduplication_service.py
@@ -27,6 +27,7 @@ from hope.apps.registration_data.api.deduplication_engine import (
 )
 from hope.apps.registration_data.services.biometric_deduplication import BiometricDeduplicationService
 from hope.models import DeduplicationEngineSimilarityPair, RegistrationDataImport
+from hope.models.individual import Individual
 from hope.models.utils import MergeStatusModel
 
 pytestmark = pytest.mark.django_db

--- a/tests/unit/apps/registration_data/test_rdi_merge.py
+++ b/tests/unit/apps/registration_data/test_rdi_merge.py
@@ -599,7 +599,7 @@ def test_merge_biometric_deduplication_enabled(
 
     args, _ = report_individuals_status_mock.call_args
     assert args[0] == program
-    assert set(args[1]) == {
+    assert {str(ind.pk) for ind in args[1]} == {
         str(_id) for _id in Individual.objects.filter(registration_data_import=rdi).values_list("id", flat=True)
     }
     assert args[2] == "merged"

--- a/tests/unit/apps/registration_data/test_rdi_merge_helpers.py
+++ b/tests/unit/apps/registration_data/test_rdi_merge_helpers.py
@@ -7,6 +7,7 @@ import pytest
 from extras.test_utils.factories import (
     BusinessAreaFactory,
     HouseholdFactory,
+    IndividualFactory,
     PendingDocumentFactory,
     PendingHouseholdFactory,
     PendingIndividualFactory,
@@ -216,6 +217,7 @@ def test_run_deduplication_calls_dedup_and_creates_tickets(
 @pytest.fixture
 def pending_household_with_kobo(rdi: RegistrationDataImport) -> PendingHousehold:
     import datetime
+    import uuid
 
     return PendingHouseholdFactory(
         registration_data_import=rdi,

--- a/tests/unit/apps/registration_data/test_rdi_merge_helpers.py
+++ b/tests/unit/apps/registration_data/test_rdi_merge_helpers.py
@@ -1,7 +1,6 @@
 """Tests for RdiMergeTask extracted helpers."""
 
 from unittest.mock import MagicMock, patch
-import uuid
 
 import pytest
 
@@ -156,7 +155,11 @@ def test_run_biometric_deduplication_enabled_calls_all_service_methods(
     rdi.program.biometric_deduplication_enabled = True
     rdi.program.save(update_fields=["biometric_deduplication_enabled"])
 
-    individual_ids = [uuid.uuid4(), uuid.uuid4()]
+    individuals = [
+        IndividualFactory(program=rdi.program, business_area=rdi.business_area, registration_data_import=rdi),
+        IndividualFactory(program=rdi.program, business_area=rdi.business_area, registration_data_import=rdi),
+    ]
+    individual_ids = [individual.id for individual in individuals]
 
     task = RdiMergeTask()
     with patch("hope.apps.registration_data.tasks.rdi_merge.BiometricDeduplicationService") as mock_service_cls:
@@ -165,11 +168,11 @@ def test_run_biometric_deduplication_enabled_calls_all_service_methods(
 
     mock_service_instance.create_grievance_tickets_for_duplicates.assert_called_once_with(rdi)
     mock_service_instance.update_rdis_deduplication_statistics.assert_called_once_with(rdi.program, exclude_rdi=rdi)
-    mock_service_instance.report_individuals_status.assert_called_once_with(
-        rdi.program,
-        [str(_id) for _id in individual_ids],
-        mock_service_cls.INDIVIDUALS_MERGED,
-    )
+    mock_service_instance.report_individuals_status.assert_called_once()
+    report_call_args = mock_service_instance.report_individuals_status.call_args[0]
+    assert report_call_args[0] == rdi.program
+    assert {str(ind.pk) for ind in report_call_args[1]} == {str(_id) for _id in individual_ids}
+    assert report_call_args[2] == mock_service_cls.INDIVIDUALS_MERGED
 
 
 # --- _run_deduplication ---

--- a/tests/unit/apps/registration_data/test_views_registration_data_import_actions.py
+++ b/tests/unit/apps/registration_data/test_views_registration_data_import_actions.py
@@ -353,7 +353,7 @@ def test_erase_rdi(
     mock_service.report_individuals_status.assert_called_once()
     report_call_args = mock_service.report_individuals_status.call_args[0]
     assert report_call_args[0] == program
-    assert set(report_call_args[1]) == {str(_id) for _id in individual_ids}  # Order doesn't matter
+    assert {str(ind.pk) for ind in report_call_args[1]} == {str(_id) for _id in individual_ids}  # Order doesn't matter
     assert report_call_args[2] == mock_biometric_service.INDIVIDUALS_REFUSED
 
 
@@ -487,9 +487,11 @@ def test_refuse_rdi(
 
     mock_biometric_service.assert_called_once()
     mock_service_instance = mock_biometric_service.return_value
-    mock_service_instance.report_individuals_status.assert_called_once_with(
-        rdi.program, [str(_id) for _id in individuals_ids_to_remove], "rejected"
-    )
+    mock_service_instance.report_individuals_status.assert_called_once()
+    report_call_args = mock_service_instance.report_individuals_status.call_args[0]
+    assert report_call_args[0] == rdi.program
+    assert {str(ind.pk) for ind in report_call_args[1]} == {str(_id) for _id in individuals_ids_to_remove}
+    assert report_call_args[2] == "rejected"
     assert remove_elasticsearch_documents_by_matching_ids_moc.call_count == 2
     remove_elasticsearch_documents_by_matching_ids_moc.assert_any_call(individuals_ids_to_remove, ANY)
 


### PR DESCRIPTION
… related services

- Introduced a new field `deduplication_engine_reference_pk` in the Individual model to facilitate communication with the biometric deduplication engine.
- Updated the CreateLaxIndividuals endpoint to include this reference in the validated data.
- Enhanced the BiometricDeduplicationService to utilize the new reference PK for individual identification during deduplication processes.
- Added tests to ensure the correct usage of the deduplication reference PK in various service methods and endpoints.