### PR TITLE
fix(payment): match account_type by string id in delivery mechanism sync

### DIFF
--- a/src/hope/apps/payment/services/payment_gateway.py
+++ b/src/hope/apps/payment/services/payment_gateway.py
@@ -723,7 +723,7 @@ class PaymentGatewayService:
         account_types = AccountType.objects.filter(payment_gateway_id__in=dm_account_types).only(
             "id", "payment_gateway_id"
         )
-        account_type_map = {account_type.payment_gateway_id: account_type for account_type in account_types}
+        account_type_map = {str(account_type.payment_gateway_id): account_type for account_type in account_types}
 
         for dm in delivery_mechanisms:
             DeliveryMechanism.objects.update_or_create(
@@ -733,7 +733,7 @@ class PaymentGatewayService:
                     "name": dm.name,
                     "transfer_type": dm.transfer_type,
                     "is_active": True,
-                    "account_type": account_type_map.get(dm.account_type) if dm.account_type else None,
+                    "account_type": account_type_map.get(str(dm.account_type)) if dm.account_type else None,
                 },
             )
 

--- a/tests/unit/apps/payment/test_payment_gateway_service.py
+++ b/tests/unit/apps/payment/test_payment_gateway_service.py
@@ -1319,6 +1319,62 @@ def test_sync_delivery_mechanisms(
     assert dm_new.payment_gateway_id == "33"
 
 
+@pytest.fixture
+def account_types_int_payment_gateway_id():
+    mobile = AccountTypeFactory(key="mobile", label="Mobile", payment_gateway_id="1")
+    bank = AccountTypeFactory(key="bank", label="Bank", payment_gateway_id="2")
+    card = AccountTypeFactory(key="card", label="Card", payment_gateway_id="3")
+    return {"mobile": mobile, "bank": bank, "card": card}
+
+
+@mock.patch("hope.apps.payment.services.payment_gateway.PaymentGatewayAPI.get_delivery_mechanisms")
+def test_sync_delivery_mechanisms_links_account_type_when_api_returns_int(
+    get_delivery_mechanisms_mock: Any,
+    account_types_int_payment_gateway_id: dict,
+) -> None:
+    get_delivery_mechanisms_mock.return_value = [
+        DeliveryMechanismData(
+            id=14,
+            code="transfer_to_digital_wallet",
+            name="Transfer to Digital Wallet",
+            transfer_type="DIGITAL",
+            account_type=1,
+        ),
+        DeliveryMechanismData(
+            id=10,
+            code="transfer_to_account",
+            name="Transfer to Account",
+            transfer_type="IN_CASH",
+            account_type=2,
+        ),
+        DeliveryMechanismData(
+            id=13,
+            code="atm_card",
+            name="ATM Card",
+            transfer_type="IN_CASH",
+            account_type=3,
+        ),
+    ]
+
+    pg_service = PaymentGatewayService()
+    pg_service.api.get_delivery_mechanisms = get_delivery_mechanisms_mock  # type: ignore
+
+    pg_service.sync_delivery_mechanisms()
+
+    dm_wallet = DeliveryMechanism.objects.get(payment_gateway_id="14")
+    assert dm_wallet.code == "transfer_to_digital_wallet"
+    assert dm_wallet.transfer_type == "DIGITAL"
+    assert dm_wallet.account_type == account_types_int_payment_gateway_id["mobile"]
+
+    dm_account = DeliveryMechanism.objects.get(payment_gateway_id="10")
+    assert dm_account.code == "transfer_to_account"
+    assert dm_account.account_type == account_types_int_payment_gateway_id["bank"]
+
+    dm_atm = DeliveryMechanism.objects.get(payment_gateway_id="13")
+    assert dm_atm.code == "atm_card"
+    assert dm_atm.account_type == account_types_int_payment_gateway_id["card"]
+
+
 @mock.patch("hope.apps.payment.services.payment_gateway.PaymentGatewayAPI.get_fsps")
 def test_sync_fsps(
     get_fsps_mock: Any,


### PR DESCRIPTION
[AB#314393](https://unicef.visualstudio.com/4e044e8d-bc28-4768-8074-f80ff6e4a0e5/_workitems/edit/314393)
- cast payment_gateway_id to str when building lookup map and querying
- add test covering int account_type values from API
