### PR TITLE
fix: defer constance REST_API_TTL lookup to request time

### DIFF
--- a/src/hope/api/caches.py
+++ b/src/hope/api/caches.py
@@ -7,9 +7,30 @@ from django.core.cache import cache
 from django.db.models import Count, Max, QuerySet
 from rest_framework import status
 from rest_framework.response import Response
+from rest_framework_extensions.cache.decorators import CacheResponse
 from rest_framework_extensions.key_constructor import bits
 from rest_framework_extensions.key_constructor.bits import KeyBitBase
 from rest_framework_extensions.key_constructor.constructors import KeyConstructor
+
+
+class _ConstanceTTLCacheResponse(CacheResponse):
+    # Reads REST_API_TTL from constance per request instead of at decoration time.
+    # Why: with the database constance backend, evaluating config.REST_API_TTL at
+    # import time hits the constance table before migrations can be applied,
+    # breaking bootstrap (URL resolver runs during `manage.py check`).
+    def __init__(
+        self,
+        key_func: Any = None,
+        cache: str | None = None,
+        cache_errors: bool | None = None,
+    ) -> None:
+        super().__init__(timeout=0, key_func=key_func, cache=cache, cache_errors=cache_errors)
+
+    def calculate_timeout(self, view_instance: Any, **_: Any) -> int:
+        return config.REST_API_TTL
+
+
+cached_response = _ConstanceTTLCacheResponse
 
 
 def _inm_matches(etag: str, inm_header: str | None) -> bool:

--- a/src/hope/apps/account/api/views.py
+++ b/src/hope/apps/account/api/views.py
@@ -1,6 +1,5 @@
 from typing import TYPE_CHECKING, Any
 
-from constance import config
 from django.contrib.auth.models import Group
 from django.db import models
 from django.db.models import Exists, OuterRef, Q, QuerySet
@@ -13,9 +12,8 @@ from rest_framework.generics import get_object_or_404
 from rest_framework.mixins import ListModelMixin, RetrieveModelMixin
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
-from rest_framework_extensions.cache.decorators import cache_response
 
-from hope.api.caches import etag_decorator
+from hope.api.caches import cached_response, etag_decorator
 from hope.apps.account.api.caches import UserListKeyConstructor
 from hope.apps.account.api.serializers import (
     GroupDetailSerializer,
@@ -148,7 +146,7 @@ class UserViewSet(
     @extend_schema(parameters=[OpenApiParameter(name="program")])
     @action(detail=False, methods=["get"], url_path="profile", url_name="profile")
     @etag_decorator(ProfileEtagKey)
-    @cache_response(timeout=config.REST_API_TTL, key_func=ProfileKeyConstructor())
+    @cached_response(key_func=ProfileKeyConstructor())
     def profile(self, request: "Request", *args: Any, **kwargs: Any) -> Response:
         user = request.user
         data = self.get_serializer(user).data
@@ -162,7 +160,7 @@ class UserViewSet(
         ]
     )
     @etag_decorator(UserListKeyConstructor)
-    @cache_response(timeout=config.REST_API_TTL, key_func=UserListKeyConstructor())
+    @cached_response(key_func=UserListKeyConstructor())
     def list(self, request: "Request", *args: Any, **kwargs: Any) -> Response:
         return super().list(request, *args, **kwargs)
 

--- a/src/hope/apps/core/api/views.py
+++ b/src/hope/apps/core/api/views.py
@@ -1,6 +1,5 @@
 from typing import Any
 
-from constance import config
 from django.db.models import Q, QuerySet
 from django.utils import timezone
 from django_filters.rest_framework import DjangoFilterBackend
@@ -12,9 +11,8 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
-from rest_framework_extensions.cache.decorators import cache_response
 
-from hope.api.caches import etag_decorator
+from hope.api.caches import cached_response, etag_decorator
 from hope.apps.core.api.caches import BusinessAreaKeyConstructor
 from hope.apps.core.api.filters import BusinessAreaFilter
 from hope.apps.core.api.mixins import BaseViewSet, CountActionMixin, PermissionsMixin
@@ -73,7 +71,7 @@ class BusinessAreaViewSet(
         )
 
     @etag_decorator(BusinessAreaKeyConstructor)
-    @cache_response(timeout=config.REST_API_TTL, key_func=BusinessAreaKeyConstructor())
+    @cached_response(key_func=BusinessAreaKeyConstructor())
     def list(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         return super().list(request, *args, **kwargs)
 

--- a/src/hope/apps/geo/api/views.py
+++ b/src/hope/apps/geo/api/views.py
@@ -1,7 +1,6 @@
 import logging
 from typing import Any
 
-from constance import config
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import extend_schema
 from rest_framework import mixins
@@ -9,9 +8,8 @@ from rest_framework.decorators import action
 from rest_framework.filters import OrderingFilter
 from rest_framework.request import Request
 from rest_framework.response import Response
-from rest_framework_extensions.cache.decorators import cache_response
 
-from hope.api.caches import etag_decorator
+from hope.api.caches import cached_response, etag_decorator
 from hope.apps.account.permissions import Permissions
 from hope.apps.core.api.mixins import BaseViewSet, BusinessAreaMixin, PermissionsMixin
 from hope.apps.geo.api.caches import AreasKeyConstructor
@@ -37,7 +35,7 @@ class AreaViewSet(
     pagination_class = None
 
     @etag_decorator(AreasKeyConstructor)
-    @cache_response(timeout=config.REST_API_TTL, key_func=AreasKeyConstructor())
+    @cached_response(key_func=AreasKeyConstructor())
     def list(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         return super().list(request, *args, **kwargs)
 
@@ -47,7 +45,7 @@ class AreaViewSet(
         },
     )
     @etag_decorator(AreasKeyConstructor)
-    @cache_response(timeout=config.REST_API_TTL, key_func=AreasKeyConstructor())
+    @cached_response(key_func=AreasKeyConstructor())
     @action(detail=False, methods=["get"], url_path="all-areas-tree")
     def all_areas_tree(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         # get Area max level 3

--- a/src/hope/apps/grievance/api/views.py
+++ b/src/hope/apps/grievance/api/views.py
@@ -1,7 +1,6 @@
 import itertools
 from typing import TYPE_CHECKING, Any
 
-from constance import config
 from django.db import transaction
 from django.db.models import (
     Avg,
@@ -37,9 +36,8 @@ from rest_framework.mixins import (
 from rest_framework.parsers import JSONParser
 from rest_framework.request import Request
 from rest_framework.response import Response
-from rest_framework_extensions.cache.decorators import cache_response
 
-from hope.api.caches import etag_decorator
+from hope.api.caches import cached_response, etag_decorator
 from hope.apps.account.permissions import (
     Permissions,
     check_creator_or_owner_permission,
@@ -349,7 +347,7 @@ class GrievanceTicketViewSet(
         )
 
     @etag_decorator(GrievanceTicketListKeyConstructor)
-    @cache_response(timeout=config.REST_API_TTL, key_func=GrievanceTicketListKeyConstructor())
+    @cached_response(key_func=GrievanceTicketListKeyConstructor())
     def list(self, request: Any, *args: Any, **kwargs: Any) -> Any:
         return super().list(request, *args, **kwargs)
 

--- a/src/hope/apps/household/api/views.py
+++ b/src/hope/apps/household/api/views.py
@@ -1,6 +1,5 @@
 from typing import Any
 
-from constance import config
 from django.db.models import Exists, F, OuterRef, Prefetch, QuerySet
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import extend_schema, inline_serializer
@@ -10,9 +9,8 @@ from rest_framework.filters import OrderingFilter
 from rest_framework.mixins import ListModelMixin, RetrieveModelMixin
 from rest_framework.request import Request
 from rest_framework.response import Response
-from rest_framework_extensions.cache.decorators import cache_response
 
-from hope.api.caches import etag_decorator
+from hope.api.caches import cached_response, etag_decorator
 from hope.apps.account.permissions import Permissions
 from hope.apps.core.api.mixins import (
     BaseViewSet,
@@ -150,7 +148,7 @@ class HouseholdViewSet(
         )
 
     @etag_decorator(HouseholdListKeyConstructor)
-    @cache_response(timeout=config.REST_API_TTL, key_func=HouseholdListKeyConstructor())
+    @cached_response(key_func=HouseholdListKeyConstructor())
     def list(self, request: Any, *args: Any, **kwargs: Any) -> Any:
         return super().list(request, *args, **kwargs)
 
@@ -422,7 +420,7 @@ class IndividualViewSet(
         )
 
     @etag_decorator(IndividualListKeyConstructor)
-    @cache_response(timeout=config.REST_API_TTL, key_func=IndividualListKeyConstructor())
+    @cached_response(key_func=IndividualListKeyConstructor())
     def list(self, request: Any, *args: Any, **kwargs: Any) -> Any:
         return super().list(request, *args, **kwargs)
 

--- a/src/hope/apps/payment/api/views.py
+++ b/src/hope/apps/payment/api/views.py
@@ -5,7 +5,6 @@ import mimetypes
 from typing import TYPE_CHECKING, Any, cast
 from zipfile import BadZipFile
 
-from constance import config
 from django.db import transaction
 from django.db.models import Prefetch, QuerySet
 from django.http import FileResponse
@@ -21,9 +20,8 @@ from rest_framework.generics import get_object_or_404
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
-from rest_framework_extensions.cache.decorators import cache_response
 
-from hope.api.caches import etag_decorator
+from hope.api.caches import cached_response, etag_decorator
 from hope.apps.account.permissions import Permissions
 from hope.apps.activity_log.utils import copy_model_object
 from hope.apps.core.api.mixins import (
@@ -764,7 +762,7 @@ class PaymentPlanViewSet(
         return get_object_or_404(PaymentPlan, id=self.kwargs.get("pk"))
 
     @etag_decorator(PaymentPlanListKeyConstructor)
-    @cache_response(timeout=config.REST_API_TTL, key_func=PaymentPlanListKeyConstructor())
+    @cached_response(key_func=PaymentPlanListKeyConstructor())
     def list(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         return super().list(request, *args, **kwargs)
 
@@ -1686,7 +1684,7 @@ class TargetPopulationViewSet(
         return get_object_or_404(PaymentPlan, id=self.kwargs.get("pk"))
 
     @etag_decorator(TargetPopulationListKeyConstructor)
-    @cache_response(timeout=config.REST_API_TTL, key_func=TargetPopulationListKeyConstructor())
+    @cached_response(key_func=TargetPopulationListKeyConstructor())
     def list(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         return super().list(request, *args, **kwargs)
 
@@ -1966,7 +1964,7 @@ class PaymentPlanManagerialViewSet(
 
     # TODO: e2e failed probably because of cache here
     @etag_decorator(PaymentPlanKeyConstructor)
-    @cache_response(timeout=config.REST_API_TTL, key_func=PaymentPlanKeyConstructor())
+    @cached_response(key_func=PaymentPlanKeyConstructor())
     def list(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         return super().list(request, *args, **kwargs)
 

--- a/src/hope/apps/periodic_data_update/api/views.py
+++ b/src/hope/apps/periodic_data_update/api/views.py
@@ -1,7 +1,6 @@
 import logging
 from typing import Any, cast
 
-from constance import config
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db import transaction
 from django.db.models import Prefetch, Q, QuerySet
@@ -18,9 +17,8 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.serializers import BaseSerializer
-from rest_framework_extensions.cache.decorators import cache_response
 
-from hope.api.caches import etag_decorator
+from hope.api.caches import cached_response, etag_decorator
 from hope.apps.account.permissions import Permissions
 from hope.apps.core.api.filters import UpdatedAtFilter
 from hope.apps.core.api.mixins import BaseViewSet, CountActionMixin, ProgramMixin, SerializerActionMixin
@@ -505,6 +503,6 @@ class PeriodicFieldViewSet(
     filterset_class = UpdatedAtFilter
 
     @etag_decorator(PeriodicFieldKeyConstructor)
-    @cache_response(timeout=config.REST_API_TTL, key_func=PeriodicFieldKeyConstructor())
+    @cached_response(key_func=PeriodicFieldKeyConstructor())
     def list(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         return super().list(request, *args, **kwargs)

--- a/src/hope/apps/program/api/views.py
+++ b/src/hope/apps/program/api/views.py
@@ -2,7 +2,6 @@ import copy
 import logging
 from typing import Any
 
-from constance import config
 from django.db import transaction
 from django.db.models import Case, IntegerField, Prefetch, QuerySet, Value, When
 from django_filters.rest_framework import DjangoFilterBackend
@@ -23,9 +22,8 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.serializers import BaseSerializer
 from rest_framework.viewsets import GenericViewSet, ModelViewSet
-from rest_framework_extensions.cache.decorators import cache_response
 
-from hope.api.caches import etag_decorator
+from hope.api.caches import cached_response, etag_decorator
 from hope.apps.account.permissions import ALL_GRIEVANCES_CREATE_MODIFY, Permissions
 from hope.apps.core.api.filters import UpdatedAtFilter
 from hope.apps.core.api.mixins import (
@@ -163,7 +161,7 @@ class ProgramViewSet(
         )
 
     @etag_decorator(ProgramListKeyConstructor)
-    @cache_response(timeout=config.REST_API_TTL, key_func=ProgramListKeyConstructor())
+    @cached_response(key_func=ProgramListKeyConstructor())
     def list(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         return super().list(request, *args, **kwargs)
 
@@ -525,7 +523,7 @@ class ProgramCycleViewSet(
     filterset_class = ProgramCycleFilter
 
     @etag_decorator(ProgramCycleKeyConstructor)
-    @cache_response(timeout=config.REST_API_TTL, key_func=ProgramCycleKeyConstructor())
+    @cached_response(key_func=ProgramCycleKeyConstructor())
     def list(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         return super().list(request, *args, **kwargs)
 
@@ -587,6 +585,6 @@ class BeneficiaryGroupViewSet(
     filterset_class = UpdatedAtFilter
 
     @etag_decorator(BeneficiaryGroupKeyConstructor)
-    @cache_response(timeout=config.REST_API_TTL, key_func=BeneficiaryGroupKeyConstructor())
+    @cached_response(key_func=BeneficiaryGroupKeyConstructor())
     def list(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         return super().list(request, *args, **kwargs)

--- a/src/hope/apps/program/migrations/0002_migration.py
+++ b/src/hope/apps/program/migrations/0002_migration.py
@@ -41,6 +41,7 @@ def create_default_object(apps, schema_editor):
 class Migration(migrations.Migration):
     dependencies = [
         ("program", "0001_migration"),
+        ("constance", "0001_initial"),
     ]
 
     operations = [

--- a/src/hope/apps/registration_data/api/views.py
+++ b/src/hope/apps/registration_data/api/views.py
@@ -1,7 +1,6 @@
 import logging
 from typing import Any
 
-from constance import config
 from django.db import transaction
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import extend_schema
@@ -13,9 +12,8 @@ from rest_framework.mixins import ListModelMixin, RetrieveModelMixin
 from rest_framework.permissions import AllowAny
 from rest_framework.request import Request
 from rest_framework.response import Response
-from rest_framework_extensions.cache.decorators import cache_response
 
-from hope.api.caches import etag_decorator
+from hope.api.caches import cached_response, etag_decorator
 from hope.apps.account.permissions import Permissions
 from hope.apps.core.api.mixins import (
     BaseViewSet,
@@ -94,7 +92,7 @@ class RegistrationDataImportViewSet(
     filterset_class = RegistrationDataImportFilter
 
     @etag_decorator(RDIKeyConstructor)
-    @cache_response(timeout=config.REST_API_TTL, key_func=RDIKeyConstructor())
+    @cached_response(key_func=RDIKeyConstructor())
     def list(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         return super().list(request, *args, **kwargs)
 

--- a/src/hope/apps/registration_data/migrations/0014_migration.py
+++ b/src/hope/apps/registration_data/migrations/0014_migration.py
@@ -6,7 +6,7 @@ import django.db.models.deletion
 
 class Migration(migrations.Migration):
     dependencies = [
-        ("core", "0023_migration"),
+        ("core", "0024_migration"),
         ("registration_data", "0013_migration"),
     ]
 

--- a/src/hope/contrib/aurora/views.py
+++ b/src/hope/contrib/aurora/views.py
@@ -1,7 +1,6 @@
 from typing import Any
 
 from admin_extra_buttons.utils import HttpResponseRedirectToReferrer
-from constance import config
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.mixins import PermissionRequiredMixin
@@ -13,9 +12,9 @@ from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework.generics import ListAPIView
 from rest_framework.request import Request
 from rest_framework.response import Response
-from rest_framework_extensions.cache.decorators import cache_response
 from sentry_sdk import set_tag
 
+from hope.api.caches import cached_response
 from hope.api.endpoints.base import HOPEAPIView
 from hope.api.filters import ProjectFilter, RegistrationFilter
 from hope.contrib.aurora.api import (
@@ -79,7 +78,7 @@ class OrganizationListView(HOPEAPIView, ListAPIView):
     queryset = Organization.objects.all()
     serializer_class = OrganizationSerializer
 
-    @cache_response(timeout=config.REST_API_TTL, key_func=AuroraKeyConstructor())
+    @cached_response(key_func=AuroraKeyConstructor())
     def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         return super().get(request, *args, **kwargs)
 
@@ -90,7 +89,7 @@ class ProjectListView(HOPEAPIView, ListAPIView):
     filter_backends = [DjangoFilterBackend]
     filterset_class = ProjectFilter
 
-    @cache_response(timeout=config.REST_API_TTL, key_func=AuroraKeyConstructor())
+    @cached_response(key_func=AuroraKeyConstructor())
     def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         return super().get(request, *args, **kwargs)
 
@@ -101,6 +100,6 @@ class RegistrationListView(HOPEAPIView, ListAPIView):
     filter_backends = [DjangoFilterBackend]
     filterset_class = RegistrationFilter
 
-    @cache_response(timeout=config.REST_API_TTL, key_func=AuroraKeyConstructor())
+    @cached_response(key_func=AuroraKeyConstructor())
     def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         return super().get(request, *args, **kwargs)


### PR DESCRIPTION
Fixes bootstrap after switching constance to the DB backend.
  `config.REST_API_TTL` was evaluated at decoration time in 19 viewset
  decorators, hitting `constance_constance` during URL import — which
  broke `manage.py migrate` itself.

  - Add `cached_response` wrapper in `hope.api.caches` that reads
    `REST_API_TTL` lazily per request (same TTL semantics).
  - Replace all 19 `@cache_response(timeout=config.REST_API_TTL, ...)`
    call sites with `@cached_response(...)`.
  - Fix dangling migration dep in `registration_data.0014_migration`
    (`core.0023_migration` → `0024_migration`).
  - Add `constance.0001_initial` as a dep of `program.0002_migration`,
    which reads constance during a `RunPython`.