### PR TITLE
block concurrent activation of verification plans

### DIFF
--- a/src/frontend/src/components/payments/ActivateVerificationPlan.tsx
+++ b/src/frontend/src/components/payments/ActivateVerificationPlan.tsx
@@ -95,15 +95,23 @@ export function ActivateVerificationPlan({
         </DialogContent>
         <DialogFooter>
           <DialogActions>
-            <Button onClick={() => setActivateDialogOpen(false)}>CANCEL</Button>
+            <Button
+              onClick={() => setActivateDialogOpen(false)}
+              disabled={activateVerificationPlanMutation.isPending}
+            >
+              CANCEL
+            </Button>
             <Button
               type="submit"
               color="primary"
               variant="contained"
               onClick={() => activate()}
               data-cy="button-submit"
+              disabled={activateVerificationPlanMutation.isPending}
             >
-              {t('ACTIVATE')}
+              {activateVerificationPlanMutation.isPending
+                ? t('ACTIVATING...')
+                : t('ACTIVATE')}
             </Button>
           </DialogActions>
         </DialogFooter>

--- a/src/hope/admin/payment_verification_plan.py
+++ b/src/hope/admin/payment_verification_plan.py
@@ -5,7 +5,9 @@ from admin_extra_buttons.mixins import confirm_action
 from adminfilters.autocomplete import AutoCompleteFilter
 from adminfilters.filters import ChoicesFieldComboFilter
 from django.contrib import admin, messages
-from django.http import HttpRequest, HttpResponseBase, HttpResponseRedirect
+from django.core.exceptions import ValidationError
+from django.db import DatabaseError
+from django.http import Http404, HttpRequest, HttpResponseBase, HttpResponseRedirect
 from django.urls import reverse
 from smart_admin.mixins import LinkedObjectsMixin
 
@@ -80,7 +82,13 @@ class PaymentVerificationPlanAdmin(LinkedObjectsMixin, HOPEModelAdminBase):
 
     def activate(self, request: HttpRequest, pk: "UUID") -> HttpResponseBase | None:
         def _do_activate(request: HttpRequest) -> None:
-            VerificationPlanStatusChangeServices(PaymentVerificationPlan.objects.get(pk=pk)).activate()
+            try:
+                payment_verification_plan = PaymentVerificationPlan.objects.select_for_update(nowait=True).get(pk=pk)
+            except PaymentVerificationPlan.DoesNotExist:
+                raise Http404
+            except DatabaseError:
+                raise ValidationError("Payment verification plan is locked by another request.")
+            VerificationPlanStatusChangeServices(payment_verification_plan).activate()
 
         return confirm_action(
             self,

--- a/src/hope/apps/payment/api/views.py
+++ b/src/hope/apps/payment/api/views.py
@@ -6,9 +6,9 @@ from typing import TYPE_CHECKING, Any, cast
 from zipfile import BadZipFile
 
 from constance import config
-from django.db import transaction
+from django.db import DatabaseError, transaction
 from django.db.models import Prefetch, QuerySet
-from django.http import FileResponse
+from django.http import FileResponse, Http404
 from django.utils import timezone
 from django_filters import rest_framework as filters
 from django_filters.rest_framework import DjangoFilterBackend
@@ -326,7 +326,14 @@ class PaymentVerificationViewSet(
         self, request: Request, verification_plan_id: str, *args: Any, **kwargs: Any
     ) -> Response:
         payment_plan = self.get_object()
-        payment_verification_plan = self.get_verification_plan_object()
+        try:
+            payment_verification_plan = PaymentVerificationPlan.objects.select_for_update(nowait=True).get(
+                pk=verification_plan_id
+            )
+        except PaymentVerificationPlan.DoesNotExist:
+            raise Http404
+        except DatabaseError:
+            raise ValidationError("Payment verification plan is locked by another request.")
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         check_concurrency_version_in_mutation(serializer.validated_data.get("version"), payment_verification_plan)

--- a/src/hope/apps/payment/services/verification_plan_status_change_services.py
+++ b/src/hope/apps/payment/services/verification_plan_status_change_services.py
@@ -73,13 +73,14 @@ class VerificationPlanStatusChangeServices:
         )
 
     def activate(self) -> PaymentVerificationPlan:
-        with cache.lock(
+        lock = cache.lock(
             f"payment_verification_plan_activate_rapidpro_{str(self.payment_verification_plan.id)}",
-            blocking_timeout=60 * 5,
             timeout=60 * 5,
-        ) as locked:
-            if not locked:
-                raise ValidationError("RapidPro activation already in progress")  # pragma: no cover
+        )
+        if not lock.acquire(blocking=False):
+            raise ValidationError("RapidPro activation already in progress")
+        try:
+            self.payment_verification_plan.refresh_from_db()
 
             if not self.payment_verification_plan.can_activate:
                 raise ValidationError("You can activate only PENDING/ERROR verifications")
@@ -94,6 +95,8 @@ class VerificationPlanStatusChangeServices:
             self.payment_verification_plan.save()
 
             return self.payment_verification_plan
+        finally:
+            lock.release()
 
     def _activate_rapidpro(self) -> None | Exception:
         api = RapidProAPI(self.payment_verification_plan.business_area.slug, RapidProAPI.MODE_VERIFICATION)

--- a/tests/unit/apps/payment/test_payment_verification_plan_view.py
+++ b/tests/unit/apps/payment/test_payment_verification_plan_view.py
@@ -387,6 +387,35 @@ def test_pvp_activate(
         assert resp_data["payment_verification_plans"][0]["status"] == PaymentVerificationPlan.STATUS_ACTIVE
 
 
+def test_pvp_activate_returns_404_when_plan_does_not_exist(
+    verification_context: dict[str, Any],
+    create_user_role_with_permissions: Any,
+) -> None:
+    create_user_role_with_permissions(
+        verification_context["user"],
+        [Permissions.PAYMENT_VERIFICATION_ACTIVATE],
+        verification_context["business_area"],
+        verification_context["program_active"],
+    )
+    missing_url = reverse(
+        "api:payments:payment-verifications-activate-payment-verification-plan",
+        kwargs={
+            "business_area_slug": verification_context["business_area"].slug,
+            "program_code": verification_context["program_active"].code,
+            "pk": str(verification_context["payment_plan"].pk),
+            "verification_plan_id": "00000000-0000-0000-0000-000000000000",
+        },
+    )
+
+    response = verification_context["client"].post(
+        missing_url,
+        {"version": verification_context["pvp"].version},
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
 @pytest.mark.django_db(transaction=True)
 def test_pvp_activate_returns_400_when_row_is_locked(
     verification_context: dict[str, Any],

--- a/tests/unit/apps/payment/test_payment_verification_plan_view.py
+++ b/tests/unit/apps/payment/test_payment_verification_plan_view.py
@@ -3,8 +3,10 @@ from pathlib import Path
 from typing import Any
 
 from django.conf import settings
+from django.db import connection
 from django.urls import reverse
 from django.utils import timezone
+import psycopg2
 import pytest
 from rest_framework import status
 
@@ -383,6 +385,56 @@ def test_pvp_activate(
         assert "id" in resp_data
         assert len(resp_data["payment_verification_plans"]) == 1
         assert resp_data["payment_verification_plans"][0]["status"] == PaymentVerificationPlan.STATUS_ACTIVE
+
+
+@pytest.mark.django_db(transaction=True)
+def test_pvp_activate_returns_400_when_row_is_locked(
+    verification_context: dict[str, Any],
+    create_user_role_with_permissions: Any,
+) -> None:
+    """Exception to the project rule of using only the ``db`` fixture.
+
+    We need ``transaction=True`` because verifying ``select_for_update(nowait=True)``
+    requires a SECOND PostgreSQL connection to hold a real row lock while the API
+    call is made on Django's connection. With the default ``db`` fixture, fixture
+    data lives in an uncommitted transaction that the second connection cannot
+    see, so the lock cannot be reproduced. ``transaction=True`` commits the
+    fixture data and truncates tables afterwards, which is the only way to make
+    a true row-level lock observable across connections.
+    """
+    create_user_role_with_permissions(
+        verification_context["user"],
+        [Permissions.PAYMENT_VERIFICATION_ACTIVATE],
+        verification_context["business_area"],
+        verification_context["program_active"],
+    )
+    pvp = verification_context["pvp"]
+
+    db = connection.settings_dict
+    locker = psycopg2.connect(
+        dbname=db["NAME"],
+        user=db["USER"],
+        password=db["PASSWORD"],
+        host=db["HOST"],
+        port=db["PORT"],
+    )
+    try:
+        with locker.cursor() as cur:
+            cur.execute(
+                "SELECT id FROM payment_paymentverificationplan WHERE id = %s FOR UPDATE",
+                [str(pvp.pk)],
+            )
+            response = verification_context["client"].post(
+                verification_context["url_activate"],
+                {"version": pvp.version},
+                format="json",
+            )
+    finally:
+        locker.rollback()
+        locker.close()
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "locked by another request" in response.content.decode()
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/apps/payment/test_verification_plan_status_change_services.py
+++ b/tests/unit/apps/payment/test_verification_plan_status_change_services.py
@@ -374,6 +374,22 @@ def test_does_payment_record_have_right_hoh_phone_number(
     assert result is True
 
 
+def test_activate_raises_when_cache_lock_is_taken(
+    rapidpro_verification_setup: dict[str, Any],
+) -> None:
+    verification = rapidpro_verification_setup["verification"]
+    lock_key = f"payment_verification_plan_activate_rapidpro_{verification.id}"
+
+    holder = cache.lock(lock_key, timeout=60 * 5)
+    holder.acquire(blocking=False)
+
+    try:
+        with pytest.raises(ValidationError, match="RapidPro activation already in progress"):
+            VerificationPlanStatusChangeServices(verification).activate()
+    finally:
+        holder.release()
+
+
 def test_export_xlsx_validation_if_no_records(
     business_area: Any,
     user: Any,


### PR DESCRIPTION
[AB#314800](https://unicef.visualstudio.com/4e044e8d-bc28-4768-8074-f80ff6e4a0e5/_workitems/edit/314800)
- guard activate dialog button against duplicate submits while pending
- acquire row lock with select_for_update(nowait=True) in API and admin
- switch cache lock to non-blocking acquire and refresh state under lock
- add tests for locked row 400 response and cache lock contention