### PR TITLE
 [AB#311718]- fix(frontend): timezone americas (part 2) 

### DIFF
--- a/src/frontend/src/components/core/UniversalMoment.test.tsx
+++ b/src/frontend/src/components/core/UniversalMoment.test.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { UniversalMoment } from './UniversalMoment';
+
+describe('UniversalMoment', () => {
+  it('renders date-only string without timezone shift', () => {
+    render(<UniversalMoment>2024-04-11</UniversalMoment>);
+    expect(screen.getByText('11 Apr 2024')).toBeTruthy();
+  });
+
+  it('renders UTC-midnight ISO timestamp as the ISO calendar date, not shifted to local', () => {
+    // "2024-04-11T00:00:00Z" is UTC midnight April 11.
+    // In UTC-5 this would previously show "10 Apr 2024". It must show "11 Apr 2024".
+    render(<UniversalMoment>2024-04-11T00:00:00Z</UniversalMoment>);
+    expect(screen.getByText('11 Apr 2024')).toBeTruthy();
+  });
+
+  it('renders UTC-midnight ISO timestamp with milliseconds as the ISO calendar date', () => {
+    render(<UniversalMoment>2024-04-11T00:00:00.000Z</UniversalMoment>);
+    expect(screen.getByText('11 Apr 2024')).toBeTruthy();
+  });
+
+  it('renders null/empty children as a dash', () => {
+    render(<UniversalMoment>{null as unknown as string}</UniversalMoment>);
+    expect(screen.getByText('-')).toBeTruthy();
+  });
+
+  it('withTime renders a time element without throwing', () => {
+    const { container } = render(
+      <UniversalMoment withTime>2024-04-11T10:30:00Z</UniversalMoment>,
+    );
+    const timeEl = container.querySelector('time');
+    expect(timeEl).toBeTruthy();
+    expect(timeEl?.textContent).toContain('Apr 2024');
+  });
+});

--- a/src/frontend/src/components/core/UniversalMoment.tsx
+++ b/src/frontend/src/components/core/UniversalMoment.tsx
@@ -12,7 +12,9 @@ export function UniversalMoment({ children, withTime }: Props): ReactElement {
   const date = children
     ? /^\d{4}-\d{2}-\d{2}$/.test(children)
       ? parseISO(children)
-      : new Date(children)
+      : withTime
+        ? parseISO(children)
+        : parseISO(children.slice(0, 10))
     : null;
   const formattedDate = date ? format(date, dateFormat) : '-';
   const dateTime = date ? date.getTime().toString() : '';


### PR DESCRIPTION
[AB#311718](https://unicef.visualstudio.com/ICTD-HCT-MIS/_workitems/edit/311718)

PART 2
  **Fix**

  In UniversalMoment.tsx, when rendering a date
  without time (withTime is false), extract the
  YYYY-MM-DD portion of any string before
  parsing:

  // Before
  : new Date(children)

  // After
  : withTime
    ? parseISO(children)
    : parseISO(children.slice(0, 10))

  parseISO("2024-04-11") is treated as local 
  midnight by date-fns, so format() renders the
  correct calendar date regardless of the user's
  timezone offset. The withTime path is unchanged
   — real timestamps still display in local time
  as intended.
