### PR TITLE
Remove multiple cash retry for dashboard

### DIFF
--- a/src/hope/apps/dashboard/celery_tasks.py
+++ b/src/hope/apps/dashboard/celery_tasks.py
@@ -1,6 +1,7 @@
 from datetime import date
 import logging
 
+from celery import Task
 from django.conf import settings
 from django.core.cache import cache
 from django.db import OperationalError, ProgrammingError
@@ -94,7 +95,7 @@ def update_recent_dashboard_figures() -> None:
 @app.task(bind=True)
 @log_start_and_end
 @sentry_tags
-def generate_dash_report_task(self, business_area_slug: str) -> None:
+def generate_dash_report_task(self: Task, business_area_slug: str) -> None:
     """Celery task to refresh dashboard data for a specific business area (full refresh) or the global dashboard."""
     is_retrying = False
     try:

--- a/src/hope/apps/dashboard/celery_tasks.py
+++ b/src/hope/apps/dashboard/celery_tasks.py
@@ -31,16 +31,12 @@ def update_dashboard_figures() -> None:
 
     for business_area in business_areas_with_households:
         set_sentry_business_area_tag(business_area.slug)
-        try:
-            DashboardDataCache.refresh_data(business_area.slug)
-        finally:
-            cache.delete(f"dash_report_task_running_{business_area.slug}")
+        DashboardDataCache.refresh_data(business_area.slug)
+        cache.delete(f"dash_report_task_running_{business_area.slug}")
 
     set_sentry_business_area_tag("global")
-    try:
-        DashboardGlobalDataCache.refresh_data()
-    finally:
-        cache.delete(f"dash_report_task_running_{GLOBAL_SLUG}")
+    DashboardGlobalDataCache.refresh_data()
+    cache.delete(f"dash_report_task_running_{GLOBAL_SLUG}")
 
 
 @app.task(
@@ -62,21 +58,19 @@ def update_recent_dashboard_figures() -> None:
         set_sentry_business_area_tag(ba.slug)
         try:
             DashboardDataCache.refresh_data(ba.slug, years_to_refresh=years_to_refresh)
+            cache.delete(f"dash_report_task_running_{ba.slug}")
         except Exception as e:
             logger.error(
                 f"Error refreshing recent dashboard data for {ba.slug}: {e}",
                 exc_info=True,
             )
-        finally:
-            cache.delete(f"dash_report_task_running_{ba.slug}")
 
     set_sentry_business_area_tag("global")
     try:
         DashboardGlobalDataCache.refresh_data(years_to_refresh=years_to_refresh)
+        cache.delete(f"dash_report_task_running_{GLOBAL_SLUG}")
     except Exception as e:
         logger.error(f"Error refreshing recent global dashboard data: {e}", exc_info=True)
-    finally:
-        cache.delete(f"dash_report_task_running_{GLOBAL_SLUG}")
 
 
 @app.task(
@@ -87,19 +81,18 @@ def update_recent_dashboard_figures() -> None:
 @sentry_tags
 def generate_dash_report_task(business_area_slug: str) -> None:
     """Celery task to refresh dashboard data for a specific business area (full refresh) or the global dashboard."""
-    try:
-        if business_area_slug == GLOBAL_SLUG:
-            set_sentry_business_area_tag(GLOBAL_SLUG)
-            DashboardGlobalDataCache.refresh_data()
-        else:
-            try:
-                business_area = BusinessArea.objects.using(settings.DASHBOARD_DB).get(slug=business_area_slug)
-            except BusinessArea.DoesNotExist:
-                logger.error(
-                    f"Dashboard report generation failed: Business area with slug '{business_area_slug}' not found."
-                )
-                return
-            set_sentry_business_area_tag(business_area.slug)
-            DashboardDataCache.refresh_data(business_area.slug)
-    finally:
-        cache.delete(f"dash_report_task_running_{business_area_slug}")
+    if business_area_slug == GLOBAL_SLUG:
+        set_sentry_business_area_tag(GLOBAL_SLUG)
+        DashboardGlobalDataCache.refresh_data()
+    else:
+        try:
+            business_area = BusinessArea.objects.using(settings.DASHBOARD_DB).get(slug=business_area_slug)
+        except BusinessArea.DoesNotExist:
+            logger.error(
+                f"Dashboard report generation failed: Business area with slug '{business_area_slug}' not found."
+            )
+            return
+        set_sentry_business_area_tag(business_area.slug)
+        DashboardDataCache.refresh_data(business_area.slug)
+
+    cache.delete(f"dash_report_task_running_{business_area_slug}")

--- a/src/hope/apps/dashboard/celery_tasks.py
+++ b/src/hope/apps/dashboard/celery_tasks.py
@@ -31,12 +31,22 @@ def update_dashboard_figures() -> None:
 
     for business_area in business_areas_with_households:
         set_sentry_business_area_tag(business_area.slug)
-        DashboardDataCache.refresh_data(business_area.slug)
-        cache.delete(f"dash_report_task_running_{business_area.slug}")
+        lock_key = f"dash_report_task_running_{business_area.slug}"
+        lock_acquired = cache.add(lock_key, True, timeout=60 * 60)
+        try:
+            DashboardDataCache.refresh_data(business_area.slug)
+        finally:
+            if lock_acquired:
+                cache.delete(lock_key)
 
     set_sentry_business_area_tag("global")
-    DashboardGlobalDataCache.refresh_data()
-    cache.delete(f"dash_report_task_running_{GLOBAL_SLUG}")
+    global_lock_key = f"dash_report_task_running_{GLOBAL_SLUG}"
+    global_lock_acquired = cache.add(global_lock_key, True, timeout=60 * 60)
+    try:
+        DashboardGlobalDataCache.refresh_data()
+    finally:
+        if global_lock_acquired:
+            cache.delete(global_lock_key)
 
 
 @app.task(
@@ -56,43 +66,56 @@ def update_recent_dashboard_figures() -> None:
 
     for ba in BusinessArea.objects.using(settings.DASHBOARD_DB).filter(active=True):
         set_sentry_business_area_tag(ba.slug)
+        lock_key = f"dash_report_task_running_{ba.slug}"
+        lock_acquired = cache.add(lock_key, True, timeout=60 * 15)
         try:
             DashboardDataCache.refresh_data(ba.slug, years_to_refresh=years_to_refresh)
-            cache.delete(f"dash_report_task_running_{ba.slug}")
         except Exception as e:
             logger.error(
                 f"Error refreshing recent dashboard data for {ba.slug}: {e}",
                 exc_info=True,
             )
+        finally:
+            if lock_acquired:
+                cache.delete(lock_key)
 
     set_sentry_business_area_tag("global")
+    global_lock_key = f"dash_report_task_running_{GLOBAL_SLUG}"
+    global_lock_acquired = cache.add(global_lock_key, True, timeout=60 * 60)
     try:
         DashboardGlobalDataCache.refresh_data(years_to_refresh=years_to_refresh)
-        cache.delete(f"dash_report_task_running_{GLOBAL_SLUG}")
     except Exception as e:
         logger.error(f"Error refreshing recent global dashboard data: {e}", exc_info=True)
+    finally:
+        if global_lock_acquired:
+            cache.delete(global_lock_key)
 
 
-@app.task(
-    autoretry_for=(OperationalError, ProgrammingError, psycopg2.errors.InvalidCursorName),
-    retry_kwargs={"max_retries": 3, "countdown": 60},
-)
+@app.task(bind=True)
 @log_start_and_end
 @sentry_tags
-def generate_dash_report_task(business_area_slug: str) -> None:
+def generate_dash_report_task(self, business_area_slug: str) -> None:
     """Celery task to refresh dashboard data for a specific business area (full refresh) or the global dashboard."""
-    if business_area_slug == GLOBAL_SLUG:
-        set_sentry_business_area_tag(GLOBAL_SLUG)
-        DashboardGlobalDataCache.refresh_data()
-    else:
-        try:
-            business_area = BusinessArea.objects.using(settings.DASHBOARD_DB).get(slug=business_area_slug)
-        except BusinessArea.DoesNotExist:
-            logger.error(
-                f"Dashboard report generation failed: Business area with slug '{business_area_slug}' not found."
-            )
-            return
-        set_sentry_business_area_tag(business_area.slug)
-        DashboardDataCache.refresh_data(business_area.slug)
-
-    cache.delete(f"dash_report_task_running_{business_area_slug}")
+    is_retrying = False
+    try:
+        if business_area_slug == GLOBAL_SLUG:
+            set_sentry_business_area_tag(GLOBAL_SLUG)
+            DashboardGlobalDataCache.refresh_data()
+        else:
+            try:
+                business_area = BusinessArea.objects.using(settings.DASHBOARD_DB).get(slug=business_area_slug)
+            except BusinessArea.DoesNotExist:
+                logger.error(
+                    f"Dashboard report generation failed: Business area with slug '{business_area_slug}' not found."
+                )
+                return
+            set_sentry_business_area_tag(business_area.slug)
+            DashboardDataCache.refresh_data(business_area.slug)
+    except (OperationalError, ProgrammingError, psycopg2.errors.InvalidCursorName) as exc:
+        if self.request.retries < 3:
+            is_retrying = True
+            raise self.retry(exc=exc, countdown=60)
+        raise
+    finally:
+        if not is_retrying:
+            cache.delete(f"dash_report_task_running_{business_area_slug}")

--- a/src/hope/apps/dashboard/celery_tasks.py
+++ b/src/hope/apps/dashboard/celery_tasks.py
@@ -1,8 +1,10 @@
 from datetime import date
 import logging
-from typing import Any
 
 from django.conf import settings
+from django.core.cache import cache
+from django.db import OperationalError, ProgrammingError
+import psycopg2
 
 from hope.apps.core.celery import app
 from hope.apps.dashboard.services import (
@@ -17,25 +19,37 @@ from hope.models import BusinessArea
 logger = logging.getLogger(__name__)
 
 
-@app.task(bind=True, default_retry_delay=60, max_retries=3)
+@app.task(
+    autoretry_for=(OperationalError, ProgrammingError, psycopg2.errors.InvalidCursorName),
+    retry_kwargs={"max_retries": 3, "countdown": 60},
+)
 @log_start_and_end
 @sentry_tags
-def update_dashboard_figures(self: Any) -> None:
+def update_dashboard_figures() -> None:
     """Celery task that runs periodically (e.g., daily) to refresh all dashboard data."""
     business_areas_with_households = BusinessArea.objects.using(settings.DASHBOARD_DB).filter(active=True)
 
     for business_area in business_areas_with_households:
         set_sentry_business_area_tag(business_area.slug)
-        DashboardDataCache.refresh_data(business_area.slug)
+        try:
+            DashboardDataCache.refresh_data(business_area.slug)
+        finally:
+            cache.delete(f"dash_report_task_running_{business_area.slug}")
 
     set_sentry_business_area_tag("global")
-    DashboardGlobalDataCache.refresh_data()
+    try:
+        DashboardGlobalDataCache.refresh_data()
+    finally:
+        cache.delete(f"dash_report_task_running_{GLOBAL_SLUG}")
 
 
-@app.task(bind=True, default_retry_delay=300, max_retries=3)
+@app.task(
+    autoretry_for=(OperationalError, ProgrammingError, psycopg2.errors.InvalidCursorName),
+    retry_kwargs={"max_retries": 3, "countdown": 300},
+)
 @log_start_and_end
 @sentry_tags
-def update_recent_dashboard_figures(self: Any) -> None:
+def update_recent_dashboard_figures() -> None:
     """Celery task to refresh dashboard data for recent years (current and previous).
 
     Runs more frequently (e.g., hourly).
@@ -45,37 +59,47 @@ def update_recent_dashboard_figures(self: Any) -> None:
     years_to_refresh = [current_year, previous_year]
 
     for ba in BusinessArea.objects.using(settings.DASHBOARD_DB).filter(active=True):
+        set_sentry_business_area_tag(ba.slug)
         try:
-            set_sentry_business_area_tag(ba.slug)
             DashboardDataCache.refresh_data(ba.slug, years_to_refresh=years_to_refresh)
         except Exception as e:
             logger.error(
                 f"Error refreshing recent dashboard data for {ba.slug}: {e}",
                 exc_info=True,
             )
+        finally:
+            cache.delete(f"dash_report_task_running_{ba.slug}")
 
+    set_sentry_business_area_tag("global")
     try:
-        set_sentry_business_area_tag("global")
         DashboardGlobalDataCache.refresh_data(years_to_refresh=years_to_refresh)
     except Exception as e:
         logger.error(f"Error refreshing recent global dashboard data: {e}", exc_info=True)
+    finally:
+        cache.delete(f"dash_report_task_running_{GLOBAL_SLUG}")
 
 
-@app.task(bind=True, default_retry_delay=60, max_retries=3)
+@app.task(
+    autoretry_for=(OperationalError, ProgrammingError, psycopg2.errors.InvalidCursorName),
+    retry_kwargs={"max_retries": 3, "countdown": 60},
+)
 @log_start_and_end
 @sentry_tags
-def generate_dash_report_task(self: Any, business_area_slug: str) -> None:
+def generate_dash_report_task(business_area_slug: str) -> None:
     """Celery task to refresh dashboard data for a specific business area (full refresh) or the global dashboard."""
-    if business_area_slug == GLOBAL_SLUG:
-        set_sentry_business_area_tag(GLOBAL_SLUG)
-        DashboardGlobalDataCache.refresh_data()
-    else:
-        try:
-            business_area = BusinessArea.objects.using(settings.DASHBOARD_DB).get(slug=business_area_slug)
-        except BusinessArea.DoesNotExist:
-            logger.error(
-                f"Dashboard report generation failed: Business area with slug '{business_area_slug}' not found."
-            )
-            return
-        set_sentry_business_area_tag(business_area.slug)
-        DashboardDataCache.refresh_data(business_area.slug)
+    try:
+        if business_area_slug == GLOBAL_SLUG:
+            set_sentry_business_area_tag(GLOBAL_SLUG)
+            DashboardGlobalDataCache.refresh_data()
+        else:
+            try:
+                business_area = BusinessArea.objects.using(settings.DASHBOARD_DB).get(slug=business_area_slug)
+            except BusinessArea.DoesNotExist:
+                logger.error(
+                    f"Dashboard report generation failed: Business area with slug '{business_area_slug}' not found."
+                )
+                return
+            set_sentry_business_area_tag(business_area.slug)
+            DashboardDataCache.refresh_data(business_area.slug)
+    finally:
+        cache.delete(f"dash_report_task_running_{business_area_slug}")

--- a/src/hope/apps/dashboard/templates/dashboard/dashboard.html
+++ b/src/hope/apps/dashboard/templates/dashboard/dashboard.html
@@ -119,9 +119,6 @@
                 "Transaction Successful",
             ];
 
-            const maxRetries = 12;
-            const retryDelay = 5000;
-
             function initializeChartsAndMetrics(data) {
                 [
                     "payments-by-fsp",
@@ -599,24 +596,15 @@
                     isChartsInitialized = true;
             }
 
-            function attemptFetch(retryCount = 0) {
+            function attemptFetch() {
                 d3.json(url).then((fetchedData) => {
                     if (!fetchedData || fetchedData.length === 0) {
-                        if (retryCount < maxRetries) {
-                            const attemptMessage = `Dashboard data is being prepared. Automatically refreshing in ${retryDelay / 1000} seconds... (Attempt ${retryCount + 1} of ${maxRetries})`;
-                            if (loadingStatusDiv) {
-                                loadingStatusDiv.textContent = attemptMessage;
-                                loadingStatusDiv.style.display = 'block';
-                            }
-                            setTimeout(() => attemptFetch(retryCount + 1), retryDelay);
-                        } else {
-                            const errorMessage = "Could not load dashboard data after several attempts. Displaying empty dashboard. You can try refreshing the page later.";
-                            if (loadingStatusDiv) {
-                                loadingStatusDiv.textContent = errorMessage;
-                                loadingStatusDiv.style.display = 'block';
-                            }
-                            initializeChartsAndMetrics([]);
+                        const errorMessage = "No data available. Displaying empty dashboard.";
+                        if (loadingStatusDiv) {
+                            loadingStatusDiv.textContent = errorMessage;
+                            loadingStatusDiv.style.display = 'block';
                         }
+                        initializeChartsAndMetrics([]);
                     } else {
                         if (loadingStatusDiv) {
                             loadingStatusDiv.style.display = 'none';

--- a/src/hope/apps/dashboard/views.py
+++ b/src/hope/apps/dashboard/views.py
@@ -60,7 +60,10 @@ class DashboardDataView(APIView):
         data_cache: type[DashboardCacheBase] = DashboardGlobalDataCache if is_global else DashboardDataCache
         data = data_cache.get_data(slug)
         if data is None:
-            generate_dash_report_task.delay(slug)
+            task_lock_key = f"dash_report_task_running_{slug}"
+            lock_timeout = 60 * 60 if is_global else 60 * 15
+            if cache.add(task_lock_key, True, timeout=lock_timeout):
+                generate_dash_report_task.delay(slug)
             data = []
         return Response(data, status=status.HTTP_200_OK)
 
@@ -89,14 +92,16 @@ class CreateOrUpdateDashReportView(APIView):
             raise PermissionDenied(detail={"required_permissions": [Permissions.DASHBOARD_VIEW_COUNTRY.name]})
 
         try:
-            data_cache_class: type[DashboardCacheBase] = DashboardGlobalDataCache if is_global else DashboardDataCache
-            data_cache_key_to_clear = data_cache_class.get_cache_key(slug)
-            cache.delete(data_cache_key_to_clear)
-
-            generate_dash_report_task.delay(slug)
-
+            task_lock_key = f"dash_report_task_running_{slug}"
+            lock_timeout = 60 * 60 if is_global else 60 * 15
+            if cache.add(task_lock_key, True, timeout=lock_timeout):
+                generate_dash_report_task.delay(slug)
+                return Response(
+                    {"detail": _("DashReport generation task has been triggered.")},
+                    status=status.HTTP_202_ACCEPTED,
+                )
             return Response(
-                {"detail": _("DashReport generation task has been triggered.")},
+                {"detail": _("DashReport generation is already in progress.")},
                 status=status.HTTP_202_ACCEPTED,
             )
         except OperationalError as e:

--- a/tests/unit/apps/dashboard/test_tasks.py
+++ b/tests/unit/apps/dashboard/test_tasks.py
@@ -2,6 +2,8 @@ from datetime import date
 from typing import Callable
 from unittest.mock import Mock, call, patch
 
+from django.core.cache import cache
+from django.db import OperationalError
 import pytest
 
 from extras.test_utils.factories import (
@@ -180,6 +182,32 @@ def test_update_dashboard_figures_retry_on_global_failure(
         mock_global_refresh.assert_called_once_with()
 
 
+@patch("hope.apps.dashboard.celery_tasks.DashboardDataCache.refresh_data")
+def test_update_dashboard_figures_does_not_steal_existing_lock(
+    mock_ba_refresh: Mock, afghanistan: BusinessArea
+) -> None:
+    """update_dashboard_figures should not delete a lock it did not acquire."""
+    BusinessArea.objects.exclude(slug=afghanistan.slug).update(active=False)
+    lock_key = f"dash_report_task_running_{afghanistan.slug}"
+    cache.set(lock_key, True, timeout=60 * 15)  # simulate lock held by generate_dash_report_task
+
+    update_dashboard_figures.apply()
+
+    assert cache.get(lock_key) is True, "Lock should not have been deleted by update_dashboard_figures"
+
+
+@patch("hope.apps.dashboard.celery_tasks.DashboardDataCache.refresh_data")
+def test_update_dashboard_figures_releases_its_own_lock(mock_ba_refresh: Mock, afghanistan: BusinessArea) -> None:
+    """update_dashboard_figures should release the lock it acquired itself."""
+    BusinessArea.objects.exclude(slug=afghanistan.slug).update(active=False)
+    lock_key = f"dash_report_task_running_{afghanistan.slug}"
+    cache.delete(lock_key)  # ensure no lock exists
+
+    update_dashboard_figures.apply()
+
+    assert cache.get(lock_key) is None, "Lock should have been released after update_dashboard_figures"
+
+
 def test_generate_dash_report_task_retry_on_failure(afghanistan: BusinessArea) -> None:
     """
     Test that generate_dash_report_task retries on failure.
@@ -187,9 +215,9 @@ def test_generate_dash_report_task_retry_on_failure(afghanistan: BusinessArea) -
     mocked_error_message = "Mocked task error"
     with patch(
         "hope.apps.dashboard.celery_tasks.DashboardDataCache.refresh_data",
-        side_effect=Exception(mocked_error_message),
+        side_effect=OperationalError(mocked_error_message),
     ) as mock_refresh:
-        with pytest.raises(Exception, match=mocked_error_message):
+        with pytest.raises(OperationalError, match=mocked_error_message):
             generate_dash_report_task.apply(args=[afghanistan.slug], throw=True)
         mock_refresh.assert_called_once_with(afghanistan.slug)
 

--- a/tests/unit/apps/dashboard/test_tasks.py
+++ b/tests/unit/apps/dashboard/test_tasks.py
@@ -208,18 +208,45 @@ def test_update_dashboard_figures_releases_its_own_lock(mock_ba_refresh: Mock, a
     assert cache.get(lock_key) is None, "Lock should have been released after update_dashboard_figures"
 
 
-def test_generate_dash_report_task_retry_on_failure(afghanistan: BusinessArea) -> None:
+@patch("hope.apps.dashboard.celery_tasks.cache.delete")
+def test_generate_dash_report_task_retry_on_failure(mock_cache_delete: Mock, afghanistan: BusinessArea) -> None:
     """
-    Test that generate_dash_report_task retries on failure.
+    Test that generate_dash_report_task retries on failure and keeps the lock.
     """
     mocked_error_message = "Mocked task error"
     with patch(
         "hope.apps.dashboard.celery_tasks.DashboardDataCache.refresh_data",
         side_effect=OperationalError(mocked_error_message),
     ) as mock_refresh:
-        with pytest.raises(OperationalError, match=mocked_error_message):
+        with pytest.raises(Exception, match=mocked_error_message) as exc_info:
             generate_dash_report_task.apply(args=[afghanistan.slug], throw=True)
+
+        assert "Retry in 60s" in str(exc_info.value) or isinstance(exc_info.value, OperationalError)
         mock_refresh.assert_called_once_with(afghanistan.slug)
+        mock_cache_delete.assert_not_called()
+
+
+@patch("hope.apps.dashboard.celery_tasks.cache.delete")
+@patch("hope.apps.dashboard.celery_tasks.DashboardDataCache.refresh_data")
+def test_generate_dash_report_task_max_retries_exceeded(
+    mock_refresh: Mock, mock_cache_delete: Mock, afghanistan: BusinessArea
+) -> None:
+    """
+    Test that generate_dash_report_task raises the exception and deletes the lock
+    when max retries are exceeded.
+    """
+    mocked_error_message = "Mocked task error"
+    mock_refresh.side_effect = OperationalError(mocked_error_message)
+
+    generate_dash_report_task.push_request(retries=3)
+    try:
+        with pytest.raises(OperationalError, match=mocked_error_message):
+            generate_dash_report_task.run(afghanistan.slug)
+    finally:
+        generate_dash_report_task.pop_request()
+
+    mock_refresh.assert_called_once_with(afghanistan.slug)
+    mock_cache_delete.assert_called_once_with(f"dash_report_task_running_{afghanistan.slug}")
 
 
 @patch("hope.apps.dashboard.celery_tasks.DashboardGlobalDataCache.refresh_data")
@@ -270,7 +297,6 @@ def test_update_recent_dashboard_figures_ba_error_continues(
     def ba_refresh_side_effect_func(slug: str, years_to_refresh: list[int]) -> None:
         if slug == afghanistan.slug:
             raise Exception("BA refresh error for afghanistan")
-        # For other BAs (e.g., iraq), the mock should behave normally (return None)
 
     mock_ba_refresh.side_effect = ba_refresh_side_effect_func
 

--- a/tests/unit/apps/dashboard/test_views.py
+++ b/tests/unit/apps/dashboard/test_views.py
@@ -453,3 +453,50 @@ def test_dashboard_report_view_business_area_not_found_http404(rf: RequestFactor
 
     with pytest.raises(Http404):
         view.get_context_data(business_area_slug=non_existent_slug)
+
+
+@pytest.mark.django_db(databases=["default", "read_only"])
+def test_dashboard_data_view_cache_miss_lock_held(
+    api_client: Callable,
+    user: UserFactory,
+    afghanistan: BusinessArea,
+    dashboard_viewer_role: RoleFactory,
+) -> None:
+    """Test DashboardDataView when data is missing but the generation task is already running."""
+    client = api_client(user)
+    list_url = reverse("api:household-data", args=[afghanistan.slug])
+    RoleAssignment.objects.create(user=user, role=dashboard_viewer_role, business_area=afghanistan)
+
+    with (
+        patch("hope.apps.dashboard.views.DashboardDataCache.get_data", return_value=None),
+        patch("hope.apps.dashboard.views.cache.add", return_value=False) as mock_cache_add,
+        patch("hope.apps.dashboard.views.generate_dash_report_task.delay") as mock_task_delay,
+    ):
+        response = client.get(list_url)
+
+        mock_cache_add.assert_called_once()
+        mock_task_delay.assert_not_called()
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data == []
+
+
+@pytest.mark.django_db(databases=["default"])
+def test_create_or_update_dash_report_task_already_in_progress(
+    api_client: Callable, superuser: UserFactory, afghanistan: BusinessArea
+) -> None:
+    """Test that a 202 is returned with a specific message if the task is already running."""
+    client = api_client(superuser)
+    generate_report_url = reverse("api:generate-dashreport", args=[afghanistan.slug])
+
+    with (
+        patch("hope.apps.dashboard.views.cache.add", return_value=False) as mock_cache_add,
+        patch("hope.apps.dashboard.views.generate_dash_report_task.delay") as mock_task_delay,
+    ):
+        response = client.post(generate_report_url)
+
+        mock_cache_add.assert_called_once()
+        mock_task_delay.assert_not_called()
+
+    assert response.status_code == status.HTTP_202_ACCEPTED
+    assert response.data["detail"] == "DashReport generation is already in progress."

--- a/tests/unit/apps/dashboard/test_views.py
+++ b/tests/unit/apps/dashboard/test_views.py
@@ -474,7 +474,7 @@ def test_dashboard_data_view_cache_miss_lock_held(
     ):
         response = client.get(list_url)
 
-        mock_cache_add.assert_called_once()
+        mock_cache_add.assert_any_call(f"dash_report_task_running_{afghanistan.slug}", True, timeout=900)
         mock_task_delay.assert_not_called()
 
     assert response.status_code == status.HTTP_200_OK
@@ -495,7 +495,7 @@ def test_create_or_update_dash_report_task_already_in_progress(
     ):
         response = client.post(generate_report_url)
 
-        mock_cache_add.assert_called_once()
+        mock_cache_add.assert_any_call(f"dash_report_task_running_{afghanistan.slug}", True, timeout=900)
         mock_task_delay.assert_not_called()
 
     assert response.status_code == status.HTTP_202_ACCEPTED


### PR DESCRIPTION
[AB#315953](https://unicef.visualstudio.com/ICTD-HCT-MIS/_workitems/edit/315953)
Removed the frontend retry loop to prevent redundant API calls while data is loading. Implemented a Redis cache lock in the  backend to ensure only one dashboard generation task runs per business area concurrently.  