### PR TITLE
[LONGTERM] 313100: PaymentPlanGroup assignment on TargetPopulation operations

### DIFF
--- a/src/frontend/src/restgenerated/models/PatchedTargetPopulationCreate.ts
+++ b/src/frontend/src/restgenerated/models/PatchedTargetPopulationCreate.ts
@@ -8,6 +8,7 @@ export type PatchedTargetPopulationCreate = {
     readonly version?: number;
     name?: string;
     programCycleId?: string;
+    paymentPlanGroupId?: string;
     rules?: Array<TargetingCriteriaRule>;
     excludedIds?: string;
     exclusionReason?: string;

--- a/src/frontend/src/restgenerated/models/TargetPopulationCopy.ts
+++ b/src/frontend/src/restgenerated/models/TargetPopulationCopy.ts
@@ -6,5 +6,6 @@ export type TargetPopulationCopy = {
     name: string;
     targetPopulationId: string;
     programCycleId: string;
+    paymentPlanGroupId: string;
 };
 

--- a/src/frontend/src/restgenerated/models/TargetPopulationCreate.ts
+++ b/src/frontend/src/restgenerated/models/TargetPopulationCreate.ts
@@ -8,6 +8,7 @@ export type TargetPopulationCreate = {
     readonly version: number;
     name: string;
     programCycleId: string;
+    paymentPlanGroupId: string;
     rules: Array<TargetingCriteriaRule>;
     excludedIds?: string;
     exclusionReason?: string;

--- a/src/hope/apps/payment/api/serializers.py
+++ b/src/hope/apps/payment/api/serializers.py
@@ -1415,6 +1415,7 @@ class TargetPopulationCreateSerializer(serializers.ModelSerializer):
     rules = TargetingCriteriaRuleSerializer(many=True)
     excluded_ids = serializers.CharField(required=False, allow_blank=True)
     exclusion_reason = serializers.CharField(required=False, allow_blank=True)
+    payment_plan_group_id = serializers.UUIDField()
     fsp_id = serializers.UUIDField(required=False, allow_null=True)
     delivery_mechanism_code = serializers.CharField(required=False, allow_blank=True, allow_null=True)
     vulnerability_score_min = serializers.DecimalField(required=False, max_digits=6, decimal_places=3)
@@ -1430,6 +1431,7 @@ class TargetPopulationCreateSerializer(serializers.ModelSerializer):
             "version",
             "name",
             "program_cycle_id",
+            "payment_plan_group_id",
             "rules",
             "excluded_ids",
             "exclusion_reason",
@@ -1487,6 +1489,7 @@ class TargetPopulationCopySerializer(serializers.Serializer):
     name = serializers.CharField()
     target_population_id = serializers.CharField()
     program_cycle_id = serializers.CharField()
+    payment_plan_group_id = serializers.UUIDField()
 
 
 class ApplyEngineFormulaSerializer(serializers.Serializer):

--- a/src/hope/apps/payment/api/views.py
+++ b/src/hope/apps/payment/api/views.py
@@ -1851,6 +1851,7 @@ class TargetPopulationViewSet(
             name = serializer.validated_data["name"].strip()
             payment_plan_id = serializer.validated_data["target_population_id"]
             program_cycle_id = serializer.validated_data["program_cycle_id"]
+            payment_plan_group_id = serializer.validated_data["payment_plan_group_id"]
             payment_plan = get_object_or_404(PaymentPlan, pk=payment_plan_id)
             program_cycle = get_object_or_404(ProgramCycle, pk=program_cycle_id)
             program = program_cycle.program
@@ -1861,6 +1862,12 @@ class TargetPopulationViewSet(
                 raise ValidationError(
                     f"Target Population with name: {name} and program cycle: {program_cycle.title} already exists."
                 )
+            if not (
+                payment_plan_group := PaymentPlanGroup.objects.filter(
+                    pk=payment_plan_group_id, cycle=program_cycle
+                ).first()
+            ):
+                raise ValidationError("Payment Plan Group does not exist in the given Programme Cycle.")
 
             payment_plan_copy = PaymentPlan(
                 name=name,
@@ -1881,6 +1888,7 @@ class TargetPopulationViewSet(
                 steficon_rule_targeting=payment_plan.steficon_rule_targeting,
                 steficon_targeting_applied_date=payment_plan.steficon_targeting_applied_date,
                 program_cycle=program_cycle,
+                payment_plan_group=payment_plan_group,
                 financial_service_provider=payment_plan.financial_service_provider,
                 delivery_mechanism=payment_plan.delivery_mechanism,
             )

--- a/src/hope/apps/payment/services/payment_plan_services.py
+++ b/src/hope/apps/payment/services/payment_plan_services.py
@@ -65,6 +65,7 @@ from hope.models import (
     Payment,
     PaymentDataCollector,
     PaymentPlan,
+    PaymentPlanGroup,
     PaymentPlanSplit,
     Program,
     ProgramCycle,
@@ -555,11 +556,19 @@ class PaymentPlanService:
         if PaymentPlan.objects.filter(name=pp_name, program_cycle__program=program, is_removed=False).exists():
             raise ValidationError(f"Target Population with name: {pp_name} and program: {program.name} already exists.")
 
+        if not (
+            payment_plan_group := PaymentPlanGroup.objects.filter(
+                pk=input_data["payment_plan_group_id"], cycle=program_cycle
+            ).first()
+        ):
+            raise ValidationError("Payment Plan Group does not exist in the given Programme Cycle.")
+
         with transaction.atomic():
             payment_plan = PaymentPlan.objects.create(
                 business_area=business_area,
                 created_by=user,
                 program_cycle=program_cycle,
+                payment_plan_group=payment_plan_group,
                 name=input_data["name"],
                 status_date=timezone.now(),
                 start_date=program_cycle.start_date,
@@ -714,6 +723,15 @@ class PaymentPlanService:
             program_cycle = get_object_or_404(ProgramCycle, pk=program_cycle_id)
             self._validate_pp_cycle(program_cycle)
             self.payment_plan.program_cycle = program_cycle
+            if not (payment_plan_group_id := input_data.get("payment_plan_group_id")):
+                raise ValidationError("Payment Plan Group is required when changing Programme Cycle.")
+            if not (
+                payment_plan_group := PaymentPlanGroup.objects.filter(
+                    pk=payment_plan_group_id, cycle=program_cycle
+                ).first()
+            ):
+                raise ValidationError("Payment Plan Group does not exist in the given Programme Cycle.")
+            self.payment_plan.payment_plan_group = payment_plan_group
 
     def _set_dispersion_dates(self, dispersion_end_date: Any | None, dispersion_start_date: Any | None) -> None:
         if dispersion_start_date and dispersion_start_date != self.payment_plan.dispersion_start_date:

--- a/tests/unit/apps/payment/test_import_export_payment_plan_payment_list.py
+++ b/tests/unit/apps/payment/test_import_export_payment_plan_payment_list.py
@@ -777,6 +777,7 @@ def test_export_payment_plan_per_fsp_with_people_program(payment_plan, fsp, deli
     )
     program_sw_cycle = ProgramCycleFactory(program=program_sw)
     payment_plan.program_cycle = program_sw_cycle
+    payment_plan.payment_plan_group = program_sw_cycle.payment_plan_groups.first()
     payment_plan.save()
 
     export_service = XlsxPaymentPlanExportPerFspService(payment_plan)

--- a/tests/unit/apps/payment/test_payment_plan_services.py
+++ b/tests/unit/apps/payment/test_payment_plan_services.py
@@ -3,6 +3,7 @@ from decimal import Decimal
 from typing import Any
 from unittest import mock
 from unittest.mock import patch
+import uuid
 
 from aniso8601 import parse_date
 from django.core.files.uploadedfile import SimpleUploadedFile
@@ -31,6 +32,7 @@ from extras.test_utils.factories import (
     PartnerFactory,
     PaymentFactory,
     PaymentPlanFactory,
+    PaymentPlanGroupFactory,
     PaymentPlanSplitFactory,
     ProgramCycleFactory,
     ProgramFactory,
@@ -290,6 +292,7 @@ def test_create_validation_errors(user: User, business_area: Any) -> None:
     program.save()
 
     create_input_data["name"] = "TEST"
+    create_input_data["payment_plan_group_id"] = PaymentPlanGroupFactory(cycle=program_cycle).id
     pp = PaymentPlanService.create(
         input_data=create_input_data,
         user=user,
@@ -344,6 +347,7 @@ def test_create(
         end_date=timezone.datetime(2099, 10, 10, tzinfo=utc).date(),
     )
     program_cycle = ProgramCycleFactory(program=program)
+    payment_plan_group = PaymentPlanGroupFactory(cycle=program_cycle)
 
     hh1 = HouseholdFactory(program=program, business_area=business_area)
     hh2 = HouseholdFactory(program=program, business_area=business_area)
@@ -368,6 +372,7 @@ def test_create(
         "business_area_slug": "afghanistan",
         "name": "paymentPlanName",
         "program_cycle_id": program_cycle.id,
+        "payment_plan_group_id": payment_plan_group.id,
         "flag_exclude_if_active_adjudication_ticket": False,
         "flag_exclude_if_on_sanction_list": False,
         "rules": [
@@ -383,7 +388,7 @@ def test_create(
     }
 
     with mock.patch("hope.apps.payment.services.payment_plan_services.transaction") as mock_transaction:
-        with django_assert_num_queries(16):
+        with django_assert_num_queries(17):
             pp = PaymentPlanService.create(
                 input_data=input_data,
                 user=user,
@@ -404,6 +409,46 @@ def test_create(
     assert pp.total_households_count == 2
     assert pp.total_individuals_count == 6
     assert pp.payment_items.count() == 2
+
+
+def test_create_raises_when_payment_plan_group_belongs_to_different_cycle(user: User, business_area: Any) -> None:
+    program = ProgramFactory(status=Program.ACTIVE, business_area=business_area)
+    program_cycle = ProgramCycleFactory(program=program)
+    other_cycle = ProgramCycleFactory(program=program)
+    group_from_other_cycle = PaymentPlanGroupFactory(cycle=other_cycle)
+
+    input_data = {
+        "business_area_slug": business_area.slug,
+        "name": "Test TP",
+        "program_cycle_id": program_cycle.id,
+        "payment_plan_group_id": group_from_other_cycle.id,
+        "flag_exclude_if_active_adjudication_ticket": False,
+        "flag_exclude_if_on_sanction_list": False,
+        "rules": [],
+    }
+
+    with pytest.raises(ValidationError) as error:
+        PaymentPlanService.create(input_data=input_data, user=user, business_area_slug=business_area.slug)
+    assert error.value.detail[0] == "Payment Plan Group does not exist in the given Programme Cycle."
+
+
+def test_create_raises_when_payment_plan_group_does_not_exist(user: User, business_area: Any) -> None:
+    program = ProgramFactory(status=Program.ACTIVE, business_area=business_area)
+    program_cycle = ProgramCycleFactory(program=program)
+
+    input_data = {
+        "business_area_slug": business_area.slug,
+        "name": "Test TP",
+        "program_cycle_id": program_cycle.id,
+        "payment_plan_group_id": uuid.uuid4(),
+        "flag_exclude_if_active_adjudication_ticket": False,
+        "flag_exclude_if_on_sanction_list": False,
+        "rules": [],
+    }
+
+    with pytest.raises(ValidationError) as error:
+        PaymentPlanService.create(input_data=input_data, user=user, business_area_slug=business_area.slug)
+    assert error.value.detail[0] == "Payment Plan Group does not exist in the given Programme Cycle."
 
 
 @freeze_time("2020-10-10")
@@ -521,7 +566,7 @@ def test_create_follow_up_pp(
     assert follow_up_payment.status == Payment.STATUS_PENDING
     assert follow_up_payment.parent == follow_up_pp
     assert follow_up_payment.source_payment is not None
-    assert follow_up_payment.plan_type == PaymentPlan.PlanType.FOLLOW_UP
+    assert follow_up_payment.is_follow_up is True
     assert follow_up_payment.business_area == follow_up_payment.source_payment.business_area
     assert follow_up_payment.household == follow_up_payment.source_payment.household
     assert follow_up_payment.head_of_household == follow_up_payment.source_payment.head_of_household
@@ -536,7 +581,7 @@ def test_create_follow_up_pp(
 
     assert pp.follow_ups.count() == 2
 
-    with django_assert_num_queries(59):
+    with django_assert_num_queries(61):
         prepare_follow_up_payment_plan_async_task(follow_up_pp_2)
 
     assert follow_up_pp_2.payment_items.count() == 1
@@ -851,6 +896,7 @@ def test_create_with_program_cycle_validation_error(user: User, business_area: A
     cycle.status = ProgramCycle.DRAFT
     cycle.end_date = None
     cycle.save()
+    input_data["payment_plan_group_id"] = PaymentPlanGroupFactory(cycle=cycle).id
     PaymentPlanService.create(
         input_data=input_data,
         user=user,
@@ -875,6 +921,7 @@ def test_full_rebuild(
         end_date=timezone.datetime(2099, 10, 10, tzinfo=utc).date(),
     )
     program_cycle = ProgramCycleFactory(program=program)
+    payment_plan_group = PaymentPlanGroupFactory(cycle=program_cycle)
 
     hh1 = HouseholdFactory(program=program, business_area=business_area)
     hh2 = HouseholdFactory(program=program, business_area=business_area)
@@ -890,6 +937,7 @@ def test_full_rebuild(
         "business_area_slug": "afghanistan",
         "name": "paymentPlanName",
         "program_cycle_id": program_cycle.id,
+        "payment_plan_group_id": payment_plan_group.id,
         "flag_exclude_if_active_adjudication_ticket": False,
         "flag_exclude_if_on_sanction_list": False,
         "rules": [
@@ -902,7 +950,7 @@ def test_full_rebuild(
         ],
     }
     with mock.patch("hope.apps.payment.services.payment_plan_services.transaction") as mock_transaction:
-        with django_assert_num_queries(12):
+        with django_assert_num_queries(13):
             pp = PaymentPlanService.create(
                 input_data=input_data,
                 user=user,
@@ -1270,11 +1318,47 @@ def test_unlock_fsp(user: User, business_area: Any, cycle: ProgramCycle) -> None
 
 def test_update_pp_program_cycle(payment_plan_base: PaymentPlan, program: Program) -> None:
     new_cycle = ProgramCycleFactory(program=program, title="New Cycle ABC")
+    new_group = PaymentPlanGroupFactory(cycle=new_cycle)
 
-    PaymentPlanService(payment_plan_base).update({"program_cycle_id": new_cycle.id})
+    PaymentPlanService(payment_plan_base).update(
+        {"program_cycle_id": new_cycle.id, "payment_plan_group_id": new_group.id}
+    )
 
     payment_plan_base.refresh_from_db()
     assert payment_plan_base.program_cycle.title == "New Cycle ABC"
+    assert payment_plan_base.payment_plan_group == new_group
+
+
+def test_edit_cycle_requires_group_from_new_cycle(payment_plan_base: PaymentPlan, program: Program) -> None:
+    new_cycle = ProgramCycleFactory(program=program)
+    new_group = PaymentPlanGroupFactory(cycle=new_cycle)
+
+    PaymentPlanService(payment_plan_base).update(
+        {"program_cycle_id": new_cycle.id, "payment_plan_group_id": new_group.id}
+    )
+
+    payment_plan_base.refresh_from_db()
+    assert payment_plan_base.program_cycle == new_cycle
+    assert payment_plan_base.payment_plan_group == new_group
+
+
+def test_edit_cycle_rejects_group_from_old_cycle(payment_plan_base: PaymentPlan, program: Program) -> None:
+    old_group = payment_plan_base.payment_plan_group
+    new_cycle = ProgramCycleFactory(program=program)
+
+    with pytest.raises(ValidationError) as error:
+        PaymentPlanService(payment_plan_base).update(
+            {"program_cycle_id": new_cycle.id, "payment_plan_group_id": old_group.id}
+        )
+    assert error.value.detail[0] == "Payment Plan Group does not exist in the given Programme Cycle."
+
+
+def test_edit_cycle_rejects_missing_group(payment_plan_base: PaymentPlan, program: Program) -> None:
+    new_cycle = ProgramCycleFactory(program=program)
+
+    with pytest.raises(ValidationError) as error:
+        PaymentPlanService(payment_plan_base).update({"program_cycle_id": new_cycle.id})
+    assert error.value.detail[0] == "Payment Plan Group is required when changing Programme Cycle."
 
 
 def test_update_pp_vulnerability_score(payment_plan_base: PaymentPlan) -> None:

--- a/tests/unit/apps/payment/test_payment_signature.py
+++ b/tests/unit/apps/payment/test_payment_signature.py
@@ -186,6 +186,7 @@ def test_signature_after_prepare_payment_plan(
         "business_area_slug": business_area.slug,
         "name": "paymentPlanName",
         "program_cycle_id": str(program_cycle.id),
+        "payment_plan_group_id": str(program_cycle.payment_plan_groups.first().id),
         "rules": rules,
         "flag_exclude_if_active_adjudication_ticket": False,
         "flag_exclude_if_on_sanction_list": False,

--- a/tests/unit/apps/payment/test_target_population_views.py
+++ b/tests/unit/apps/payment/test_target_population_views.py
@@ -20,6 +20,7 @@ from extras.test_utils.factories import (
     PartnerFactory,
     PaymentFactory,
     PaymentPlanFactory,
+    PaymentPlanGroupFactory,
     ProgramCycleFactory,
     ProgramFactory,
     RuleCommitFactory,
@@ -694,6 +695,7 @@ def test_create_payment_plan_success(
     data = {
         "name": "New Payment Plan",
         "program_cycle_id": target_population_create_update_context["cycle"].id,
+        "payment_plan_group_id": target_population_create_update_context["cycle"].payment_plan_groups.first().id,
         "rules": target_population_create_update_context["rules"],
         "excluded_ids": "IND-123",
         "exclusion_reason": "Just MMM Qwool Test",
@@ -939,7 +941,11 @@ def test_copy_tp(
         target_population_actions_context["business_area"],
         target_population_actions_context["program_active"],
     )
-    data = {"name": "Copied TP test 123", "program_cycle_id": target_population_actions_context["cycle"].pk}
+    data = {
+        "name": "Copied TP test 123",
+        "program_cycle_id": target_population_actions_context["cycle"].pk,
+        "payment_plan_group_id": target_population_actions_context["target_population"].payment_plan_group.pk,
+    }
     response = target_population_actions_context["client"].post(
         target_population_actions_context["url_copy"],
         data,
@@ -970,9 +976,11 @@ def test_copy_tp_validation_errors(
         business_area=target_population_actions_context["business_area"],
         program_cycle=cycle,
     )
+    group = PaymentPlanGroupFactory(cycle=cycle)
     data = {
         "name": "Copied TP AGAIN",
         "program_cycle_id": cycle.pk,
+        "payment_plan_group_id": group.pk,
     }
     response = target_population_actions_context["client"].post(
         target_population_actions_context["url_copy"],
@@ -1002,6 +1010,35 @@ def test_copy_tp_validation_errors(
     assert response_3.status_code == status.HTTP_400_BAD_REQUEST
     assert "name" in response_3.data
     assert "program_cycle_id" in response_3.data
+    assert "payment_plan_group_id" in response_3.data
+
+
+def test_copy_tp_rejects_group_from_wrong_cycle(
+    target_population_actions_context: dict[str, Any],
+    create_user_role_with_permissions: Any,
+) -> None:
+    create_user_role_with_permissions(
+        target_population_actions_context["user"],
+        [Permissions.TARGETING_DUPLICATE],
+        target_population_actions_context["business_area"],
+        target_population_actions_context["program_active"],
+    )
+    other_cycle = ProgramCycleFactory(program=target_population_actions_context["program_active"])
+    group_from_other_cycle = PaymentPlanGroupFactory(cycle=other_cycle)
+
+    data = {
+        "name": "Copied TP wrong group",
+        "program_cycle_id": target_population_actions_context["cycle"].pk,
+        "payment_plan_group_id": group_from_other_cycle.pk,
+    }
+    response = target_population_actions_context["client"].post(
+        target_population_actions_context["url_copy"],
+        data,
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "Payment Plan Group does not exist in the given Programme Cycle." in response.data
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/apps/targeting/test_celery_tasks.py
+++ b/tests/unit/apps/targeting/test_celery_tasks.py
@@ -81,7 +81,7 @@ def valid_form(program_cycle, payment_plan_group):
     return form
 
 
-@patch("hope.apps.household.forms.CreateTargetPopulationTextForm")
+@patch("hope.apps.targeting.celery_tasks.CreateTargetPopulationTextForm")
 @patch("hope.apps.payment.services.payment_plan_services.PaymentPlanService.create_payments")
 def test_create_tp_from_list_creates_payment_plan_and_triggers_payments(
     mock_create_payments,


### PR DESCRIPTION
[AB#313100](https://unicef.visualstudio.com/4e044e8d-bc28-4768-8074-f80ff6e4a0e5/_workitems/edit/313100)
[AB#313364](https://unicef.visualstudio.com/4e044e8d-bc28-4768-8074-f80ff6e4a0e5/_workitems/edit/313364)
The TargetPopulation service and serializer now require payment_plan_group_id on create and copy, and validate that the group belongs to the target cycle.

When updating TargetPopulations program cycle make it required to update also group that is form this new program cycle.

Fix test for 100% passing tests.