### PR TITLE
Hotfix: celery_async_job_queue_on_commit & aurora create task for processing records

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [ "setuptools", "wheel" ]
 
 [project]
 name = "hope"
-version = "4.14.0"
+version = "4.14.1"
 description = "HCT MIS is UNICEF's humanitarian cash transfer platform."
 readme = "README.md"
 license = { text = "None" }

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "4.14.0",
+  "version": "4.14.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/hope/contrib/aurora/services/base_flex_registration_service.py
+++ b/src/hope/contrib/aurora/services/base_flex_registration_service.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 
 
 class BaseRegistrationService(AuroraProcessor, abc.ABC):
-    process_flex_records_async_task = process_flex_records_task
+    process_flex_records_task = process_flex_records_task
 
     def __init__(self, registration: Registration) -> None:
         self.registration = registration

--- a/src/hope/models/async_job.py
+++ b/src/hope/models/async_job.py
@@ -2,7 +2,7 @@ from typing import Any
 
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
-from django.db import models
+from django.db import models, transaction
 from django_celery_boost.models import AsyncJobModel
 
 
@@ -90,12 +90,14 @@ class AsyncJob(AsyncJobModel):
             **payload,
         }
 
-        job = (
-            cls.create_for_instance(instance, **job_payload)
-            if instance is not None
-            else cls.objects.create(**job_payload)
-        )
-        job.queue()
+        with transaction.atomic():
+            job = (
+                cls.create_for_instance(instance, **job_payload)
+                if instance is not None
+                else cls.objects.create(**job_payload)
+            )
+            transaction.on_commit(job.queue)
+
         return job
 
     def save(self, *args: Any, **kwargs: Any) -> None:

--- a/tests/unit/apps/account/test_celery_task_invalidate_permissions_cache_for_expired_role.py
+++ b/tests/unit/apps/account/test_celery_task_invalidate_permissions_cache_for_expired_role.py
@@ -305,8 +305,11 @@ def test_invalidate_permissions_cache_role_on_users_and_partner_action(
 
 
 @patch.object(AsyncJob, "queue")
-def test_invalidate_permissions_cache_role_task_schedules_async_job(mock_queue: Any) -> None:
-    result = invalidate_permissions_cache_for_user_if_expired_role_async_task()
+def test_invalidate_permissions_cache_role_task_schedules_async_job(
+    mock_queue: Any, django_capture_on_commit_callbacks: Any
+) -> None:
+    with django_capture_on_commit_callbacks(execute=True):
+        result = invalidate_permissions_cache_for_user_if_expired_role_async_task()
 
     job = AsyncJob.objects.get()
 

--- a/tests/unit/apps/accountability/test_celery_tasks.py
+++ b/tests/unit/apps/accountability/test_celery_tasks.py
@@ -182,8 +182,11 @@ def create_async_job(action: str, config: dict) -> AsyncJob:
 
 
 @patch.object(AsyncJob, "queue")
-def test_export_survey_sample_task_schedules_async_job(mock_queue: Mock, survey, user) -> None:
-    export_survey_sample_async_task(survey, user)
+def test_export_survey_sample_task_schedules_async_job(
+    mock_queue: Mock, survey, user, django_capture_on_commit_callbacks
+) -> None:
+    with django_capture_on_commit_callbacks(execute=True):
+        export_survey_sample_async_task(survey, user)
 
     job = AsyncJob.objects.get()
 
@@ -243,8 +246,11 @@ def test_export_survey_sample_task_action_success_without_email_notification(
 
 
 @patch.object(AsyncJob, "queue")
-def test_send_survey_to_users_task_schedules_async_job(mock_queue: Mock, survey) -> None:
-    send_survey_to_users_async_task(survey)
+def test_send_survey_to_users_task_schedules_async_job(
+    mock_queue: Mock, survey, django_capture_on_commit_callbacks
+) -> None:
+    with django_capture_on_commit_callbacks(execute=True):
+        send_survey_to_users_async_task(survey)
 
     job = AsyncJob.objects.get()
 

--- a/tests/unit/apps/core/test_kobo_template_upload.py
+++ b/tests/unit/apps/core/test_kobo_template_upload.py
@@ -250,10 +250,13 @@ def test_unsuccessful_when_error_in_response_sets_unsuccessful_status(mock_paren
 
 
 @patch.object(AsyncJob, "queue")
-def test_upload_new_kobo_template_task_with_retry_schedules_async_job(mock_queue, admin_user):
+def test_upload_new_kobo_template_task_with_retry_schedules_async_job(
+    mock_queue, admin_user, django_capture_on_commit_callbacks
+):
     xlsx_kobo_template = XLSXKoboTemplateFactory(uploaded_by=admin_user)
 
-    upload_new_kobo_template_and_update_flex_fields_task_with_retry_async_task(str(xlsx_kobo_template.id))
+    with django_capture_on_commit_callbacks(execute=True):
+        upload_new_kobo_template_and_update_flex_fields_task_with_retry_async_task(str(xlsx_kobo_template.id))
 
     job = AsyncJob.objects.get()
 
@@ -356,10 +359,11 @@ def test_upload_new_kobo_template_task_with_retry_action_marks_template_unsucces
 
 
 @patch.object(AsyncJob, "queue")
-def test_upload_new_kobo_template_task_schedules_async_job(mock_queue, admin_user):
+def test_upload_new_kobo_template_task_schedules_async_job(mock_queue, admin_user, django_capture_on_commit_callbacks):
     xlsx_kobo_template = XLSXKoboTemplateFactory(uploaded_by=admin_user)
 
-    upload_new_kobo_template_and_update_flex_fields_async_task(str(xlsx_kobo_template.id))
+    with django_capture_on_commit_callbacks(execute=True):
+        upload_new_kobo_template_and_update_flex_fields_async_task(str(xlsx_kobo_template.id))
 
     job = AsyncJob.objects.get()
 

--- a/tests/unit/apps/core/test_kobo_template_upload.py
+++ b/tests/unit/apps/core/test_kobo_template_upload.py
@@ -141,7 +141,7 @@ def test_upload_valid_template_shows_success_message(
 ):
     mock_country_choices.return_value = _get_all_country_choices()
 
-    with django_assert_num_queries(24):
+    with django_assert_num_queries(20):
         response = _upload_file(client, admin_user, "kobo-template-valid.xlsx")
 
         messages = [m.message for m in get_messages(response.wsgi_request)]

--- a/tests/unit/apps/generic_import/test_celery_tasks.py
+++ b/tests/unit/apps/generic_import/test_celery_tasks.py
@@ -450,15 +450,16 @@ def test_process_generic_import_task_updates_rdi_despite_import_data_update_fail
 
 
 @pytest.mark.django_db
-def test_process_generic_import_task_schedules_async_job(rdi):
+def test_process_generic_import_task_schedules_async_job(rdi, django_capture_on_commit_callbacks):
     with patch("hope.apps.generic_import.celery_tasks.AsyncRetryJob.objects.create") as mock_create:
         mock_job = Mock()
         mock_create.return_value = mock_job
 
-        process_generic_import_async_task(
-            registration_data_import=rdi,
-            import_data=rdi.import_data,
-        )
+        with django_capture_on_commit_callbacks(execute=True):
+            process_generic_import_async_task(
+                registration_data_import=rdi,
+                import_data=rdi.import_data,
+            )
 
     mock_create.assert_called_once_with(
         job_name=process_generic_import_async_task.__name__,

--- a/tests/unit/apps/geo/test_celery_tasks.py
+++ b/tests/unit/apps/geo/test_celery_tasks.py
@@ -105,10 +105,11 @@ def test_import_areas_from_no_country_column(country: Country) -> None:
 
 
 @patch.object(AsyncJob, "queue")
-def test_import_areas_from_csv_task_schedules_async_job(mock_queue: Mock) -> None:
+def test_import_areas_from_csv_task_schedules_async_job(mock_queue: Mock, django_capture_on_commit_callbacks) -> None:
     csv_data = "Country,State,country_pcode,state_pcode\nTestland,State1,TL,TL01"
 
-    import_areas_from_csv_async_task(csv_data, delay_mptt_updates=True)
+    with django_capture_on_commit_callbacks(execute=True):
+        import_areas_from_csv_async_task(csv_data, delay_mptt_updates=True)
 
     job = AsyncJob.objects.get()
 

--- a/tests/unit/apps/grievance/test_tasks.py
+++ b/tests/unit/apps/grievance/test_tasks.py
@@ -342,7 +342,8 @@ def test_sensitive_ticket_notified_when_never_notified(mock_notification_cls: Mo
         created_days_ago=2,
     )
 
-    periodic_grievances_notifications_async_task()
+    job = create_async_job("hope.apps.grievance.celery_tasks.periodic_grievances_notifications_async_task_action", {})
+    periodic_grievances_notifications_async_task_action(job)
 
     # Verify called once and check first argument is the ticket
     mock_notification_cls.assert_called_once()
@@ -361,7 +362,8 @@ def test_sensitive_ticket_notified_when_last_sent_overdue(mock_notification_cls:
         last_notification_sent=timezone.now() - timedelta(days=2),
     )
 
-    periodic_grievances_notifications_async_task()
+    job = create_async_job("hope.apps.grievance.celery_tasks.periodic_grievances_notifications_async_task_action", {})
+    periodic_grievances_notifications_async_task_action(job)
 
     # Verify called once and check first argument is the ticket
     mock_notification_cls.assert_called_once()
@@ -378,7 +380,8 @@ def test_sensitive_ticket_skipped_when_email_disabled(mock_notification_cls: Moc
         enable_email=False,
     )
 
-    periodic_grievances_notifications_async_task()
+    job = create_async_job("hope.apps.grievance.celery_tasks.periodic_grievances_notifications_async_task_action", {})
+    periodic_grievances_notifications_async_task_action(job)
 
     mock_notification_cls.return_value.send_email_notification.assert_not_called()
 
@@ -391,7 +394,8 @@ def test_closed_ticket_excluded_from_notifications(mock_notification_cls: Mock) 
         created_days_ago=2,
     )
 
-    periodic_grievances_notifications_async_task()
+    job = create_async_job("hope.apps.grievance.celery_tasks.periodic_grievances_notifications_async_task_action", {})
+    periodic_grievances_notifications_async_task_action(job)
 
     mock_notification_cls.return_value.send_email_notification.assert_not_called()
 
@@ -403,7 +407,8 @@ def test_other_ticket_notified_when_overdue(mock_notification_cls: Mock) -> None
         created_days_ago=31,
     )
 
-    periodic_grievances_notifications_async_task()
+    job = create_async_job("hope.apps.grievance.celery_tasks.periodic_grievances_notifications_async_task_action", {})
+    periodic_grievances_notifications_async_task_action(job)
 
     # Verify called once and check first argument is the ticket
     mock_notification_cls.assert_called_once()
@@ -421,7 +426,8 @@ def test_sensitive_ticket_excluded_from_other_notifications(mock_notification_cl
         created_days_ago=31,
     )
 
-    periodic_grievances_notifications_async_task()
+    job = create_async_job("hope.apps.grievance.celery_tasks.periodic_grievances_notifications_async_task_action", {})
+    periodic_grievances_notifications_async_task_action(job)
 
     # Sensitive ticket 31 days old matches 1-day threshold → ACTION_SENSITIVE_REMINDER only
     # Verify called once and check first argument is the ticket

--- a/tests/unit/apps/grievance/test_tasks.py
+++ b/tests/unit/apps/grievance/test_tasks.py
@@ -161,7 +161,7 @@ def test_execute_non_postponed_with_screening(
 
 @patch.object(AsyncJob, "queue")
 def test_deduplicate_and_check_sanctions_single_individual_task_schedules_async_job(
-    mock_queue: Mock, task_context: dict[str, Any]
+    mock_queue: Mock, task_context: dict[str, Any], django_capture_on_commit_callbacks
 ) -> None:
     individual = task_context["individual"]
 
@@ -169,7 +169,8 @@ def test_deduplicate_and_check_sanctions_single_individual_task_schedules_async_
         deduplicate_and_check_against_sanctions_list_task_single_individual_async_task,
     )
 
-    deduplicate_and_check_against_sanctions_list_task_single_individual_async_task(True, individual)
+    with django_capture_on_commit_callbacks(execute=True):
+        deduplicate_and_check_against_sanctions_list_task_single_individual_async_task(True, individual)
 
     job = AsyncJob.objects.get()
 
@@ -222,8 +223,11 @@ def test_deduplicate_and_check_sanctions_single_individual_action_failure_rerais
 
 
 @patch.object(AsyncJob, "queue")
-def test_periodic_grievances_notifications_schedules_async_job(mock_queue: Mock) -> None:
-    periodic_grievances_notifications_async_task()
+def test_periodic_grievances_notifications_schedules_async_job(
+    mock_queue: Mock, django_capture_on_commit_callbacks
+) -> None:
+    with django_capture_on_commit_callbacks(execute=True):
+        periodic_grievances_notifications_async_task()
 
     job = AsyncJob.objects.get()
 

--- a/tests/unit/apps/household/test_household_admin.py
+++ b/tests/unit/apps/household/test_household_admin.py
@@ -155,21 +155,10 @@ def test_households_withdraw_from_list(
     households_context,
     post_request,
     mixin_mocks,
-    django_assert_num_queries,
 ) -> None:
     program = households_context["program"]
     household = households_context["household"]
     household2 = households_context["household2"]
-    household_other_program = households_context["household_other_program"]
-    individual = households_context["individual"]
-    individuals2 = households_context["individuals2"]
-    individual_other_program = households_context["individual_other_program"]
-    document = households_context["document"]
-    grievance_ticket = households_context["grievance_ticket"]
-    grievance_ticket2 = households_context["grievance_ticket2"]
-    grievance_ticket_household2 = households_context["grievance_ticket_household2"]
-    ticket_complaint_details = households_context["ticket_complaint_details"]
-    ticket_individual_data_update = households_context["ticket_individual_data_update"]
 
     tag = "Some tag reason"
     post_request.POST = {  # type: ignore
@@ -180,69 +169,15 @@ def test_households_withdraw_from_list(
         "business_area": program.business_area,
     }
 
-    with patch("hope.admin.household.increment_grievance_ticket_version_cache_for_ticket_ids") as mocked_increment:
-        with django_assert_num_queries(26):
-            HouseholdWithdrawFromListMixin().withdraw_households_from_list(request=post_request)
+    with patch("hope.admin.household.mass_withdraw_households_from_list_async_task") as mock_task:
+        response = HouseholdWithdrawFromListMixin().withdraw_households_from_list(request=post_request)
 
-    mocked_increment.assert_called_once()
-    assert mocked_increment.call_args.args[0] == program.business_area.slug
-    assert set(mocked_increment.call_args.args[1]) == {
-        grievance_ticket.id,
-        grievance_ticket2.id,
-        grievance_ticket_household2.id,
-    }
-
-    household.refresh_from_db()
-    household_other_program.refresh_from_db()
-    household2.refresh_from_db()
-    individual_other_program.refresh_from_db()
-    individual.refresh_from_db()
-    individuals2[0].refresh_from_db()
-    individuals2[1].refresh_from_db()
-    document.refresh_from_db()
-    grievance_ticket.refresh_from_db()
-    grievance_ticket2.refresh_from_db()
-    grievance_ticket_household2.refresh_from_db()
-
-    assert household.withdrawn is True
-    assert household.withdrawn_date is not None
-    assert household.internal_data["withdrawn_tag"] == tag
-    assert individual.withdrawn is True
-    assert individual.withdrawn_date is not None
-    assert document.status == Document.STATUS_INVALID
-    assert grievance_ticket.status == GrievanceTicket.STATUS_CLOSED
-    assert grievance_ticket.extras["status_before_withdrawn"] == str(GrievanceTicket.STATUS_IN_PROGRESS)
-    assert grievance_ticket2.status == GrievanceTicket.STATUS_CLOSED
-    assert grievance_ticket2.extras["status_before_withdrawn"] == str(GrievanceTicket.STATUS_IN_PROGRESS)
-
-    assert household2.withdrawn is True
-    assert household2.withdrawn_date is not None
-    assert household2.internal_data["withdrawn_tag"] == tag
-    assert individuals2[0].withdrawn is True
-    assert individuals2[0].withdrawn_date is not None
-    assert individuals2[1].withdrawn is True
-    assert individuals2[1].withdrawn_date is not None
-    assert grievance_ticket_household2.status == GrievanceTicket.STATUS_CLOSED
-    assert grievance_ticket_household2.extras["status_before_withdrawn"] == str(GrievanceTicket.STATUS_IN_PROGRESS)
-
-    assert household_other_program.withdrawn is False
-    assert individual_other_program.withdrawn is False
-
-    service = HouseholdWithdraw(household)
-    service.unwithdraw()
-    service.change_tickets_status([ticket_complaint_details, ticket_individual_data_update])
-    household.refresh_from_db()
-    individual.refresh_from_db()
-    grievance_ticket.refresh_from_db()
-    grievance_ticket2.refresh_from_db()
-    assert household.withdrawn is False
-    assert household.withdrawn_date is None
-    assert individual.withdrawn is False
-    assert individual.withdrawn_date is None
-    assert grievance_ticket.status == GrievanceTicket.STATUS_IN_PROGRESS
-    assert grievance_ticket.extras.get("status_before_withdrawn") == ""
-    assert grievance_ticket2.status == GrievanceTicket.STATUS_IN_PROGRESS
-    assert grievance_ticket2.extras.get("status_before_withdrawn") == ""
+    assert response.status_code == 302
+    mock_task.assert_called_once_with(
+        [household.unicef_id, household2.unicef_id],
+        tag,
+        program,
+    )
 
 
 def test_split_list_of_ids() -> None:
@@ -365,6 +300,87 @@ def test_mass_withdraw_from_list_bulk_invalidates_cache(households_context) -> N
 
     assert new_hh_version > initial_hh_version
     assert new_ind_version > initial_ind_version
+
+
+def test_mass_withdraw_from_list_bulk_updates_related_objects(
+    households_context,
+    django_capture_on_commit_callbacks,
+) -> None:
+    program = households_context["program"]
+    household = households_context["household"]
+    household2 = households_context["household2"]
+    household_other_program = households_context["household_other_program"]
+    individual = households_context["individual"]
+    individuals2 = households_context["individuals2"]
+    individual_other_program = households_context["individual_other_program"]
+    document = households_context["document"]
+    grievance_ticket = households_context["grievance_ticket"]
+    grievance_ticket2 = households_context["grievance_ticket2"]
+    grievance_ticket_household2 = households_context["grievance_ticket_household2"]
+    ticket_complaint_details = households_context["ticket_complaint_details"]
+    ticket_individual_data_update = households_context["ticket_individual_data_update"]
+
+    tag = "Some tag reason"
+
+    with django_capture_on_commit_callbacks(execute=True):
+        HouseholdWithdrawFromListMixin().mass_withdraw_households_from_list_bulk(
+            [household.unicef_id, household2.unicef_id],
+            tag,
+            program,
+        )
+
+    household.refresh_from_db()
+    household_other_program.refresh_from_db()
+    household2.refresh_from_db()
+    individual_other_program.refresh_from_db()
+    individual.refresh_from_db()
+    individuals2[0].refresh_from_db()
+    individuals2[1].refresh_from_db()
+    document.refresh_from_db()
+    grievance_ticket.refresh_from_db()
+    grievance_ticket2.refresh_from_db()
+    grievance_ticket_household2.refresh_from_db()
+
+    assert household.withdrawn is True
+    assert household.withdrawn_date is not None
+    assert household.internal_data["withdrawn_tag"] == tag
+    assert individual.withdrawn is True
+    assert individual.withdrawn_date is not None
+    assert document.status == Document.STATUS_INVALID
+    assert grievance_ticket.status == GrievanceTicket.STATUS_CLOSED
+    assert grievance_ticket.extras["status_before_withdrawn"] == str(GrievanceTicket.STATUS_IN_PROGRESS)
+    assert grievance_ticket2.status == GrievanceTicket.STATUS_CLOSED
+    assert grievance_ticket2.extras["status_before_withdrawn"] == str(GrievanceTicket.STATUS_IN_PROGRESS)
+
+    assert household2.withdrawn is True
+    assert household2.withdrawn_date is not None
+    assert household2.internal_data["withdrawn_tag"] == tag
+    assert individuals2[0].withdrawn is True
+    assert individuals2[0].withdrawn_date is not None
+    assert individuals2[1].withdrawn is True
+    assert individuals2[1].withdrawn_date is not None
+    assert grievance_ticket_household2.status == GrievanceTicket.STATUS_CLOSED
+    assert grievance_ticket_household2.extras["status_before_withdrawn"] == str(GrievanceTicket.STATUS_IN_PROGRESS)
+
+    assert household_other_program.withdrawn is False
+    assert individual_other_program.withdrawn is False
+
+    service = HouseholdWithdraw(household)
+    service.unwithdraw()
+    service.change_tickets_status([ticket_complaint_details, ticket_individual_data_update])
+    household.refresh_from_db()
+    individual.refresh_from_db()
+    grievance_ticket.refresh_from_db()
+    grievance_ticket2.refresh_from_db()
+
+    assert household.withdrawn is False
+    assert household.withdrawn_date is None
+    assert individual.withdrawn is False
+    assert individual.withdrawn_date is None
+    assert grievance_ticket.status == GrievanceTicket.STATUS_IN_PROGRESS
+    assert grievance_ticket.extras.get("status_before_withdrawn") == ""
+    assert grievance_ticket2.status == GrievanceTicket.STATUS_IN_PROGRESS
+    assert grievance_ticket2.extras.get("status_before_withdrawn") == ""
 
 
 # ── mass_withdraw / mass_unwithdraw action tests ──────────────────────────

--- a/tests/unit/apps/household/test_tasks.py
+++ b/tests/unit/apps/household/test_tasks.py
@@ -258,13 +258,16 @@ def test_cleanup_inactive_program_indexes_task_multiple_programs(delete_mock):
 
 
 @patch.object(AsyncJob, "queue")
-def test_enroll_households_to_program_task_schedules_async_job(mock_queue, user, program_target):
+def test_enroll_households_to_program_task_schedules_async_job(
+    mock_queue, user, program_target, django_capture_on_commit_callbacks
+):
     hh_id = uuid.uuid4()
-    enroll_households_to_program_async_task(
-        households_ids=[hh_id],
-        program_for_enroll_id=str(program_target.id),
-        user_id=str(user.pk),
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        enroll_households_to_program_async_task(
+            households_ids=[hh_id],
+            program_for_enroll_id=str(program_target.id),
+            user_id=str(user.pk),
+        )
 
     job = AsyncJob.objects.get()
 
@@ -285,8 +288,9 @@ def test_enroll_households_to_program_task_schedules_async_job(mock_queue, user,
 
 
 @patch.object(AsyncJob, "queue")
-def test_cleanup_inactive_program_indexes_task_schedules_async_job(mock_queue):
-    cleanup_indexes_in_inactive_programs_async_task()
+def test_cleanup_inactive_program_indexes_task_schedules_async_job(mock_queue, django_capture_on_commit_callbacks):
+    with django_capture_on_commit_callbacks(execute=True):
+        cleanup_indexes_in_inactive_programs_async_task()
 
     job = AsyncJob.objects.get()
 
@@ -300,8 +304,9 @@ def test_cleanup_inactive_program_indexes_task_schedules_async_job(mock_queue):
 
 
 @patch.object(AsyncJob, "queue")
-def test_recalculate_population_fields_chunk_task_schedules_async_job(mock_queue):
-    recalculate_population_fields_chunk_async_task(households_ids=["hh-1"], program_id=None)
+def test_recalculate_population_fields_chunk_task_schedules_async_job(mock_queue, django_capture_on_commit_callbacks):
+    with django_capture_on_commit_callbacks(execute=True):
+        recalculate_population_fields_chunk_async_task(households_ids=["hh-1"], program_id=None)
 
     job = AsyncJob.objects.get()
 
@@ -314,8 +319,9 @@ def test_recalculate_population_fields_chunk_task_schedules_async_job(mock_queue
 
 
 @patch.object(AsyncJob, "queue")
-def test_recalculate_population_fields_task_schedules_async_job(mock_queue):
-    recalculate_population_fields_async_task(household_ids=["hh-1"], program_id=None)
+def test_recalculate_population_fields_task_schedules_async_job(mock_queue, django_capture_on_commit_callbacks):
+    with django_capture_on_commit_callbacks(execute=True):
+        recalculate_population_fields_async_task(household_ids=["hh-1"], program_id=None)
 
     job = AsyncJob.objects.get()
 
@@ -328,8 +334,11 @@ def test_recalculate_population_fields_task_schedules_async_job(mock_queue):
 
 
 @patch.object(AsyncJob, "queue")
-def test_interval_recalculate_population_fields_task_schedules_async_job(mock_queue):
-    interval_recalculate_population_fields_async_task()
+def test_interval_recalculate_population_fields_task_schedules_async_job(
+    mock_queue, django_capture_on_commit_callbacks
+):
+    with django_capture_on_commit_callbacks(execute=True):
+        interval_recalculate_population_fields_async_task()
 
     job = AsyncJob.objects.get()
 
@@ -342,9 +351,10 @@ def test_interval_recalculate_population_fields_task_schedules_async_job(mock_qu
 
 
 @patch.object(AsyncJob, "queue")
-def test_revalidate_phone_number_task_schedules_async_job(mock_queue):
+def test_revalidate_phone_number_task_schedules_async_job(mock_queue, django_capture_on_commit_callbacks):
     individual_id = uuid.uuid4()
-    revalidate_phone_number_async_task(individual_ids=[individual_id])
+    with django_capture_on_commit_callbacks(execute=True):
+        revalidate_phone_number_async_task(individual_ids=[individual_id])
 
     job = AsyncJob.objects.get()
 
@@ -377,10 +387,13 @@ def test_revalidate_phone_number_task_action_updates_individuals(
 
 
 @patch.object(AsyncJob, "queue")
-def test_mass_withdraw_households_from_list_task_schedules_async_job(mock_queue, program_source):
-    mass_withdraw_households_from_list_async_task(
-        household_id_list=["hh-1"], tag="tag-1", program_id=str(program_source.id)
-    )
+def test_mass_withdraw_households_from_list_task_schedules_async_job(
+    mock_queue, program_source, django_capture_on_commit_callbacks
+):
+    with django_capture_on_commit_callbacks(execute=True):
+        mass_withdraw_households_from_list_async_task(
+            household_id_list=["hh-1"], tag="tag-1", program_id=str(program_source.id)
+        )
 
     job = AsyncJob.objects.get()
 
@@ -414,8 +427,11 @@ def test_mass_withdraw_households_from_list_task_action_success(mock_withdraw_mi
 
 
 @patch.object(AsyncJob, "queue")
-def test_calculate_children_fields_for_not_collected_individual_data_schedules_async_job(mock_queue):
-    calculate_children_fields_for_not_collected_individual_data_async_task()
+def test_calculate_children_fields_for_not_collected_individual_data_schedules_async_job(
+    mock_queue, django_capture_on_commit_callbacks
+):
+    with django_capture_on_commit_callbacks(execute=True):
+        calculate_children_fields_for_not_collected_individual_data_async_task()
 
     job = AsyncJob.objects.get()
 

--- a/tests/unit/apps/payment/test_payment_celery_tasks.py
+++ b/tests/unit/apps/payment/test_payment_celery_tasks.py
@@ -225,13 +225,15 @@ def test_payment_plan_async_job_factories_attach_jobs_to_payment_plan(
     job_model: type[AsyncJob] | type[AsyncRetryJob],
     args_builder: Any,
     expected_job_name: str,
+    django_capture_on_commit_callbacks,
 ) -> None:
     payment_plan = PaymentPlanFactory()
     user = UserFactory()
     rule = RuleFactory()
 
     with patch("django_celery_boost.models.CeleryTaskModel.queue", autospec=True) as mock_queue:
-        task(*args_builder(payment_plan, user, rule))
+        with django_capture_on_commit_callbacks(execute=True):
+            task(*args_builder(payment_plan, user, rule))
 
     job = job_model.objects.latest("pk")
     assert job.content_object == payment_plan
@@ -779,9 +781,10 @@ def test_create_payment_plan_payment_list_xlsx_per_fsp_action_skips_emails_when_
     mock_service.send_email_with_passwords.assert_not_called()
 
 
-def test_get_sync_run_rapid_pro_task_queues_retry_job() -> None:
+def test_get_sync_run_rapid_pro_task_queues_retry_job(django_capture_on_commit_callbacks) -> None:
     with patch("hope.apps.payment.celery_tasks.AsyncRetryJob.queue", autospec=True) as mock_queue:
-        get_sync_run_rapid_pro_async_task()
+        with django_capture_on_commit_callbacks(execute=True):
+            get_sync_run_rapid_pro_async_task()
 
     job = AsyncRetryJob.objects.latest("pk")
     assert job.type == AsyncJobModel.JobType.JOB_TASK
@@ -1454,12 +1457,13 @@ def test_export_pdf_payment_plan_summary_action_replaces_existing_file_and_sends
     mock_send_email.assert_called_once()
 
 
-def test_export_pdf_payment_plan_summary_queues_retry_job() -> None:
+def test_export_pdf_payment_plan_summary_queues_retry_job(django_capture_on_commit_callbacks) -> None:
     payment_plan = PaymentPlanFactory()
     user = UserFactory()
 
     with patch("hope.apps.payment.celery_tasks.AsyncRetryJob.queue", autospec=True) as mock_queue:
-        export_pdf_payment_plan_summary_async_task(payment_plan, str(user.pk))
+        with django_capture_on_commit_callbacks(execute=True):
+            export_pdf_payment_plan_summary_async_task(payment_plan, str(user.pk))
 
     job = AsyncRetryJob.objects.latest("pk")
     assert job.type == AsyncJobModel.JobType.JOB_TASK
@@ -1680,12 +1684,13 @@ def test_send_to_payment_gateway_queues_async_job() -> None:
     assert job.description == f"Send payment plan {payment_plan.pk} to payment gateway"
 
 
-def test_create_payment_verification_plan_xlsx_queues_retry_job() -> None:
+def test_create_payment_verification_plan_xlsx_queues_retry_job(django_capture_on_commit_callbacks) -> None:
     payment_verification_plan = PaymentVerificationPlanFactory()
     user = UserFactory()
 
     with patch("hope.apps.payment.celery_tasks.AsyncRetryJob.queue", autospec=True) as mock_queue:
-        create_payment_verification_plan_xlsx_async_task(payment_verification_plan, str(user.pk))
+        with django_capture_on_commit_callbacks(execute=True):
+            create_payment_verification_plan_xlsx_async_task(payment_verification_plan, str(user.pk))
 
     job = AsyncRetryJob.objects.latest("pk")
     assert job.type == AsyncJobModel.JobType.JOB_TASK
@@ -1735,9 +1740,10 @@ def test_periodic_sync_payment_gateway_fsp_action_returns_on_missing_credentials
     assert periodic_sync_payment_gateway_fsp_async_task_action() is None
 
 
-def test_periodic_sync_payment_gateway_fsp_queues_retry_job() -> None:
+def test_periodic_sync_payment_gateway_fsp_queues_retry_job(django_capture_on_commit_callbacks) -> None:
     with patch("hope.apps.payment.celery_tasks.AsyncRetryJob.queue", autospec=True) as mock_queue:
-        periodic_sync_payment_gateway_fsp_async_task()
+        with django_capture_on_commit_callbacks(execute=True):
+            periodic_sync_payment_gateway_fsp_async_task()
 
     job = AsyncRetryJob.objects.latest("pk")
     assert job.type == AsyncJobModel.JobType.JOB_TASK
@@ -1766,9 +1772,12 @@ def test_periodic_sync_payment_gateway_account_types_action_returns_on_missing_c
     assert periodic_sync_payment_gateway_account_types_async_task_action() is None
 
 
-def test_periodic_sync_payment_gateway_account_types_queues_retry_job() -> None:
+def test_periodic_sync_payment_gateway_account_types_queues_retry_job(
+    django_capture_on_commit_callbacks,
+) -> None:
     with patch("hope.apps.payment.celery_tasks.AsyncRetryJob.queue", autospec=True) as mock_queue:
-        periodic_sync_payment_gateway_account_types_async_task()
+        with django_capture_on_commit_callbacks(execute=True):
+            periodic_sync_payment_gateway_account_types_async_task()
 
     job = AsyncRetryJob.objects.latest("pk")
     assert job.type == AsyncJobModel.JobType.JOB_TASK
@@ -1786,9 +1795,10 @@ def test_periodic_sync_payment_gateway_records_action_runs_service(mock_service_
     mock_service_cls.return_value.sync_records.assert_called_once()
 
 
-def test_periodic_sync_payment_gateway_records_queues_retry_job() -> None:
+def test_periodic_sync_payment_gateway_records_queues_retry_job(django_capture_on_commit_callbacks) -> None:
     with patch("hope.apps.payment.celery_tasks.AsyncRetryJob.queue", autospec=True) as mock_queue:
-        periodic_sync_payment_gateway_records_async_task()
+        with django_capture_on_commit_callbacks(execute=True):
+            periodic_sync_payment_gateway_records_async_task()
 
     job = AsyncRetryJob.objects.latest("pk")
     assert job.type == AsyncJobModel.JobType.JOB_TASK

--- a/tests/unit/apps/payment/test_payment_plan_actions_views.py
+++ b/tests/unit/apps/payment/test_payment_plan_actions_views.py
@@ -674,6 +674,7 @@ def test_pp_entitlement_export_xlsx(
     permissions: list,
     expected_status: int,
     create_user_role_with_permissions: Any,
+    django_capture_on_commit_callbacks: Any,
 ) -> None:
     create_user_role_with_permissions(
         payment_plan_actions_context["user"],
@@ -684,7 +685,10 @@ def test_pp_entitlement_export_xlsx(
     payment_plan_actions_context["pp"].status = PaymentPlan.Status.LOCKED
     payment_plan_actions_context["pp"].save()
 
-    response = payment_plan_actions_context["client"].get(payment_plan_actions_context["url_export_entitlement_xlsx"])
+    with django_capture_on_commit_callbacks(execute=True):
+        response = payment_plan_actions_context["client"].get(
+            payment_plan_actions_context["url_export_entitlement_xlsx"]
+        )
     assert response.status_code == expected_status
     if expected_status == status.HTTP_200_OK:
         payment_plan_actions_context["pp"].refresh_from_db()

--- a/tests/unit/apps/payment/test_payment_plan_services.py
+++ b/tests/unit/apps/payment/test_payment_plan_services.py
@@ -336,6 +336,7 @@ def test_create(
     dm_transfer_to_account: Any,
     account_type_bank: AccountType,
     django_assert_num_queries: Any,
+    django_capture_on_commit_callbacks: Any,
 ) -> None:
     program = ProgramFactory(
         status=Program.ACTIVE,
@@ -396,7 +397,8 @@ def test_create(
     assert pp.total_individuals_count == 0
     assert pp.payment_items.count() == 0
 
-    prepare_payment_plan_async_task(pp)
+    with django_capture_on_commit_callbacks(execute=True):
+        prepare_payment_plan_async_task(pp)
 
     pp.refresh_from_db()
     assert pp.status == PaymentPlan.Status.TP_OPEN
@@ -867,6 +869,7 @@ def test_full_rebuild(
     user: User,
     business_area: Any,
     django_assert_num_queries: Any,
+    django_capture_on_commit_callbacks: Any,
 ) -> None:
     program = ProgramFactory(
         status=Program.ACTIVE,
@@ -915,7 +918,8 @@ def test_full_rebuild(
     assert pp.total_individuals_count == 0
     assert pp.payment_items.count() == 0
 
-    prepare_payment_plan_async_task(pp)
+    with django_capture_on_commit_callbacks(execute=True):
+        prepare_payment_plan_async_task(pp)
 
     pp.refresh_from_db()
     assert pp.status == PaymentPlan.Status.TP_OPEN
@@ -1397,12 +1401,13 @@ def test_update_pp_dm_fsp(
     assert payment_plan.financial_service_provider == fsp
 
 
-def test_export_xlsx(payment_plan_base: PaymentPlan, user) -> None:
+def test_export_xlsx(payment_plan_base: PaymentPlan, user: User, django_capture_on_commit_callbacks: Any) -> None:
     payment_plan_base.status = PaymentPlan.Status.LOCKED
     payment_plan_base.save()
     assert FileTemp.objects.all().count() == 0
 
-    PaymentPlanService(payment_plan_base).export_xlsx(str(user.pk))
+    with django_capture_on_commit_callbacks(execute=True):
+        PaymentPlanService(payment_plan_base).export_xlsx(str(user.pk))
 
     assert FileTemp.objects.all().count() == 1
     assert FileTemp.objects.first().object_id == str(payment_plan_base.pk)

--- a/tests/unit/apps/payment/test_payment_plan_services.py
+++ b/tests/unit/apps/payment/test_payment_plan_services.py
@@ -540,7 +540,7 @@ def test_create_follow_up_pp(
 
     assert pp.follow_ups.count() == 2
 
-    with django_assert_num_queries(59):
+    with django_assert_num_queries(61):
         with django_capture_on_commit_callbacks(execute=True):
             prepare_follow_up_payment_plan_async_task(follow_up_pp_2)
 

--- a/tests/unit/apps/payment/test_payment_plan_services.py
+++ b/tests/unit/apps/payment/test_payment_plan_services.py
@@ -440,6 +440,7 @@ def test_create_follow_up_pp(
     business_area: Any,
     cycle: ProgramCycle,
     django_assert_num_queries: Any,
+    django_capture_on_commit_callbacks: Any,
 ) -> None:
     pp = PaymentPlanFactory(
         total_households_count=1,
@@ -505,7 +506,8 @@ def test_create_follow_up_pp(
 
     assert pp.follow_ups.count() == 1
 
-    prepare_follow_up_payment_plan_async_task(follow_up_pp)
+    with django_capture_on_commit_callbacks(execute=True):
+        prepare_follow_up_payment_plan_async_task(follow_up_pp)
     follow_up_pp.refresh_from_db()
 
     assert follow_up_pp.status == PaymentPlan.Status.OPEN
@@ -539,7 +541,8 @@ def test_create_follow_up_pp(
     assert pp.follow_ups.count() == 2
 
     with django_assert_num_queries(59):
-        prepare_follow_up_payment_plan_async_task(follow_up_pp_2)
+        with django_capture_on_commit_callbacks(execute=True):
+            prepare_follow_up_payment_plan_async_task(follow_up_pp_2)
 
     assert follow_up_pp_2.payment_items.count() == 1
     assert {follow_up_payment.source_payment.id} == set(
@@ -1112,7 +1115,9 @@ def test_update_pp_validation_errors(user: User, business_area: Any, cycle: Prog
     assert error.value.detail[0] == "Not possible to assign Finished Program Cycle"
 
 
-def test_rebuild_payment_plan_population(user: User, business_area: Any, cycle: ProgramCycle) -> None:
+def test_rebuild_payment_plan_population(
+    user: User, business_area: Any, cycle: ProgramCycle, django_capture_on_commit_callbacks: Any
+) -> None:
     pp = PaymentPlanFactory(
         name="test_data",
         program_cycle=cycle,
@@ -1121,24 +1126,25 @@ def test_rebuild_payment_plan_population(user: User, business_area: Any, cycle: 
         status=PaymentPlan.Status.TP_OPEN,
     )
 
-    PaymentPlanService.rebuild_payment_plan_population(
-        rebuild_list=False,
-        should_update_money_stats=True,
-        vulnerability_filter=False,
-        payment_plan=pp,
-    )
-    PaymentPlanService.rebuild_payment_plan_population(
-        rebuild_list=True,
-        should_update_money_stats=False,
-        vulnerability_filter=False,
-        payment_plan=pp,
-    )
-    PaymentPlanService.rebuild_payment_plan_population(
-        rebuild_list=False,
-        should_update_money_stats=False,
-        vulnerability_filter=True,
-        payment_plan=pp,
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        PaymentPlanService.rebuild_payment_plan_population(
+            rebuild_list=False,
+            should_update_money_stats=True,
+            vulnerability_filter=False,
+            payment_plan=pp,
+        )
+        PaymentPlanService.rebuild_payment_plan_population(
+            rebuild_list=True,
+            should_update_money_stats=False,
+            vulnerability_filter=False,
+            payment_plan=pp,
+        )
+        PaymentPlanService.rebuild_payment_plan_population(
+            rebuild_list=False,
+            should_update_money_stats=False,
+            vulnerability_filter=True,
+            payment_plan=pp,
+        )
 
     pp.refresh_from_db(fields=("build_status",))
     assert pp.build_status == PaymentPlan.BuildStatus.BUILD_STATUS_OK

--- a/tests/unit/apps/payment/test_payment_signature.py
+++ b/tests/unit/apps/payment/test_payment_signature.py
@@ -141,6 +141,7 @@ def test_signature_after_prepare_payment_plan(
     user: Any,
     program: Program,
     program_cycle: Any,
+    django_capture_on_commit_callbacks: Any,
 ) -> None:
     DeliveryMechanismFactory(code="cash", name="Cash")
     fsp = FinancialServiceProviderFactory()
@@ -207,7 +208,8 @@ def test_signature_after_prepare_payment_plan(
     pp.refresh_from_db()
     assert pp.build_status == PaymentPlan.BuildStatus.BUILD_STATUS_PENDING
 
-    prepare_payment_plan_async_task(pp)
+    with django_capture_on_commit_callbacks(execute=True):
+        prepare_payment_plan_async_task(pp)
     pp.refresh_from_db()
 
     assert pp.build_status == PaymentPlan.BuildStatus.BUILD_STATUS_OK

--- a/tests/unit/apps/periodic_data_update/test_celery_tasks.py
+++ b/tests/unit/apps/periodic_data_update/test_celery_tasks.py
@@ -16,11 +16,12 @@ from hope.models import AsyncJob, AsyncRetryJob, PDUOnlineEdit
 pytestmark = pytest.mark.django_db
 
 
-def test_import_periodic_data_update_queues_async_job() -> None:
+def test_import_periodic_data_update_queues_async_job(django_capture_on_commit_callbacks) -> None:
     upload = PDUXlsxUploadFactory()
 
     with patch("hope.apps.periodic_data_update.celery_tasks.AsyncRetryJob.queue", autospec=True) as mock_queue:
-        import_periodic_data_update_async_task(upload)
+        with django_capture_on_commit_callbacks(execute=True):
+            import_periodic_data_update_async_task(upload)
 
     job = AsyncJob.objects.latest("pk")
     assert job.content_object == upload
@@ -31,11 +32,14 @@ def test_import_periodic_data_update_queues_async_job() -> None:
     mock_queue.assert_called_once_with(job)
 
 
-def test_export_periodic_data_update_export_template_service_queues_async_job() -> None:
+def test_export_periodic_data_update_export_template_service_queues_async_job(
+    django_capture_on_commit_callbacks,
+) -> None:
     template = PDUXlsxTemplateFactory()
 
     with patch("hope.apps.periodic_data_update.celery_tasks.AsyncRetryJob.queue", autospec=True) as mock_queue:
-        export_periodic_data_update_export_template_service_async_task(template)
+        with django_capture_on_commit_callbacks(execute=True):
+            export_periodic_data_update_export_template_service_async_task(template)
 
     job = AsyncJob.objects.latest("pk")
     assert job.content_object == template
@@ -49,13 +53,14 @@ def test_export_periodic_data_update_export_template_service_queues_async_job() 
     mock_queue.assert_called_once_with(job)
 
 
-def test_generate_pdu_online_edit_data_task_queues_async_job() -> None:
+def test_generate_pdu_online_edit_data_task_queues_async_job(django_capture_on_commit_callbacks) -> None:
     online_edit = PDUOnlineEditFactory()
     filters = {"field": "value"}
     rounds_data = [{"round": 1}]
 
     with patch("hope.apps.periodic_data_update.celery_tasks.AsyncRetryJob.queue", autospec=True) as mock_queue:
-        generate_pdu_online_edit_data_async_task(online_edit, filters, rounds_data)
+        with django_capture_on_commit_callbacks(execute=True):
+            generate_pdu_online_edit_data_async_task(online_edit, filters, rounds_data)
 
     job = AsyncJob.objects.latest("pk")
     assert job.content_object == online_edit
@@ -70,11 +75,12 @@ def test_generate_pdu_online_edit_data_task_queues_async_job() -> None:
     mock_queue.assert_called_once_with(job)
 
 
-def test_merge_pdu_online_edit_task_queues_async_job() -> None:
+def test_merge_pdu_online_edit_task_queues_async_job(django_capture_on_commit_callbacks) -> None:
     online_edit = PDUOnlineEditFactory()
 
     with patch("hope.apps.periodic_data_update.celery_tasks.AsyncRetryJob.queue", autospec=True) as mock_queue:
-        merge_pdu_online_edit_async_task(online_edit)
+        with django_capture_on_commit_callbacks(execute=True):
+            merge_pdu_online_edit_async_task(online_edit)
 
     job = AsyncJob.objects.latest("pk")
     assert job.content_object == online_edit
@@ -85,12 +91,13 @@ def test_merge_pdu_online_edit_task_queues_async_job() -> None:
     mock_queue.assert_called_once_with(job)
 
 
-def test_send_pdu_online_edit_notification_emails_queues_async_job() -> None:
+def test_send_pdu_online_edit_notification_emails_queues_async_job(django_capture_on_commit_callbacks) -> None:
     online_edit = PDUOnlineEditFactory()
     user = UserFactory()
 
     with patch("hope.apps.periodic_data_update.celery_tasks.AsyncRetryJob.queue", autospec=True) as mock_queue:
-        send_pdu_online_edit_notification_emails_async_task(online_edit, "approved", str(user.pk), "2026-03-20")
+        with django_capture_on_commit_callbacks(execute=True):
+            send_pdu_online_edit_notification_emails_async_task(online_edit, "approved", str(user.pk), "2026-03-20")
 
     job = AsyncJob.objects.latest("pk")
     assert job.content_object == online_edit

--- a/tests/unit/apps/periodic_data_update/test_periodic_data_update_online_edit_bulk_merge.py
+++ b/tests/unit/apps/periodic_data_update/test_periodic_data_update_online_edit_bulk_merge.py
@@ -484,6 +484,7 @@ def test_bulk_merge_success(
     pdu_edit_approved_2: PDUOnlineEdit,
     url_bulk_merge: str,
     create_user_role_with_permissions: Callable,
+    django_capture_on_commit_callbacks: Any,
 ) -> None:
     create_user_role_with_permissions(
         user,
@@ -493,7 +494,8 @@ def test_bulk_merge_success(
     )
 
     data = {"ids": [pdu_edit_approved_1.id, pdu_edit_approved_2.id]}
-    response = authenticated_client.post(url_bulk_merge, data=data)
+    with django_capture_on_commit_callbacks(execute=True):
+        response = authenticated_client.post(url_bulk_merge, data=data)
 
     assert response.status_code == status.HTTP_200_OK
     response_json = response.json()
@@ -515,6 +517,7 @@ def test_bulk_merge_single_edit(
     pdu_edit_approved_1: PDUOnlineEdit,
     url_bulk_merge: str,
     create_user_role_with_permissions: Callable,
+    django_capture_on_commit_callbacks: Any,
 ) -> None:
     create_user_role_with_permissions(
         user,
@@ -524,7 +527,8 @@ def test_bulk_merge_single_edit(
     )
 
     data = {"ids": [pdu_edit_approved_1.id]}
-    response = authenticated_client.post(url_bulk_merge, data=data)
+    with django_capture_on_commit_callbacks(execute=True):
+        response = authenticated_client.post(url_bulk_merge, data=data)
 
     assert response.status_code == status.HTTP_200_OK
     response_json = response.json()
@@ -669,6 +673,7 @@ def test_bulk_merge_preserves_other_fields(
     pdu_edit_approved_1: PDUOnlineEdit,
     url_bulk_merge: str,
     create_user_role_with_permissions: Callable,
+    django_capture_on_commit_callbacks: Any,
 ) -> None:
     create_user_role_with_permissions(
         user,
@@ -686,7 +691,8 @@ def test_bulk_merge_preserves_other_fields(
     original_approved_at = pdu_edit_approved_1.approved_at
 
     data = {"ids": [pdu_edit_approved_1.id]}
-    response = authenticated_client.post(url_bulk_merge, data=data)
+    with django_capture_on_commit_callbacks(execute=True):
+        response = authenticated_client.post(url_bulk_merge, data=data)
 
     assert response.status_code == status.HTTP_200_OK
 
@@ -715,6 +721,7 @@ def test_bulk_merge_updates_individual_data_string_and_decimal(
     decimal_attribute: Any,
     url_bulk_merge: str,
     create_user_role_with_permissions: Callable,
+    django_capture_on_commit_callbacks: Any,
 ) -> None:
     create_user_role_with_permissions(
         user,
@@ -730,7 +737,8 @@ def test_bulk_merge_updates_individual_data_string_and_decimal(
 
     # Perform bulk merge
     data = {"ids": [pdu_edit_approved_1.id]}
-    response = authenticated_client.post(url_bulk_merge, data=data)
+    with django_capture_on_commit_callbacks(execute=True):
+        response = authenticated_client.post(url_bulk_merge, data=data)
 
     assert response.status_code == status.HTTP_200_OK
     pdu_edit_approved_1.refresh_from_db()
@@ -755,6 +763,7 @@ def test_bulk_merge_updates_individual_data_boolean_and_date(
     date_attribute: Any,
     url_bulk_merge: str,
     create_user_role_with_permissions: Callable,
+    django_capture_on_commit_callbacks: Any,
 ) -> None:
     create_user_role_with_permissions(
         user,
@@ -770,7 +779,8 @@ def test_bulk_merge_updates_individual_data_boolean_and_date(
 
     # Perform bulk merge
     data = {"ids": [pdu_edit_approved_2.id]}
-    response = authenticated_client.post(url_bulk_merge, data=data)
+    with django_capture_on_commit_callbacks(execute=True):
+        response = authenticated_client.post(url_bulk_merge, data=data)
 
     assert response.status_code == status.HTTP_200_OK
     pdu_edit_approved_2.refresh_from_db()
@@ -799,6 +809,7 @@ def test_bulk_merge_multiple_edits_updates_multiple_individuals(
     date_attribute: Any,
     url_bulk_merge: str,
     create_user_role_with_permissions: Callable,
+    django_capture_on_commit_callbacks: Any,
 ) -> None:
     create_user_role_with_permissions(
         user,
@@ -815,7 +826,8 @@ def test_bulk_merge_multiple_edits_updates_multiple_individuals(
 
     # Perform bulk merge for both edits
     data = {"ids": [pdu_edit_approved_1.id, pdu_edit_approved_2.id]}
-    response = authenticated_client.post(url_bulk_merge, data=data)
+    with django_capture_on_commit_callbacks(execute=True):
+        response = authenticated_client.post(url_bulk_merge, data=data)
 
     assert response.status_code == status.HTTP_200_OK
 
@@ -844,6 +856,7 @@ def test_bulk_merge_with_non_editable_fields_skips_update(
     setup_individuals_with_pdu: None,
     url_bulk_merge: str,
     create_user_role_with_permissions: Callable,
+    django_capture_on_commit_callbacks: Any,
 ) -> None:
     create_user_role_with_permissions(
         user,
@@ -881,7 +894,8 @@ def test_bulk_merge_with_non_editable_fields_skips_update(
 
     # Perform bulk merge
     data = {"ids": [pdu_edit_non_editable.id]}
-    response = authenticated_client.post(url_bulk_merge, data=data)
+    with django_capture_on_commit_callbacks(execute=True):
+        response = authenticated_client.post(url_bulk_merge, data=data)
 
     assert response.status_code == status.HTTP_200_OK
     pdu_edit_non_editable.refresh_from_db()
@@ -903,6 +917,7 @@ def test_bulk_merge_with_existing_data_prevents_overwrite(
     setup_individuals_with_pdu: None,
     url_bulk_merge: str,
     create_user_role_with_permissions: Callable,
+    django_capture_on_commit_callbacks: Any,
 ) -> None:
     # Merge fails when trying to overwrite existing data.
     create_user_role_with_permissions(
@@ -954,7 +969,8 @@ def test_bulk_merge_with_existing_data_prevents_overwrite(
 
     # Attempt to merge edit that would overwrite existing data
     data = {"ids": [pdu_edit.id]}
-    response = authenticated_client.post(url_bulk_merge, data=data)
+    with django_capture_on_commit_callbacks(execute=True):
+        response = authenticated_client.post(url_bulk_merge, data=data)
 
     # Should return 200 (task queued successfully), but the task should fail
     assert response.status_code == status.HTTP_200_OK
@@ -980,6 +996,7 @@ def test_bulk_merge_validate_value_string_invalid(
     setup_individuals_with_pdu: None,
     url_bulk_merge: str,
     create_user_role_with_permissions: Callable,
+    django_capture_on_commit_callbacks: Any,
 ) -> None:
     create_user_role_with_permissions(
         user,
@@ -1010,7 +1027,8 @@ def test_bulk_merge_validate_value_string_invalid(
     )
 
     data = {"ids": [pdu_edit.id]}
-    response = authenticated_client.post(url_bulk_merge, data=data)
+    with django_capture_on_commit_callbacks(execute=True):
+        response = authenticated_client.post(url_bulk_merge, data=data)
     assert response.status_code == status.HTTP_200_OK
 
     pdu_edit.refresh_from_db()
@@ -1027,6 +1045,7 @@ def test_bulk_merge_validate_value_bool_invalid(
     setup_individuals_with_pdu: None,
     url_bulk_merge: str,
     create_user_role_with_permissions: Callable,
+    django_capture_on_commit_callbacks: Any,
 ) -> None:
     create_user_role_with_permissions(
         user,
@@ -1057,7 +1076,8 @@ def test_bulk_merge_validate_value_bool_invalid(
     )
 
     data = {"ids": [pdu_edit.id]}
-    response = authenticated_client.post(url_bulk_merge, data=data)
+    with django_capture_on_commit_callbacks(execute=True):
+        response = authenticated_client.post(url_bulk_merge, data=data)
     assert response.status_code == status.HTTP_200_OK
 
     pdu_edit.refresh_from_db()
@@ -1074,6 +1094,7 @@ def test_bulk_merge_validate_value_decimal_invalid(
     setup_individuals_with_pdu: None,
     url_bulk_merge: str,
     create_user_role_with_permissions: Callable,
+    django_capture_on_commit_callbacks: Any,
 ) -> None:
     create_user_role_with_permissions(
         user,
@@ -1104,7 +1125,8 @@ def test_bulk_merge_validate_value_decimal_invalid(
     )
 
     data = {"ids": [pdu_edit.id]}
-    response = authenticated_client.post(url_bulk_merge, data=data)
+    with django_capture_on_commit_callbacks(execute=True):
+        response = authenticated_client.post(url_bulk_merge, data=data)
     assert response.status_code == status.HTTP_200_OK
 
     pdu_edit.refresh_from_db()
@@ -1121,6 +1143,7 @@ def test_bulk_merge_validate_value_date_invalid(
     setup_individuals_with_pdu: None,
     url_bulk_merge: str,
     create_user_role_with_permissions: Callable,
+    django_capture_on_commit_callbacks: Any,
 ) -> None:
     create_user_role_with_permissions(
         user,
@@ -1151,7 +1174,8 @@ def test_bulk_merge_validate_value_date_invalid(
     )
 
     data = {"ids": [pdu_edit.id]}
-    response = authenticated_client.post(url_bulk_merge, data=data)
+    with django_capture_on_commit_callbacks(execute=True):
+        response = authenticated_client.post(url_bulk_merge, data=data)
     assert response.status_code == status.HTTP_200_OK
 
     pdu_edit.refresh_from_db()

--- a/tests/unit/apps/periodic_data_update/test_periodic_data_update_online_edit_create.py
+++ b/tests/unit/apps/periodic_data_update/test_periodic_data_update_online_edit_create.py
@@ -220,6 +220,7 @@ def test_create_pdu_online_edit_base(
     base_data: dict,
     url_create: str,
     create_user_role_with_permissions: Any,
+    django_capture_on_commit_callbacks: Any,
 ) -> None:
     create_user_role_with_permissions(
         user=user,
@@ -227,7 +228,8 @@ def test_create_pdu_online_edit_base(
         business_area=business_area,
         program=program,
     )
-    response = authenticated_client.post(url_create, data=base_data)
+    with django_capture_on_commit_callbacks(execute=True):
+        response = authenticated_client.post(url_create, data=base_data)
     assert response.status_code == status.HTTP_201_CREATED
 
     assert PDUOnlineEdit.objects.count() == 1
@@ -349,6 +351,7 @@ def test_create_pdu_online_edit_with_name(
     base_data: dict,
     url_create: str,
     create_user_role_with_permissions: Any,
+    django_capture_on_commit_callbacks: Any,
 ) -> None:
     create_user_role_with_permissions(
         user=user,
@@ -361,7 +364,8 @@ def test_create_pdu_online_edit_with_name(
         **base_data,
     }
 
-    response = authenticated_client.post(url_create, data=data)
+    with django_capture_on_commit_callbacks(execute=True):
+        response = authenticated_client.post(url_create, data=data)
     assert response.status_code == status.HTTP_201_CREATED
 
     assert PDUOnlineEdit.objects.count() == 1
@@ -496,6 +500,7 @@ def test_create_pdu_online_edit_field_is_editable_flag(
     pdu_field_health: Any,
     url_create: str,
     create_user_role_with_permissions: Any,
+    django_capture_on_commit_callbacks: Any,
 ) -> None:
     create_user_role_with_permissions(
         user=user,
@@ -527,7 +532,8 @@ def test_create_pdu_online_edit_field_is_editable_flag(
         },
     }
 
-    response = authenticated_client.post(url_create, data=data)
+    with django_capture_on_commit_callbacks(execute=True):
+        response = authenticated_client.post(url_create, data=data)
     assert response.status_code == status.HTTP_201_CREATED
 
     pdu_online_edit = PDUOnlineEdit.objects.first()
@@ -553,6 +559,7 @@ def test_create_pdu_online_edit_with_covered_individual(
     pdu_field_health: Any,
     url_create: str,
     create_user_role_with_permissions: Any,
+    django_capture_on_commit_callbacks: Any,
 ) -> None:
     create_user_role_with_permissions(
         user=user,
@@ -578,7 +585,8 @@ def test_create_pdu_online_edit_with_covered_individual(
         },
     }
 
-    response = authenticated_client.post(url_create, data=data)
+    with django_capture_on_commit_callbacks(execute=True):
+        response = authenticated_client.post(url_create, data=data)
     assert response.status_code == status.HTTP_201_CREATED
 
     pdu_online_edit = PDUOnlineEdit.objects.first()

--- a/tests/unit/apps/periodic_data_update/test_periodic_data_update_xlsx_template_views.py
+++ b/tests/unit/apps/periodic_data_update/test_periodic_data_update_xlsx_template_views.py
@@ -607,6 +607,7 @@ def test_create_periodic_data_update_template(
     pdu_field_health: Any,
     url_create_pdu_template_program1: str,
     create_user_role_with_permissions: Callable,
+    django_capture_on_commit_callbacks: Any,
 ) -> None:
     create_user_role_with_permissions(
         user,
@@ -644,7 +645,8 @@ def test_create_periodic_data_update_template(
             "number_of_records": 0,
         },
     ]
-    response = authenticated_client.post(url_create_pdu_template_program1, data=data)
+    with django_capture_on_commit_callbacks(execute=True):
+        response = authenticated_client.post(url_create_pdu_template_program1, data=data)
     assert response.status_code == status.HTTP_201_CREATED
 
     response_json = response.json()
@@ -764,6 +766,7 @@ def test_export_periodic_data_update_template(
     pdu_template1: PDUXlsxTemplate,
     url_export_pdu_template_program1: str,
     create_user_role_with_permissions: Callable,
+    django_capture_on_commit_callbacks: Any,
 ) -> None:
     create_user_role_with_permissions(
         user,
@@ -776,7 +779,8 @@ def test_export_periodic_data_update_template(
     pdu_template1.file = None
     pdu_template1.save()
 
-    response = authenticated_client.post(url_export_pdu_template_program1)
+    with django_capture_on_commit_callbacks(execute=True):
+        response = authenticated_client.post(url_export_pdu_template_program1)
     assert response.status_code == status.HTTP_200_OK
 
     pdu_template1.refresh_from_db()

--- a/tests/unit/apps/periodic_data_update/test_periodic_data_update_xlsx_upload_views.py
+++ b/tests/unit/apps/periodic_data_update/test_periodic_data_update_xlsx_upload_views.py
@@ -391,6 +391,7 @@ def test_upload_periodic_data_update_upload(
     program1: Program,
     url_upload: str,
     create_user_role_with_permissions: Callable,
+    django_capture_on_commit_callbacks: Any,
 ) -> None:
     create_user_role_with_permissions(
         user,
@@ -448,7 +449,8 @@ def test_upload_periodic_data_update_upload(
         tmp_file.getvalue(),
         content_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
     )
-    response = authenticated_client.post(url_upload, {"file": simple_file}, format="multipart")
+    with django_capture_on_commit_callbacks(execute=True):
+        response = authenticated_client.post(url_upload, {"file": simple_file}, format="multipart")
 
     assert response.status_code == status.HTTP_202_ACCEPTED
 

--- a/tests/unit/apps/program/test_program_utils.py
+++ b/tests/unit/apps/program/test_program_utils.py
@@ -376,14 +376,15 @@ def test_enroll_household_with_head_of_household_already_copied(enrollment_test_
 @pytest.mark.usefixtures("django_elasticsearch_setup")
 @pytest.mark.xdist_group(name="elasticsearch")
 @override_config(IS_ELASTICSEARCH_ENABLED=True)
-def test_enroll_households_to_program_task(enrollment_test_data: dict) -> None:
+def test_enroll_households_to_program_task(enrollment_test_data: dict, django_capture_on_commit_callbacks: Any) -> None:
     hh_count = Household.objects.count()
     ind_count = Individual.objects.count()
-    enroll_households_to_program_async_task(
-        [enrollment_test_data["household_already_enrolled"].id],
-        str(enrollment_test_data["program2"].pk),
-        str(enrollment_test_data["user"].pk),
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        enroll_households_to_program_async_task(
+            [enrollment_test_data["household_already_enrolled"].id],
+            str(enrollment_test_data["program2"].pk),
+            str(enrollment_test_data["user"].pk),
+        )
     assert hh_count == Household.objects.count()
     assert ind_count == Individual.objects.count()
 
@@ -392,7 +393,9 @@ def test_enroll_households_to_program_task(enrollment_test_data: dict) -> None:
 @pytest.mark.usefixtures("django_elasticsearch_setup")
 @pytest.mark.xdist_group(name="elasticsearch")
 @override_config(IS_ELASTICSEARCH_ENABLED=True)
-def test_enroll_households_to_program_task_already_running(enrollment_test_data: dict) -> None:
+def test_enroll_households_to_program_task_already_running(
+    enrollment_test_data: dict, django_capture_on_commit_callbacks: Any
+) -> None:
     hh_count = Household.objects.count()
     ind_count = Individual.objects.count()
 
@@ -405,22 +408,24 @@ def test_enroll_households_to_program_task_already_running(enrollment_test_data:
     cache_key = hashlib.sha256(task_params_str.encode()).hexdigest()
     cache.set(cache_key, True, timeout=24 * 60 * 60)
 
-    enroll_households_to_program_async_task(
-        [enrollment_test_data["household"].id],
-        str(enrollment_test_data["program2"].pk),
-        str(enrollment_test_data["user"].pk),
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        enroll_households_to_program_async_task(
+            [enrollment_test_data["household"].id],
+            str(enrollment_test_data["program2"].pk),
+            str(enrollment_test_data["user"].pk),
+        )
 
     assert hh_count == Household.objects.count()
     assert ind_count == Individual.objects.count()
 
     cache.delete(cache_key)
 
-    enroll_households_to_program_async_task(
-        [enrollment_test_data["household"].id],
-        str(enrollment_test_data["program2"].pk),
-        str(enrollment_test_data["user"].pk),
-    )
+    with django_capture_on_commit_callbacks(execute=True):
+        enroll_households_to_program_async_task(
+            [enrollment_test_data["household"].id],
+            str(enrollment_test_data["program2"].pk),
+            str(enrollment_test_data["user"].pk),
+        )
 
     assert hh_count + 1 == Household.objects.count()
     assert ind_count + 2 == Individual.objects.count()

--- a/tests/unit/apps/registration_data/test_celery_tasks.py
+++ b/tests/unit/apps/registration_data/test_celery_tasks.py
@@ -381,7 +381,9 @@ def test_registration_kobo_import_hourly_task_action_returns_when_no_loading_rdi
     mock_rdi_kobo_create_task.assert_not_called()
 
 
-def test_registration_kobo_import_task_queues_retry_job_with_rdi_content_object() -> None:
+def test_registration_kobo_import_task_queues_retry_job_with_rdi_content_object(
+    django_capture_on_commit_callbacks,
+) -> None:
     business_area = BusinessAreaFactory(name="Afghanistan")
     program = ProgramFactory(business_area=business_area)
     import_data = ImportDataFactory(business_area_slug=business_area.slug)
@@ -392,12 +394,13 @@ def test_registration_kobo_import_task_queues_retry_job_with_rdi_content_object(
     )
 
     with patch("hope.apps.registration_data.celery_tasks.AsyncRetryJob.queue", autospec=True) as mock_queue:
-        registration_kobo_import_async_task(
-            registration_data_import=rdi,
-            import_data_id=str(import_data.id),
-            business_area_id=str(business_area.id),
-            program_id=str(program.id),
-        )
+        with django_capture_on_commit_callbacks(execute=True):
+            registration_kobo_import_async_task(
+                registration_data_import=rdi,
+                import_data_id=str(import_data.id),
+                business_area_id=str(business_area.id),
+                program_id=str(program.id),
+            )
 
     job = AsyncRetryJob.objects.latest("pk")
     assert job.content_object == rdi
@@ -412,9 +415,10 @@ def test_registration_kobo_import_task_queues_retry_job_with_rdi_content_object(
     mock_queue.assert_called_once_with(job)
 
 
-def test_registration_kobo_import_hourly_task_queues_retry_job() -> None:
+def test_registration_kobo_import_hourly_task_queues_retry_job(django_capture_on_commit_callbacks) -> None:
     with patch("hope.apps.registration_data.celery_tasks.AsyncRetryJob.queue", autospec=True) as mock_queue:
-        registration_kobo_import_hourly_async_task()
+        with django_capture_on_commit_callbacks(execute=True):
+            registration_kobo_import_hourly_async_task()
 
     job = AsyncRetryJob.objects.latest("pk")
     assert job.job_name == "registration_kobo_import_hourly_async_task"
@@ -469,11 +473,13 @@ def test_merge_registration_data_import_task(
 
 def test_merge_registration_data_import_task_queues_retry_job_with_rdi_content_object(
     registration_import_context: dict[str, object],
+    django_capture_on_commit_callbacks,
 ) -> None:
     registration_data_import = registration_import_context["registration_data_import"]
 
     with patch("hope.apps.registration_data.celery_tasks.AsyncRetryJob.queue", autospec=True) as mock_queue:
-        merge_registration_data_import_async_task(registration_data_import=registration_data_import)
+        with django_capture_on_commit_callbacks(execute=True):
+            merge_registration_data_import_async_task(registration_data_import=registration_data_import)
 
     job = AsyncRetryJob.objects.latest("pk")
     assert job.content_object == registration_data_import
@@ -523,11 +529,13 @@ def test_rdi_deduplication_task_exception(
 
 def test_rdi_deduplication_task_queues_retry_job_with_rdi_content_object(
     registration_import_context: dict[str, object],
+    django_capture_on_commit_callbacks,
 ) -> None:
     registration_data_import = registration_import_context["registration_data_import"]
 
     with patch("hope.apps.registration_data.celery_tasks.AsyncRetryJob.queue", autospec=True) as mock_queue:
-        rdi_deduplication_async_task(registration_data_import=registration_data_import)
+        with django_capture_on_commit_callbacks(execute=True):
+            rdi_deduplication_async_task(registration_data_import=registration_data_import)
 
     job = AsyncRetryJob.objects.latest("pk")
     assert job.content_object == registration_data_import

--- a/tests/unit/apps/registration_data/test_registration_program_population_import_task.py
+++ b/tests/unit/apps/registration_data/test_registration_program_population_import_task.py
@@ -324,14 +324,16 @@ def test_registration_program_population_import_task_queues_retry_job(
     business_area: Any,
     programs: dict[str, Any],
     registration_data_import: Any,
+    django_capture_on_commit_callbacks,
 ) -> None:
     with patch("hope.apps.registration_data.celery_tasks.AsyncRetryJob.queue", autospec=True) as mock_queue:
-        registration_program_population_import_async_task(
-            registration_data_import,
-            str(business_area.id),
-            str(programs["from"].id),
-            str(programs["to"].id),
-        )
+        with django_capture_on_commit_callbacks(execute=True):
+            registration_program_population_import_async_task(
+                registration_data_import,
+                str(business_area.id),
+                str(programs["from"].id),
+                str(programs["to"].id),
+            )
 
     job = AsyncRetryJob.objects.latest("pk")
     assert job.content_object == registration_data_import

--- a/tests/unit/apps/registration_data/test_registration_xlsx_import_task.py
+++ b/tests/unit/apps/registration_data/test_registration_xlsx_import_task.py
@@ -146,7 +146,9 @@ def test_rdi_marked_as_import_error_on_task_failed(
     assert rdi.status == RegistrationDataImport.IMPORT_ERROR
 
 
-def test_registration_xlsx_import_task_queues_retry_job(business_area: Any, program: Any) -> None:
+def test_registration_xlsx_import_task_queues_retry_job(
+    business_area: Any, program: Any, django_capture_on_commit_callbacks
+) -> None:
     rdi = RegistrationDataImportFactory(
         status=RegistrationDataImport.IMPORT_SCHEDULED,
         business_area=business_area,
@@ -155,12 +157,13 @@ def test_registration_xlsx_import_task_queues_retry_job(business_area: Any, prog
     import_data_id = str(uuid4())
 
     with patch("hope.apps.registration_data.celery_tasks.AsyncRetryJob.queue", autospec=True) as mock_queue:
-        registration_xlsx_import_async_task(
-            registration_data_import=rdi,
-            import_data_id=str(import_data_id),
-            business_area_id=str(business_area.id),
-            program_id=str(program.id),
-        )
+        with django_capture_on_commit_callbacks(execute=True):
+            registration_xlsx_import_async_task(
+                registration_data_import=rdi,
+                import_data_id=str(import_data_id),
+                business_area_id=str(business_area.id),
+                program_id=str(program.id),
+            )
 
     job = AsyncRetryJob.objects.latest("pk")
     assert job.content_object == rdi

--- a/tests/unit/apps/sanction_list/test_sl_celery_tasks.py
+++ b/tests/unit/apps/sanction_list/test_sl_celery_tasks.py
@@ -27,12 +27,13 @@ def test_sync_sanction_list_task(mocked_responses: "RequestsMock", sanction_list
     assert SanctionListIndividual.objects.count() == 2
 
 
-def test_check_against_sanction_list_task_queues_retry_job() -> None:
+def test_check_against_sanction_list_task_queues_retry_job(django_capture_on_commit_callbacks) -> None:
     uploaded_file_id = "123e4567-e89b-12d3-a456-426614174000"
     original_file_name = "test.xlsx"
 
     with patch("hope.apps.sanction_list.celery_tasks.AsyncRetryJob.queue", autospec=True) as mock_queue:
-        check_against_sanction_list_async_task(uploaded_file_id, original_file_name)
+        with django_capture_on_commit_callbacks(execute=True):
+            check_against_sanction_list_async_task(uploaded_file_id, original_file_name)
 
     job = AsyncRetryJob.objects.latest("pk")
     assert job.action == "hope.apps.sanction_list.celery_tasks.check_against_sanction_list_async_task_action"

--- a/tests/unit/apps/universal_update_script/test_celery_tasks.py
+++ b/tests/unit/apps/universal_update_script/test_celery_tasks.py
@@ -188,11 +188,14 @@ def test_run_universal_individual_update(
     queue_and_run_async_task(run_universal_individual_update_async_task, str(universal_update.id))
 
 
-def test_run_universal_individual_update_creates_related_async_job(program: Program) -> None:
+def test_run_universal_individual_update_creates_related_async_job(
+    program: Program, django_capture_on_commit_callbacks
+) -> None:
     universal_update = UniversalUpdate.objects.create(program=program)
 
     with patch("hope.apps.universal_update_script.celery_tasks.AsyncJob.queue", autospec=True) as mock_queue:
-        run_universal_individual_update_async_task(str(universal_update.pk))
+        with django_capture_on_commit_callbacks(execute=True):
+            run_universal_individual_update_async_task(str(universal_update.pk))
 
     job = AsyncJob.objects.latest("pk")
     assert job.content_object == universal_update

--- a/uv.lock
+++ b/uv.lock
@@ -1895,7 +1895,7 @@ wheels = [
 
 [[package]]
 name = "hope"
-version = "4.14.0"
+version = "4.14.1"
 source = { editable = "." }
 dependencies = [
     { name = "black" },


### PR DESCRIPTION
fix for
https://hope.unicef.org/flower/task/835c0fe2-d8da-45ce-8dcd-c683ac61494f

hope.models.async_job.AsyncRetryJob.DoesNotExist: AsyncRetryJob matching query does not exist.

queue async task on AsyncJob instance creation commit

[AB#313932](https://dev.azure.com/unicef/ICTD-HCT-MIS/_workitems/edit/313932): Nigeria: pushing Aurora registration error

After refactoring in `BaseRegistrationService` we are using `process_flex_records_async_task` instead of old `process_flex_records_task`