### PR TITLE
🔥 hotfix(grievances): resolve admin area pCode to label in hh data update ticket

### DIFF
--- a/src/frontend/src/components/grievances/EditHouseholdDataChange/EditHouseholdDataChangeField.tsx
+++ b/src/frontend/src/components/grievances/EditHouseholdDataChange/EditHouseholdDataChangeField.tsx
@@ -59,11 +59,6 @@ export const EditHouseholdDataChangeField = ({
         fieldProps = {
           component: FormikAsyncAutocomplete,
           restEndpoint: 'adminAreas',
-          fetchData: (data) =>
-            data?.results?.map((area) => ({
-              labelEn: `${area.name} - ${area.pCode}`,
-              value: area.pCode,
-            })),
           variables: {
             businessArea,
           },

--- a/src/frontend/src/components/grievances/RequestedHouseholdDataChangeTable/CurrentValue.tsx
+++ b/src/frontend/src/components/grievances/RequestedHouseholdDataChangeTable/CurrentValue.tsx
@@ -1,5 +1,8 @@
 import { GrievanceFlexFieldPhotoModal } from '../GrievancesPhotoModals/GrievanceFlexFieldPhotoModal';
 import { ReactElement } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { RestService } from '@restgenerated/services/RestService';
+import { useBaseUrl } from '@hooks/useBaseUrl';
 
 export interface CurrentValueProps {
   field: {
@@ -17,6 +20,17 @@ export function CurrentValue({
   field,
   value,
 }: CurrentValueProps): ReactElement {
+  const { businessArea } = useBaseUrl();
+
+  const { data: areasData } = useQuery({
+    queryKey: ['adminAreas', businessArea],
+    queryFn: () =>
+      RestService.restBusinessAreasGeoAreasList({
+        businessAreaSlug: businessArea,
+      }),
+    enabled: field?.name === 'admin_area_title' && !!businessArea,
+  });
+
   let displayValue;
 
   if (
@@ -24,19 +38,24 @@ export function CurrentValue({
     field?.name === 'country_origin' ||
     field?.name === 'admin_area_title'
   ) {
-    displayValue = value || '-';
+    if (field.name === 'admin_area_title') {
+      const area = areasData?.find((a) => a.pCode === value);
+      displayValue = area ? `${area.name} - ${area.pCode}` : value || '-';
+    } else {
+      displayValue = value || '-';
+    }
   } else {
     switch (field?.type) {
       case 'SELECT_ONE':
         displayValue =
-          field.choices.find((item) => item.value === value)?.labelEn || '-';
+          field.choices?.find((item) => item.value === value)?.labelEn || '-';
         break;
       case 'SELECT_MANY':
         if (value instanceof Array) {
           displayValue = value
             .map(
               (choice) =>
-                field.choices.find((item) => item.value === choice)?.labelEn ||
+                field.choices?.find((item) => item.value === choice)?.labelEn ||
                 '-',
             )
             .join(', ');
@@ -45,7 +64,7 @@ export function CurrentValue({
         }
         break;
       case 'BOOL':
-         
+
         displayValue = value === null ? '-' : value ? 'Yes' : 'No';
         break;
       case 'IMAGE':

--- a/src/frontend/src/components/grievances/RequestedHouseholdDataChangeTable/NewValue.tsx
+++ b/src/frontend/src/components/grievances/RequestedHouseholdDataChangeTable/NewValue.tsx
@@ -1,5 +1,8 @@
 import { GrievanceFlexFieldPhotoModal } from '../GrievancesPhotoModals/GrievanceFlexFieldPhotoModal';
 import { ReactElement } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { RestService } from '@restgenerated/services/RestService';
+import { useBaseUrl } from '@hooks/useBaseUrl';
 
 export interface NewValueProps {
   field: {
@@ -14,29 +17,46 @@ export interface NewValueProps {
 }
 
 export function NewValue({ field, value }: NewValueProps): ReactElement {
+  const { businessArea } = useBaseUrl();
+
+  const { data: areasData } = useQuery({
+    queryKey: ['adminAreas', businessArea],
+    queryFn: () =>
+      RestService.restBusinessAreasGeoAreasList({
+        businessAreaSlug: businessArea,
+      }),
+    enabled: field?.name === 'admin_area_title' && !!businessArea,
+  });
+
   let displayValue;
   switch (field?.type) {
     case 'SELECT_ONE':
-      displayValue =
-        field.choices.find((item) => item.value === value)?.labelEn ||
-        value ||
-        '-';
+      if (field.name === 'admin_area_title') {
+        const area = areasData?.find((a) => a.pCode === value);
+        displayValue = area ? `${area.name} - ${area.pCode}` : value || '-';
+      } else {
+        displayValue =
+          field.choices?.find((item) => item.value === value)?.labelEn ||
+          value ||
+          '-';
+      }
       break;
     case 'SELECT_MANY':
-      displayValue =
-        field.choices.find((item) => item.value === value)?.labelEn || '-';
       if (value instanceof Array) {
         displayValue = value
           .map(
             (choice) =>
-              field.choices.find((item) => item.value === choice)?.labelEn ||
+              field.choices?.find((item) => item.value === choice)?.labelEn ||
               '-',
           )
           .join(', ');
+      } else {
+        displayValue =
+          field.choices?.find((item) => item.value === value)?.labelEn || '-';
       }
       break;
     case 'BOOL':
-       
+
       displayValue = value === null ? '-' : value ? 'Yes' : 'No';
       break;
     case 'IMAGE':


### PR DESCRIPTION
[AB#315920](https://unicef.visualstudio.com/ICTD-HCT-MIS/_workitems/edit/315920)

**Problem**                                                       
    
  When creating a Household Data Update grievance ticket and    
  selecting the "Admin Area Title" field:
                                                                
  1. The area dropdown was empty — the fetchData prop in        
  EditHouseholdDataChangeField used data?.results?.map(...) but
  the API returns a plain array, so results was always          
  undefined.
  2. The "New Value" column in the Requested Data Change table
  showed only the raw pCode (e.g. AF16) instead of the          
  human-readable label (Lyonsbury - AF16).
  3. When a ticket was closed, the "Previous Value" column also 
  degraded to a raw pCode (AF01) because it switches from the   
  live household.adminAreaTitle string to the stored
  previousValue from the ticket data.                           
    
  **Solution**                               

  - EditHouseholdDataChangeField.tsx — removed the broken       
  fetchData prop so FormikAsyncAutocomplete falls through to its
   built-in defaultFetchData, which already handles both array  
  and paginated response shapes.
  - NewValue.tsx — added a useQuery fetch of areas (keyed
  ['adminAreas', businessArea]) for the admin_area_title field; 
  resolves the stored pCode to name - pCode for display.
  - CurrentValue.tsx — same resolution applied so the Previous  
  Value column shows the full label when viewing a closed ticket
   (where the value comes from the stored pCode rather than the
  live household model).                                        
    
  The areas query is shared between both components via the     
  React Query cache, so only one network request is made.