### PR TITLE
fix: exclusion by individual IDs not working in social worker programs

### DIFF
--- a/src/hope/apps/targeting/services/targeting_service.py
+++ b/src/hope/apps/targeting/services/targeting_service.py
@@ -39,8 +39,7 @@ class TargetingCriteriaQueryingBase:
         return " OR ".join(rules_string).strip()
 
     def get_basic_query(self) -> Q:
-        key_filter = "unicef_id__in" if not self.is_social_worker_program else "individuals__unicef_id__in"
-        return Q(withdrawn=False) & ~Q(**{key_filter: self.excluded_household_ids_targeting_level})
+        return Q(withdrawn=False) & ~Q(unicef_id__in=self.excluded_household_ids_targeting_level)
 
     def apply_targeting_criteria_exclusion_flags(self) -> Q:
         return self.apply_flag_exclude_if_active_adjudication_ticket() & self.apply_flag_exclude_if_on_sanction_list()

--- a/tests/unit/apps/payment/test_payment_plan_services.py
+++ b/tests/unit/apps/payment/test_payment_plan_services.py
@@ -392,7 +392,7 @@ def test_create(
     assert pp.total_individuals_count == 0
     assert pp.payment_items.count() == 0
 
-    with django_assert_num_queries(86):
+    with django_assert_num_queries(85):
         prepare_payment_plan_task.delay(str(pp.id))
 
     pp.refresh_from_db()
@@ -914,7 +914,7 @@ def test_full_rebuild(
     assert pp.total_individuals_count == 0
     assert pp.payment_items.count() == 0
 
-    with django_assert_num_queries(70):
+    with django_assert_num_queries(69):
         prepare_payment_plan_task.delay(str(pp.id))
 
     pp.refresh_from_db()

--- a/tests/unit/apps/targeting/test_individual_block_filters.py
+++ b/tests/unit/apps/targeting/test_individual_block_filters.py
@@ -338,6 +338,43 @@ def test_exclude_by_ids(user, program_cycle, program, households_individuals):
     assert payment_plan.is_social_worker_program
     basic_query_2 = payment_plan.get_basic_query()
     assert (
-        str(basic_query_2) == f"(AND: ('withdrawn', False), (NOT (AND: ('individuals__unicef_id__in', "
+        str(basic_query_2) == f"(AND: ('withdrawn', False), (NOT (AND: ('unicef_id__in', "
         f"['{households_individuals['hh1'].unicef_id}', '{households_individuals['hh2'].unicef_id}']))))"
     )
+
+
+def test_exclude_by_individual_ids_social_worker_program(user, program_cycle, program, households_individuals):
+    """Regression: excluding individual IDs in social worker programs must actually exclude their households."""
+    program.data_collecting_type.type = DataCollectingType.Type.SOCIAL
+    program.data_collecting_type.save()
+
+    ind1 = households_individuals["ind1"]
+    ind2 = households_individuals["ind2"]
+    hh1 = households_individuals["hh1"]
+    hh2 = households_individuals["hh2"]
+
+    payment_plan = PaymentPlanFactory(
+        program_cycle=program_cycle,
+        created_by=user,
+        business_area=program.business_area,
+    )
+
+    # Verify baseline: both households appear in household_list before exclusion
+    assert hh1 in payment_plan.household_list
+    assert hh2 in payment_plan.household_list
+
+    # Exclude single individual by unicef_id
+    payment_plan.excluded_ids = ind1.unicef_id
+    payment_plan.save()
+    payment_plan.refresh_from_db()
+
+    assert hh1 not in payment_plan.household_list
+    assert hh2 in payment_plan.household_list
+
+    # Exclude multiple individuals by unicef_id
+    payment_plan.excluded_ids = f"{ind1.unicef_id},{ind2.unicef_id}"
+    payment_plan.save()
+    payment_plan.refresh_from_db()
+
+    assert hh1 not in payment_plan.household_list
+    assert hh2 not in payment_plan.household_list


### PR DESCRIPTION
[AB#308529](https://unicef.visualstudio.com/ICTD-HCT-MIS/_workitems/edit/308529): Excluded Target Population Entries are still reflected in Payment Plan