### PR TITLE
[AB#290132]-set up document type to empty in initial household filter

### DIFF
--- a/src/frontend/src/components/accountability/Communication/LookUpsCommunication/LookUpSelectionCommunication.tsx
+++ b/src/frontend/src/components/accountability/Communication/LookUpsCommunication/LookUpSelectionCommunication.tsx
@@ -88,7 +88,7 @@ export function LookUpSelectionCommunication({
 
   const initialFilterHH = {
     search: '',
-    documentType: choicesData?.documentTypeChoices?.[0]?.value,
+    documentType: '',
     documentNumber: '',
     residenceStatus: '',
     admin2: '',

--- a/src/frontend/src/containers/pages/grievances/GrievancesTablePage.tsx
+++ b/src/frontend/src/containers/pages/grievances/GrievancesTablePage.tsx
@@ -44,7 +44,7 @@ export const GrievancesTablePage = (): ReactElement => {
 
   const initialFilter = {
     search: '',
-    documentType: choicesData?.documentTypeChoices?.[0]?.value,
+    documentType: '',
     documentNumber: '',
     status: '',
     fsp: '',

--- a/src/frontend/src/containers/pages/people/PeoplePage.tsx
+++ b/src/frontend/src/containers/pages/people/PeoplePage.tsx
@@ -47,7 +47,7 @@ const PeoplePage = (): ReactElement => {
 
   const initialFilter = {
     search: '',
-    documentType: householdChoicesData?.documentTypeChoices?.[0].value,
+    documentType: '',
     documentNumber: '',
     admin1: '',
     admin2: '',

--- a/src/frontend/src/containers/pages/population/PopulationHouseholdPage.tsx
+++ b/src/frontend/src/containers/pages/population/PopulationHouseholdPage.tsx
@@ -34,7 +34,7 @@ function PopulationHouseholdPage(): ReactElement {
 
   const initialFilter = {
     search: '',
-    documentType: choicesData?.documentTypeChoices?.[0]?.value,
+    documentType: '',
     documentNumber: '',
     residenceStatus: '',
     admin1: '',


### PR DESCRIPTION
[AB#290132](https://unicef.visualstudio.com/ICTD-HCT-MIS/_workitems/edit/290132)

It's better to set doc type filter's value to empty initially instead of using the value from choices, because sometimes there will be a race condition where the value is set in an unpredictable way.