### PR TITLE
TP Lock: not allow to lock if `build status not OK`

### DIFF
--- a/src/hope/apps/payment/services/payment_plan_services.py
+++ b/src/hope/apps/payment/services/payment_plan_services.py
@@ -182,6 +182,12 @@ class PaymentPlanService:
         return self.payment_plan
 
     def tp_lock(self) -> PaymentPlan:
+        if self.payment_plan.build_status in [
+            PaymentPlan.BuildStatus.BUILD_STATUS_BUILDING,
+            PaymentPlan.BuildStatus.BUILD_STATUS_PENDING,
+            PaymentPlan.BuildStatus.BUILD_STATUS_FAILED,
+        ]:
+            raise ValidationError(f"Can't Lock within Build Status {self.payment_plan.build_status}")
         flow = PaymentPlanFlow(self.payment_plan)
         flow.status_tp_lock()
         self.payment_plan.save(update_fields=("status", "status_date", "updated_at"))

--- a/src/hope/apps/payment/services/payment_plan_services.py
+++ b/src/hope/apps/payment/services/payment_plan_services.py
@@ -183,7 +183,7 @@ class PaymentPlanService:
 
     def tp_lock(self) -> PaymentPlan:
         if self.payment_plan.build_status != PaymentPlan.BuildStatus.BUILD_STATUS_OK:
-            raise ValidationError("Can be Locked within Build Status Ok")
+            raise ValidationError("Can only be locked when Build Status OK")
         flow = PaymentPlanFlow(self.payment_plan)
         flow.status_tp_lock()
         self.payment_plan.save(update_fields=("status", "status_date", "updated_at"))

--- a/src/hope/apps/payment/services/payment_plan_services.py
+++ b/src/hope/apps/payment/services/payment_plan_services.py
@@ -182,12 +182,8 @@ class PaymentPlanService:
         return self.payment_plan
 
     def tp_lock(self) -> PaymentPlan:
-        if self.payment_plan.build_status in [
-            PaymentPlan.BuildStatus.BUILD_STATUS_BUILDING,
-            PaymentPlan.BuildStatus.BUILD_STATUS_PENDING,
-            PaymentPlan.BuildStatus.BUILD_STATUS_FAILED,
-        ]:
-            raise ValidationError(f"Can't Lock within Build Status {self.payment_plan.build_status}")
+        if self.payment_plan.build_status != PaymentPlan.BuildStatus.BUILD_STATUS_OK:
+            raise ValidationError(f"Can be Locked within Build Status Ok")
         flow = PaymentPlanFlow(self.payment_plan)
         flow.status_tp_lock()
         self.payment_plan.save(update_fields=("status", "status_date", "updated_at"))

--- a/src/hope/apps/payment/services/payment_plan_services.py
+++ b/src/hope/apps/payment/services/payment_plan_services.py
@@ -183,7 +183,7 @@ class PaymentPlanService:
 
     def tp_lock(self) -> PaymentPlan:
         if self.payment_plan.build_status != PaymentPlan.BuildStatus.BUILD_STATUS_OK:
-            raise ValidationError(f"Can be Locked within Build Status Ok")
+            raise ValidationError("Can be Locked within Build Status Ok")
         flow = PaymentPlanFlow(self.payment_plan)
         flow.status_tp_lock()
         self.payment_plan.save(update_fields=("status", "status_date", "updated_at"))

--- a/tests/unit/apps/payment/test_payment_plan_services.py
+++ b/tests/unit/apps/payment/test_payment_plan_services.py
@@ -994,7 +994,7 @@ def test_tp_lock_invalid_build_status(user: User, business_area: Any, cycle: Pro
     )
     with pytest.raises(ValidationError) as error:
         PaymentPlanService(payment_plan).tp_lock()
-    assert error.value.detail[0] == "Can be Locked within Build Status Ok"
+    assert error.value.detail[0] == "Can only be locked when Build Status OK"
 
 
 def test_tp_unlock(user: User, business_area: Any, cycle: ProgramCycle) -> None:

--- a/tests/unit/apps/payment/test_payment_plan_services.py
+++ b/tests/unit/apps/payment/test_payment_plan_services.py
@@ -977,6 +977,7 @@ def test_tp_lock_invalid_pp_status(user: User, business_area: Any, cycle: Progra
         created_by=user,
         business_area=business_area,
         status=PaymentPlan.Status.DRAFT,
+        build_status=PaymentPlan.BuildStatus.BUILD_STATUS_OK,
     )
     with pytest.raises(TransitionNotAllowed) as error:
         PaymentPlanService(payment_plan).tp_lock()

--- a/tests/unit/apps/payment/test_payment_plan_services.py
+++ b/tests/unit/apps/payment/test_payment_plan_services.py
@@ -983,6 +983,19 @@ def test_tp_lock_invalid_pp_status(user: User, business_area: Any, cycle: Progra
     assert str(error.value) == 'Status_Tp_Lock :: no transition from "DRAFT"'
 
 
+def test_tp_lock_invalid_build_status(user: User, business_area: Any, cycle: ProgramCycle) -> None:
+    payment_plan = PaymentPlanFactory(
+        program_cycle=cycle,
+        created_by=user,
+        business_area=business_area,
+        status=PaymentPlan.Status.TP_OPEN,
+        build_status=PaymentPlan.BuildStatus.BUILD_STATUS_BUILDING,
+    )
+    with pytest.raises(ValidationError) as error:
+        PaymentPlanService(payment_plan).tp_lock()
+    assert error.value.detail[0] == "Can't Lock within Build Status BUILDING"
+
+
 def test_tp_unlock(user: User, business_area: Any, cycle: ProgramCycle) -> None:
     payment_plan = PaymentPlanFactory(
         program_cycle=cycle,

--- a/tests/unit/apps/payment/test_payment_plan_services.py
+++ b/tests/unit/apps/payment/test_payment_plan_services.py
@@ -993,7 +993,7 @@ def test_tp_lock_invalid_build_status(user: User, business_area: Any, cycle: Pro
     )
     with pytest.raises(ValidationError) as error:
         PaymentPlanService(payment_plan).tp_lock()
-    assert error.value.detail[0] == "Can't Lock within Build Status BUILDING"
+    assert error.value.detail[0] == "Can be Locked within Build Status Ok"
 
 
 def test_tp_unlock(user: User, business_area: Any, cycle: ProgramCycle) -> None:

--- a/tests/unit/apps/payment/test_target_population_views.py
+++ b/tests/unit/apps/payment/test_target_population_views.py
@@ -267,6 +267,7 @@ def target_population_actions_context(
         status=PaymentPlan.Status.TP_OPEN,
         created_by=user,
         created_at=timezone.datetime(2022, 2, 24, tzinfo=dt_timezone.utc),
+        build_status=PaymentPlan.BuildStatus.BUILD_STATUS_OK,
     )
     url_kwargs = {
         "business_area_slug": business_area.slug,


### PR DESCRIPTION
Partially [AB#311246](https://unicef.visualstudio.com/ICTD-HCT-MIS/_workitems/edit/311246): Syria: Payee List is not showing


Fix issue when user can klick `Lock TP` and didn't wait when the list of HH is displayed and build status is OK. 