### PR TITLE
🔥hotfix/[AB#314936]-programme cycle date issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [ "setuptools", "wheel" ]
 
 [project]
 name = "hope"
-version = "4.14.1"
+version = "4.14.2"
 description = "HCT MIS is UNICEF's humanitarian cash transfer platform."
 readme = "README.md"
 license = { text = "None" }

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "4.14.1",
+  "version": "4.14.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/frontend/src/containers/GlobalProgramSelect.tsx
+++ b/src/frontend/src/containers/GlobalProgramSelect.tsx
@@ -215,6 +215,8 @@ export const GlobalProgramSelect = () => {
           beneficiaryGroup,
           code,
           canImportRdi,
+          startDate,
+          endDate,
         } = program;
 
         setSelectedProgram({
@@ -226,6 +228,8 @@ export const GlobalProgramSelect = () => {
           beneficiaryGroup,
           code,
           canImportRdi,
+          startDate,
+          endDate,
         });
       }
     }

--- a/src/frontend/src/containers/tables/ProgramCycle/NewProgramCycle/CreateProgramCycle.tsx
+++ b/src/frontend/src/containers/tables/ProgramCycle/NewProgramCycle/CreateProgramCycle.tsx
@@ -74,12 +74,16 @@ const CreateProgramCycle = ({
       .required(t('Programme Cycle Title is required'))
       .min(2, t('Too short'))
       .max(150, t('Too long')),
-    startDate: Yup.date()
-      .required(t('Start Date is required'))
-      .min(
-        program.startDate,
-        t('Start Date cannot be before Programme Start Date'),
-      ),
+    startDate: (() => {
+      let s = Yup.date().required(t('Start Date is required'));
+      if (program.startDate) {
+        s = s.min(
+          new Date(program.startDate),
+          t('Start Date cannot be before Programme Start Date'),
+        );
+      }
+      return s;
+    })(),
     endDate: endDate,
   });
 

--- a/src/frontend/src/containers/tables/ProgramCycle/NewProgramCycle/CreateProgramCycle.tsx
+++ b/src/frontend/src/containers/tables/ProgramCycle/NewProgramCycle/CreateProgramCycle.tsx
@@ -74,16 +74,12 @@ const CreateProgramCycle = ({
       .required(t('Programme Cycle Title is required'))
       .min(2, t('Too short'))
       .max(150, t('Too long')),
-    startDate: (() => {
-      let s = Yup.date().required(t('Start Date is required'));
-      if (program.startDate) {
-        s = s.min(
-          new Date(program.startDate),
-          t('Start Date cannot be before Programme Start Date'),
-        );
-      }
-      return s;
-    })(),
+    startDate: Yup.date()
+      .required(t('Start Date is required'))
+      .min(
+        new Date(program.startDate),
+        t('Start Date cannot be before Programme Start Date'),
+      ),
     endDate: endDate,
   });
 


### PR DESCRIPTION
[AB#314936](https://unicef.visualstudio.com/ICTD-HCT-MIS/_workitems/edit/314936)
in CreateProgramCycle
The startDate validation now only attaches .min()
  when program.startDate is defined, matching the existing
  guard on endDate. Also added new Date(...) wrapping to be  
  consistent with the endDate