### PR TITLE
[HOTFIX] Admin mass_withdraw/mass_unwithdraw fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [ "setuptools", "wheel" ]
 
 [project]
 name = "hope"
-version = "4.13.0"
+version = "4.13.1"
 description = "HCT MIS is UNICEF's humanitarian cash transfer platform."
 readme = "README.md"
 license = { text = "None" }

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "4.13.0",
+  "version": "4.13.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/hope/admin/household.py
+++ b/src/hope/admin/household.py
@@ -47,6 +47,7 @@ from hope.apps.household.forms import (
     WithdrawHouseholdsForm,
 )
 from hope.apps.household.services.household_withdraw import HouseholdWithdraw
+from hope.apps.program.signals import adjust_program_size
 from hope.apps.utils.security import is_root
 from hope.models import (
     HEAD,
@@ -84,16 +85,18 @@ class HouseholdWithDrawnMixin:
                 )
             else:
                 tickets = filter(lambda t: t.ticket.status != GrievanceTicket.STATUS_CLOSED, tickets)
+        tickets = list(tickets)
         service = HouseholdWithdraw(hh)
-        service.change_tickets_status(tickets)
         if hh.withdrawn:
             service.unwithdraw()
+            adjust_program_size(hh.program)
             message = "{target} has been restored by {user}. {comment}"
             ticket_message = "Ticket reopened due to Household restore"
         else:
             service.withdraw(tag=tag)
             message = "{target} has been withdrawn by {user}. {comment}"
             ticket_message = "Ticket closed due to Household withdrawn"
+        service.change_tickets_status(tickets)
 
         for individual in service.individuals:
             self.log_change(
@@ -132,7 +135,7 @@ class HouseholdWithDrawnMixin:
                             tag=form.cleaned_data["tag"],
                             comment=form.cleaned_data["reason"],
                         )
-                        if service.household.withdraw:
+                        if service.household.withdrawn:
                             results += 1
                 self.message_user(request, f"Changed {results} Households.")
                 return None
@@ -147,7 +150,7 @@ class HouseholdWithDrawnMixin:
         )
         return TemplateResponse(request, "admin/household/household/mass_withdrawn.html", context)
 
-    mass_withdraw.allowed_permissions = ["household.can_withdrawn"]
+    mass_withdraw.allowed_permissions = ["withdrawn"]
 
     def mass_unwithdraw(self, request: HttpRequest, qs: QuerySet) -> TemplateResponse | None:
         context = self.get_common_context(request, title="Restore")
@@ -171,7 +174,7 @@ class HouseholdWithDrawnMixin:
                             tickets=tickets,
                             comment=form.cleaned_data["reason"],
                         )
-                        if not service.household.withdraw:
+                        if not service.household.withdrawn:
                             results += 1
                 self.message_user(request, f"Changed {results} Households.")
                 return None
@@ -185,7 +188,7 @@ class HouseholdWithDrawnMixin:
         )
         return TemplateResponse(request, "admin/household/household/mass_withdrawn.html", context)
 
-    mass_withdraw.allowed_permissions = ["withdrawn"]
+    mass_unwithdraw.allowed_permissions = ["withdrawn"]
 
     @button(permission="household.can_withdrawn")
     def withdraw(self, request: HttpRequest, pk: UUID) -> HttpResponseRedirect | TemplateResponse:
@@ -281,6 +284,8 @@ class HouseholdWithdrawFromListMixin:
             withdrawn_date=timezone.now(),
             internal_data=JSONBSet(F("internal_data"), Value("{withdrawn_tag}"), Value(f'"{tag}"')),
         )
+
+        adjust_program_size(program)
 
     @staticmethod
     def split_list_of_ids(household_list: str) -> list:

--- a/tests/unit/apps/household/test_household_admin.py
+++ b/tests/unit/apps/household/test_household_admin.py
@@ -2,6 +2,7 @@ from typing import Any
 from unittest.mock import patch
 
 from django.contrib.admin import AdminSite
+from django.contrib.auth.models import Permission
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.http import HttpRequest
 from django.urls import reverse
@@ -519,9 +520,44 @@ def test_mass_unwithdraw_counts_only_newly_unwithrawn(
     assert messages_sent == ["Changed 1 Households."]
 
 
-def test_mass_withdraw_actions_require_withdrawn_permission() -> None:
-    assert getattr(HouseholdAdmin.mass_withdraw, "allowed_permissions", None) == ["withdrawn"]
-    assert getattr(HouseholdAdmin.mass_unwithdraw, "allowed_permissions", None) == ["withdrawn"]
+def test_has_withdrawn_permission_grants_access_with_perm() -> None:
+    user = UserFactory(is_staff=True)
+    user.user_permissions.add(Permission.objects.get(codename="can_withdrawn"))
+    request = HttpRequest()
+    request.user = user
+
+    assert HouseholdAdmin(Household, AdminSite()).has_withdrawn_permission(request) is True
+
+
+def test_has_withdrawn_permission_denies_access_without_perm() -> None:
+    user = UserFactory(is_staff=True)
+    request = HttpRequest()
+    request.user = user
+
+    assert HouseholdAdmin(Household, AdminSite()).has_withdrawn_permission(request) is False
+
+
+def test_mass_withdraw_unwithdraw_not_available_without_withdrawn_permission() -> None:
+    user = UserFactory(is_staff=True)
+    request = HttpRequest()
+    request.user = user
+
+    actions = HouseholdAdmin(Household, AdminSite()).get_actions(request)
+
+    assert "mass_withdraw" not in actions
+    assert "mass_unwithdraw" not in actions
+
+
+def test_mass_withdraw_unwithdraw_available_with_withdrawn_permission() -> None:
+    user = UserFactory(is_staff=True)
+    user.user_permissions.add(Permission.objects.get(codename="can_withdrawn"))
+    request = HttpRequest()
+    request.user = user
+
+    actions = HouseholdAdmin(Household, AdminSite()).get_actions(request)
+
+    assert "mass_withdraw" in actions
+    assert "mass_unwithdraw" in actions
 
 
 def test_mass_withdraw_fires_household_withdrawn_signal(
@@ -655,3 +691,49 @@ def test_single_unwithdraw_calls_adjust_program_size(withdrawn_household_with_ti
         admin_http_client.post(url, {"tag": "", "reason": ""})
 
     mock_adjust.assert_called_once_with(household.program)
+
+
+def test_single_withdraw_button_allowed_with_withdrawn_permission(active_household_with_ticket, client) -> None:
+    user = UserFactory(is_staff=True)
+    user.user_permissions.add(Permission.objects.get(codename="can_withdrawn"))
+    client.force_login(user, backend="django.contrib.auth.backends.ModelBackend")
+    household = active_household_with_ticket["household"]
+
+    url = reverse("admin:household_household_withdraw", args=[household.pk])
+    response = client.post(url, {"tag": "test-tag", "reason": ""})
+
+    assert response.status_code == 302
+
+
+def test_single_withdraw_button_requires_withdrawn_permission(active_household_with_ticket, client) -> None:
+    user = UserFactory(is_staff=True)
+    client.force_login(user, backend="django.contrib.auth.backends.ModelBackend")
+    household = active_household_with_ticket["household"]
+
+    url = reverse("admin:household_household_withdraw", args=[household.pk])
+    response = client.post(url, {"tag": "test-tag", "reason": ""})
+
+    assert response.status_code == 403
+
+
+def test_single_unwithdraw_button_allowed_with_withdrawn_permission(withdrawn_household_with_ticket, client) -> None:
+    user = UserFactory(is_staff=True)
+    user.user_permissions.add(Permission.objects.get(codename="can_withdrawn"))
+    client.force_login(user, backend="django.contrib.auth.backends.ModelBackend")
+    household = withdrawn_household_with_ticket["household"]
+
+    url = reverse("admin:household_household_withdraw", args=[household.pk])
+    response = client.post(url, {"tag": "", "reason": ""})
+
+    assert response.status_code == 302
+
+
+def test_single_unwithdraw_button_requires_withdrawn_permission(withdrawn_household_with_ticket, client) -> None:
+    user = UserFactory(is_staff=True)
+    client.force_login(user, backend="django.contrib.auth.backends.ModelBackend")
+    household = withdrawn_household_with_ticket["household"]
+
+    url = reverse("admin:household_household_withdraw", args=[household.pk])
+    response = client.post(url, {"tag": "", "reason": ""})
+
+    assert response.status_code == 403

--- a/tests/unit/apps/household/test_household_admin.py
+++ b/tests/unit/apps/household/test_household_admin.py
@@ -501,7 +501,7 @@ def test_mass_withdraw_counts_only_newly_withdrawn(
     assert messages_sent == ["Changed 1 Households."]
 
 
-def test_mass_unwithdraw_counts_only_newly_unwithrawn(
+def test_mass_unwithdraw_counts_only_newly_unwithdrawn(
     active_household_with_ticket, withdrawn_household_with_ticket, admin_post_request
 ) -> None:
     withdrawn_hh = withdrawn_household_with_ticket["household"]

--- a/tests/unit/apps/household/test_household_admin.py
+++ b/tests/unit/apps/household/test_household_admin.py
@@ -1,8 +1,10 @@
 from typing import Any
 from unittest.mock import patch
 
+from django.contrib.admin import AdminSite
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.http import HttpRequest
+from django.urls import reverse
 import pytest
 
 from extras.test_utils.factories import (
@@ -12,11 +14,12 @@ from extras.test_utils.factories import (
     HouseholdFactory,
     IndividualFactory,
     ProgramFactory,
+    UserFactory,
 )
-from hope.admin.household import HouseholdWithdrawFromListMixin
+from hope.admin.household import HouseholdAdmin, HouseholdWithdrawFromListMixin
 from hope.apps.grievance.models import GrievanceTicket, TicketComplaintDetails, TicketIndividualDataUpdateDetails
 from hope.apps.household.services.household_withdraw import HouseholdWithdraw
-from hope.models import Document
+from hope.models import Document, Household
 
 pytestmark = pytest.mark.django_db
 
@@ -334,3 +337,321 @@ def test_post_households_withdraw_from_list_step_2(
         resp = HouseholdWithdrawFromListMixin().withdraw_households_from_list(request=post_request)
 
     assert resp.status_code == 200
+
+
+# ── mass_withdraw / mass_unwithdraw action tests ──────────────────────────
+
+
+@pytest.fixture
+def admin_user():
+    return UserFactory(username="admin_btn", is_staff=True, is_superuser=True, is_active=True, status="ACTIVE")
+
+
+@pytest.fixture
+def admin_withdraw_mocks(monkeypatch):
+    monkeypatch.setattr(HouseholdAdmin, "get_common_context", lambda *a, **k: {}, raising=False)
+    monkeypatch.setattr(HouseholdAdmin, "message_user", lambda *a, **k: None, raising=False)
+    monkeypatch.setattr(HouseholdAdmin, "log_change", lambda *a, **k: None, raising=False)
+
+
+@pytest.fixture
+def admin_post_request(admin_user):
+    def _make(household, extra_post: dict | None = None) -> HttpRequest:
+        request = HttpRequest()
+        request.method = "POST"
+        request.user = admin_user
+        request.POST = {"apply": "1", "reason": "", "_selected_action": str(household.pk), **(extra_post or {})}  # type: ignore
+        return request
+
+    return _make
+
+
+@pytest.fixture
+def active_household_with_ticket(business_area, programs):
+    program = programs["program"]
+    household = HouseholdFactory(business_area=business_area, program=program, create_role=False)
+    individual = IndividualFactory(household=household, business_area=business_area, program=program)
+    household.head_of_household = individual
+    household.save(update_fields=["head_of_household"])
+    document = DocumentFactory(individual=individual, program=program)
+    ticket = GrievanceTicketFactory(status=GrievanceTicket.STATUS_IN_PROGRESS, business_area=business_area)
+    ticket.programs.add(program)
+    TicketComplaintDetails.objects.create(ticket=ticket, household=household)
+    return {"household": household, "individual": individual, "document": document, "ticket": ticket}
+
+
+@pytest.fixture
+def withdrawn_household_with_ticket(business_area, programs):
+    program = programs["program"]
+    household = HouseholdFactory(business_area=business_area, program=program, create_role=False, withdrawn=True)
+    individual = IndividualFactory(household=household, business_area=business_area, program=program, withdrawn=True)
+    household.head_of_household = individual
+    household.save(update_fields=["head_of_household"])
+    ticket = GrievanceTicketFactory(
+        status=GrievanceTicket.STATUS_CLOSED,
+        business_area=business_area,
+        extras={"status_before_withdrawn": str(GrievanceTicket.STATUS_IN_PROGRESS)},
+    )
+    ticket.programs.add(program)
+    TicketComplaintDetails.objects.create(ticket=ticket, household=household)
+    document = DocumentFactory(individual=individual, program=program, status=Document.STATUS_INVALID)
+    return {"household": household, "individual": individual, "ticket": ticket, "document": document}
+
+
+def test_mass_withdraw_closes_linked_tickets_and_invalidates_documents(
+    active_household_with_ticket, admin_withdraw_mocks, admin_post_request
+) -> None:
+    household = active_household_with_ticket["household"]
+    ticket = active_household_with_ticket["ticket"]
+    document = active_household_with_ticket["document"]
+
+    HouseholdAdmin(Household, AdminSite()).mass_withdraw(
+        admin_post_request(household, {"tag": "test-tag"}),
+        Household.objects.filter(pk=household.pk),
+    )
+
+    ticket.refresh_from_db()
+    document.refresh_from_db()
+    assert ticket.status == GrievanceTicket.STATUS_CLOSED
+    assert ticket.extras["status_before_withdrawn"] == GrievanceTicket.STATUS_IN_PROGRESS
+    assert document.status == Document.STATUS_INVALID
+
+
+def test_mass_withdraw_skips_already_withdrawn(
+    withdrawn_household_with_ticket, admin_withdraw_mocks, admin_post_request
+) -> None:
+    household = withdrawn_household_with_ticket["household"]
+
+    HouseholdAdmin(Household, AdminSite()).mass_withdraw(
+        admin_post_request(household, {"tag": "test-tag"}),
+        Household.objects.filter(pk=household.pk),
+    )
+
+    household.refresh_from_db()
+    assert household.withdrawn is True
+
+
+def test_mass_unwithdraw_reopens_linked_tickets(
+    withdrawn_household_with_ticket, admin_withdraw_mocks, admin_post_request
+) -> None:
+    household = withdrawn_household_with_ticket["household"]
+    ticket = withdrawn_household_with_ticket["ticket"]
+
+    HouseholdAdmin(Household, AdminSite()).mass_unwithdraw(
+        admin_post_request(household, {"reopen_tickets": "on"}),
+        Household.objects.filter(pk=household.pk),
+    )
+
+    household.refresh_from_db()
+    ticket.refresh_from_db()
+    assert household.withdrawn is False
+    assert ticket.status == GrievanceTicket.STATUS_IN_PROGRESS
+    assert ticket.extras.get("status_before_withdrawn") == ""
+
+
+def test_mass_unwithdraw_restores_document_status(
+    withdrawn_household_with_ticket, admin_withdraw_mocks, admin_post_request
+) -> None:
+    household = withdrawn_household_with_ticket["household"]
+    document = withdrawn_household_with_ticket["document"]
+
+    HouseholdAdmin(Household, AdminSite()).mass_unwithdraw(
+        admin_post_request(household),
+        Household.objects.filter(pk=household.pk),
+    )
+
+    document.refresh_from_db()
+    assert document.status == Document.STATUS_NEED_INVESTIGATION
+
+
+def test_mass_unwithdraw_keeps_tickets_closed_when_reopen_not_requested(
+    withdrawn_household_with_ticket, admin_withdraw_mocks, admin_post_request
+) -> None:
+    household = withdrawn_household_with_ticket["household"]
+    ticket = withdrawn_household_with_ticket["ticket"]
+
+    HouseholdAdmin(Household, AdminSite()).mass_unwithdraw(
+        admin_post_request(household),
+        Household.objects.filter(pk=household.pk),
+    )
+
+    household.refresh_from_db()
+    ticket.refresh_from_db()
+    assert household.withdrawn is False
+    assert ticket.status == GrievanceTicket.STATUS_CLOSED
+
+
+def test_mass_withdraw_counts_only_newly_withdrawn(
+    active_household_with_ticket, withdrawn_household_with_ticket, admin_post_request
+) -> None:
+    active_hh = active_household_with_ticket["household"]
+    already_withdrawn_hh = withdrawn_household_with_ticket["household"]
+    qs = Household.objects.filter(pk__in=[active_hh.pk, already_withdrawn_hh.pk])
+    messages_sent = []
+    with (
+        patch.object(HouseholdAdmin, "get_common_context", return_value={}),
+        patch.object(HouseholdAdmin, "log_change"),
+        patch.object(HouseholdAdmin, "message_user", side_effect=lambda req, msg, *a, **k: messages_sent.append(msg)),
+    ):
+        HouseholdAdmin(Household, AdminSite()).mass_withdraw(
+            admin_post_request(active_hh, {"tag": "test-tag"}),
+            qs,
+        )
+    assert messages_sent == ["Changed 1 Households."]
+
+
+def test_mass_unwithdraw_counts_only_newly_unwithrawn(
+    active_household_with_ticket, withdrawn_household_with_ticket, admin_post_request
+) -> None:
+    withdrawn_hh = withdrawn_household_with_ticket["household"]
+    not_withdrawn_hh = active_household_with_ticket["household"]
+    qs = Household.objects.filter(pk__in=[withdrawn_hh.pk, not_withdrawn_hh.pk])
+    messages_sent = []
+    with (
+        patch.object(HouseholdAdmin, "get_common_context", return_value={}),
+        patch.object(HouseholdAdmin, "log_change"),
+        patch.object(HouseholdAdmin, "message_user", side_effect=lambda req, msg, *a, **k: messages_sent.append(msg)),
+    ):
+        HouseholdAdmin(Household, AdminSite()).mass_unwithdraw(
+            admin_post_request(withdrawn_hh, {"reopen_tickets": "on"}),
+            qs,
+        )
+    assert messages_sent == ["Changed 1 Households."]
+
+
+def test_mass_withdraw_actions_require_withdrawn_permission() -> None:
+    assert getattr(HouseholdAdmin.mass_withdraw, "allowed_permissions", None) == ["withdrawn"]
+    assert getattr(HouseholdAdmin.mass_unwithdraw, "allowed_permissions", None) == ["withdrawn"]
+
+
+def test_mass_withdraw_fires_household_withdrawn_signal(
+    active_household_with_ticket, admin_withdraw_mocks, admin_post_request
+) -> None:
+    from hope.apps.household.signals import household_withdrawn
+
+    household = active_household_with_ticket["household"]
+    signal_calls = []
+
+    def on_signal(sender, instance, **kwargs):
+        signal_calls.append(instance)
+
+    household_withdrawn.connect(on_signal)
+    try:
+        HouseholdAdmin(Household, AdminSite()).mass_withdraw(
+            admin_post_request(household, {"tag": "test-tag"}),
+            Household.objects.filter(pk=household.pk),
+        )
+    finally:
+        household_withdrawn.disconnect(on_signal)
+
+    assert len(signal_calls) == 1
+    assert signal_calls[0].pk == household.pk
+
+
+def test_mass_withdraw_invalidates_grievance_ticket_cache(
+    active_household_with_ticket, admin_withdraw_mocks, admin_post_request
+) -> None:
+    household = active_household_with_ticket["household"]
+
+    with patch("hope.apps.grievance.signals.increment_grievance_ticket_version_cache") as mock_cache:
+        HouseholdAdmin(Household, AdminSite()).mass_withdraw(
+            admin_post_request(household, {"tag": "test-tag"}),
+            Household.objects.filter(pk=household.pk),
+        )
+
+    assert mock_cache.called
+
+
+def test_mass_unwithdraw_invalidates_grievance_ticket_cache(
+    withdrawn_household_with_ticket, admin_withdraw_mocks, admin_post_request
+) -> None:
+    household = withdrawn_household_with_ticket["household"]
+
+    with patch("hope.apps.grievance.signals.increment_grievance_ticket_version_cache") as mock_cache:
+        HouseholdAdmin(Household, AdminSite()).mass_unwithdraw(
+            admin_post_request(household, {"reopen_tickets": "on"}),
+            Household.objects.filter(pk=household.pk),
+        )
+
+    assert mock_cache.called
+
+
+def test_mass_unwithdraw_calls_adjust_program_size(
+    withdrawn_household_with_ticket, admin_withdraw_mocks, admin_post_request
+) -> None:
+    household = withdrawn_household_with_ticket["household"]
+
+    with patch("hope.admin.household.adjust_program_size") as mock_adjust:
+        HouseholdAdmin(Household, AdminSite()).mass_unwithdraw(
+            admin_post_request(household),
+            Household.objects.filter(pk=household.pk),
+        )
+
+    mock_adjust.assert_called_once_with(household.program)
+
+
+def test_mass_withdraw_from_list_bulk_calls_adjust_program_size(households_context) -> None:
+    program = households_context["program"]
+    household = households_context["household"]
+
+    with patch("hope.admin.household.adjust_program_size") as mock_adjust:
+        HouseholdWithdrawFromListMixin().mass_withdraw_households_from_list_bulk(
+            [household.unicef_id], "test-tag", program
+        )
+
+    mock_adjust.assert_called_once_with(program)
+
+
+# ── single withdraw / unwithdraw button tests ─────────────────────────────
+
+
+@pytest.fixture
+def admin_http_client(client, admin_user):
+    client.force_login(admin_user, backend="django.contrib.auth.backends.ModelBackend")
+    return client
+
+
+def test_single_withdraw_closes_linked_tickets_and_invalidates_documents(
+    active_household_with_ticket, admin_http_client
+) -> None:
+    household = active_household_with_ticket["household"]
+    ticket = active_household_with_ticket["ticket"]
+    document = active_household_with_ticket["document"]
+
+    url = reverse("admin:household_household_withdraw", args=[household.pk])
+    response = admin_http_client.post(url, {"tag": "test-tag", "reason": ""})
+
+    assert response.status_code == 302
+    ticket.refresh_from_db()
+    document.refresh_from_db()
+    assert ticket.status == GrievanceTicket.STATUS_CLOSED
+    assert ticket.extras["status_before_withdrawn"] == GrievanceTicket.STATUS_IN_PROGRESS
+    assert document.status == Document.STATUS_INVALID
+
+
+def test_single_unwithdraw_reopens_linked_tickets_and_restores_documents(
+    withdrawn_household_with_ticket, admin_http_client
+) -> None:
+    household = withdrawn_household_with_ticket["household"]
+    ticket = withdrawn_household_with_ticket["ticket"]
+    document = withdrawn_household_with_ticket["document"]
+
+    url = reverse("admin:household_household_withdraw", args=[household.pk])
+    response = admin_http_client.post(url, {"tag": "", "reason": ""})
+
+    assert response.status_code == 302
+    ticket.refresh_from_db()
+    document.refresh_from_db()
+    assert ticket.status == GrievanceTicket.STATUS_IN_PROGRESS
+    assert ticket.extras.get("status_before_withdrawn") == ""
+    assert document.status == Document.STATUS_NEED_INVESTIGATION
+
+
+def test_single_unwithdraw_calls_adjust_program_size(withdrawn_household_with_ticket, admin_http_client) -> None:
+    household = withdrawn_household_with_ticket["household"]
+    url = reverse("admin:household_household_withdraw", args=[household.pk])
+
+    with patch("hope.admin.household.adjust_program_size") as mock_adjust:
+        admin_http_client.post(url, {"tag": "", "reason": ""})
+
+    mock_adjust.assert_called_once_with(household.program)


### PR DESCRIPTION
[AB#313660](https://unicef.visualstudio.com/4e044e8d-bc28-4768-8074-f80ff6e4a0e5/_workitems/edit/313660)
Fixed bugs on the withdraw/unwithdraw and mass_withdraw/mass_unwithdraw actions:

* Ticket closing/reopening
* logging for tickets - was missing - due to iterating though exhausted iterator
* results counter for logging - typo .withdraw -> .withdrawn; method was = True so it was calculating every hh
* adjust_program_size missing from unwithdraw
* adjust_program_size missing in bulk flow
* allowed_permissions broken for mass withdraw/unwithdraw; also missing perm for unwithdraw (duplicated assignment for "withdraw" action)