### PR TITLE
Add Inform API form discovery for RDI imports

### DIFF
--- a/src/frontend/src/restgenerated/index.ts
+++ b/src/frontend/src/restgenerated/index.ts
@@ -109,6 +109,8 @@ export type { FullList as FullListCamelCase } from './models/FullList';
 export type { GenericImportResponse as GenericImportResponseCamelCase } from './models/GenericImportResponse';
 export type { GenericImportUpload as GenericImportUploadCamelCase } from './models/GenericImportUpload';
 export type { GetKoboAssetList as GetKoboAssetListCamelCase } from './models/GetKoboAssetList';
+export type { GetInformFormList as GetInformFormListCamelCase } from './models/GetInformFormList';
+export type { InformFormObject as InformFormObjectCamelCase } from './models/InformFormObject';
 export type { GrievanceChoices as GrievanceChoicesCamelCase } from './models/GrievanceChoices';
 export type { GrievanceComplaintTicketExtras as GrievanceComplaintTicketExtrasCamelCase } from './models/GrievanceComplaintTicketExtras';
 export type { GrievanceCreateNote as GrievanceCreateNoteCamelCase } from './models/GrievanceCreateNote';

--- a/src/frontend/src/restgenerated/models/GetInformFormList.ts
+++ b/src/frontend/src/restgenerated/models/GetInformFormList.ts
@@ -1,0 +1,13 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * Request body for retrieving the list of Inform forms.
+ *
+ * The Inform forms endpoint does not require any request body, but this
+ * empty interface is provided to maintain parity with other generated
+ * endpoints and to satisfy the TypeScript type checker.
+ */
+export type GetInformFormList = {};

--- a/src/frontend/src/restgenerated/models/InformFormObject.ts
+++ b/src/frontend/src/restgenerated/models/InformFormObject.ts
@@ -1,0 +1,17 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * Minimal representation of an Inform form as returned from the API.
+ *
+ * Only the ``id`` and ``name`` fields are guaranteed.  The
+ * ``dateModified`` field is optional and may be absent depending on the
+ * response from the Inform service.
+ */
+export type InformFormObject = {
+    id: string;
+    name: string;
+    dateModified?: string;
+};

--- a/src/frontend/src/restgenerated/services/RestService.ts
+++ b/src/frontend/src/restgenerated/services/RestService.ts
@@ -32,6 +32,8 @@ import type { FspChoices } from '../models/FspChoices';
 import type { GenericImportResponse } from '../models/GenericImportResponse';
 import type { GenericImportUpload } from '../models/GenericImportUpload';
 import type { GetKoboAssetList } from '../models/GetKoboAssetList';
+import type { GetInformFormList } from '../models/GetInformFormList';
+import type { InformFormObject } from '../models/InformFormObject';
 import type { GrievanceChoices } from '../models/GrievanceChoices';
 import type { GrievanceCreateNote } from '../models/GrievanceCreateNote';
 import type { GrievanceDashboard } from '../models/GrievanceDashboard';
@@ -14738,6 +14740,38 @@ export class RestService {
             },
             body: requestBody,
             mediaType: 'application/json',
+        });
+    }
+
+    /**
+     * Return all Inform forms available to the user.
+     *
+     * This endpoint proxies the list of forms from the Inform service.  It does
+     * not require a request body.  The returned array contains minimal
+     * metadata about each form, such as its ``id`` and ``name``.
+     *
+     * @returns InformFormObject
+     * @throws ApiError
+     */
+    public static restBusinessAreasAllInformFormsList({
+        slug,
+        ordering,
+    }: {
+        slug: string,
+        /**
+         * Which field to use when ordering the results.
+         */
+        ordering?: string,
+    }): CancelablePromise<Array<InformFormObject>> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/rest/business-areas/{slug}/all-inform-forms/',
+            path: {
+                'slug': slug,
+            },
+            query: {
+                'ordering': ordering,
+            },
         });
     }
     /**

--- a/src/hope/apps/core/api/serializers.py
+++ b/src/hope/apps/core/api/serializers.py
@@ -69,6 +69,37 @@ class KoboAssetObjectSerializer(serializers.Serializer):
     xls_link = serializers.CharField()
 
 
+# ---------------------------------------------------------------------------
+# Inform API serializers
+#
+# These serializers are used to represent data returned by the Inform
+# integration.  They closely follow the pattern used for Kobo assets but
+# provide only the fields that are relevant for listing and selecting
+# forms.  Additional fields can be added here as needed once the
+# structure of the Inform API is better understood.
+
+class InformFormObjectSerializer(serializers.Serializer):
+    """Serializer for an Inform form entry.
+
+    Only the "id" and "name" fields are required.  "date_modified" is
+    optional and may not be present on all responses.
+    """
+
+    id = serializers.CharField()
+    name = serializers.CharField()
+    date_modified = serializers.CharField(required=False)
+
+
+class GetInformFormListSerializer(serializers.Serializer):  # noqa: D401
+    """Empty serializer used solely for OpenAPI request body documentation.
+
+    The Inform forms list endpoint does not require any input body.  This
+    serializer exists to satisfy the DRF spectacular OpenAPI generator.
+    """
+
+    pass
+
+
 def attr_resolver(attname: str, default_value: Any, obj: Any) -> Any:
     return getattr(obj, attname, default_value)
 

--- a/src/hope/apps/core/api/views.py
+++ b/src/hope/apps/core/api/views.py
@@ -23,7 +23,10 @@ from hope.apps.core.api.serializers import (
     FieldAttributeSerializer,
     GetKoboAssetListSerializer,
     KoboAssetObjectSerializer,
+    InformFormObjectSerializer,
+    GetInformFormListSerializer,
 )
+from hope.apps.core.inform.api import InformAPI
 from hope.apps.core.field_attributes.fields_types import TYPE_STRING
 from hope.apps.core.languages import Languages
 from hope.apps.core.utils import (
@@ -132,6 +135,35 @@ class BusinessAreaViewSet(
             only_deployed=request.data.get("only_deployed", False),
         )
         return Response(KoboAssetObjectSerializer(assets_list, many=True).data, status=200)
+
+    @extend_schema(
+        request=GetInformFormListSerializer,
+        responses={
+            200: InformFormObjectSerializer(many=True),
+        },
+    )
+    @action(
+        detail=True,
+        methods=["get"],
+        url_path="all-inform-forms",
+        pagination_class=None,
+    )
+    def all_inform_forms(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        """Return all Inform forms available to the authenticated user.
+
+        This endpoint proxies the list of forms from the Inform API.  It
+        expects no request body.  The returned data is a list of objects
+        containing at minimum the form ID and name.  If the Inform
+        integration is not configured the response will be an empty list.
+        """
+        try:
+            api = InformAPI()
+            forms = api.get_forms()
+        except Exception:
+            # Fail gracefully by returning an empty list.  Specific errors
+            # are logged within the InformAPI class.
+            forms = []
+        return Response(InformFormObjectSerializer(forms, many=True).data, status=200)
 
 
 class ChoicesViewSet(ViewSet):

--- a/src/hope/apps/core/inform/api.py
+++ b/src/hope/apps/core/inform/api.py
@@ -1,0 +1,174 @@
+"""
+Client for interacting with UNICEF's Inform API.
+
+This module provides a thin wrapper around the Inform REST service.  It
+mirrors the pattern used by the existing KoboAPI class to maintain a
+consistent interface across data-collection platforms.  The implementation
+relies on the `requests` library and uses environment settings defined in
+``hope.config.fragments.inform``.  No additional dependencies are required.
+
+Typical usage::
+
+    from hope.apps.core.inform.api import InformAPI
+
+    api = InformAPI()
+    forms = api.get_forms()
+    for form in forms:
+        print(form["id"], form["title"])
+
+    submissions = api.get_form_submissions(form_id="12345")
+
+The class caches its session and sets the Authorization header using the
+prefix and token provided via the Django settings.  If no base URL or
+token is configured the API will still instantiate, but calls to the
+remote service will likely fail with a connection or authorization error.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List
+
+import requests
+from django.conf import settings
+
+logger = logging.getLogger(__name__)
+
+
+class InformAPIError(Exception):
+    """Base exception for Inform API errors."""
+
+
+class InformAPI:
+    """Simple client for the Inform REST API.
+
+    Parameters can be overridden when instantiating the client, but by
+    default they are pulled from the Django settings module.  The
+    Authorization header is constructed automatically using the provided
+    prefix and token.
+    """
+
+    def __init__(
+        self,
+        base_url: str | None = None,
+        token: str | None = None,
+        auth_header_prefix: str | None = None,
+        forms_endpoint: str | None = None,
+        data_endpoint_template: str | None = None,
+    ) -> None:
+        self._base_url = base_url or getattr(settings, "INFORM_API_BASE_URL", "")
+        self._token = token or getattr(settings, "INFORM_API_TOKEN", "")
+        self._auth_header_prefix = auth_header_prefix or getattr(
+            settings, "INFORM_API_AUTH_HEADER_PREFIX", "Token"
+        )
+        # Endpoint for listing forms (e.g. "/api/v1/forms")
+        self._forms_endpoint = forms_endpoint or getattr(
+            settings, "INFORM_FORMS_ENDPOINT", "/api/v1/forms"
+        )
+        # Template for retrieving submissions for a given form (e.g.
+        # "/api/v1/data/{form_id}")
+        self._data_endpoint_template = data_endpoint_template or getattr(
+            settings,
+            "INFORM_DATA_ENDPOINT_TEMPLATE",
+            "/api/v1/data/{form_id}",
+        )
+
+        self._session = requests.Session()
+        self._configure_session()
+
+    def _configure_session(self) -> None:
+        """Initialise the requests session with appropriate headers."""
+        if self._token:
+            authorization = f"{self._auth_header_prefix} {self._token}"
+            self._session.headers.update({"Authorization": authorization})
+
+    def _get(self, path: str) -> requests.Response:
+        """Send a GET request to the given path and return the Response.
+
+        Args:
+            path: The path relative to the base URL.  Should not
+                include the base URL itself.
+        Returns:
+            requests.Response: The HTTP response.
+        Raises:
+            InformAPIError: If the response status code indicates an error.
+        """
+        if not self._base_url:
+            raise InformAPIError("INFORM_API_BASE_URL is not configured.")
+        url = f"{self._base_url}{path}"
+        try:
+            response = self._session.get(url)
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as exc:  # pragma: no cover
+            logger.error("Inform API request failed: %s", exc)
+            raise InformAPIError(str(exc))
+        return response
+
+    def get_forms(self) -> List[Dict[str, Any]]:
+        """Retrieve a list of available forms from the Inform API.
+
+        Returns:
+            list[dict[str, Any]]: A list of form metadata dictionaries.  Each
+                dictionary contains at minimum an "id" and "name" key if
+                present in the response.  Additional keys are returned as
+                provided by the Inform service.
+
+        Raises:
+            InformAPIError: If the request fails.
+        """
+        response = self._get(self._forms_endpoint)
+        try:
+            data = response.json()
+        except ValueError as exc:  # pragma: no cover
+            logger.error("Failed to parse Inform forms response: %s", exc)
+            raise InformAPIError("Invalid JSON in Inform forms response")
+
+        forms: List[Dict[str, Any]] = []
+        # The API may return either a list of forms directly or wrap it in a
+        # "results" key similar to Kobo.  We normalise the result into a list.
+        if isinstance(data, list):
+            raw_forms = data
+        elif isinstance(data, dict) and "results" in data:
+            raw_forms = data.get("results", [])
+        else:
+            raw_forms = []
+
+        for item in raw_forms:
+            # Copy all available metadata but ensure id/name keys exist
+            form: Dict[str, Any] = {}
+            # Use "id" or "pk" or "uid" whichever is present
+            form_id = item.get("id") or item.get("uid") or item.get("pk")
+            if form_id is None:
+                # Skip invalid entries
+                continue
+            form["id"] = str(form_id)
+            # Name may be under different keys; fall back to title if present
+            form_name = item.get("name") or item.get("title") or item.get("form_id") or ""
+            form["name"] = form_name
+            # Include date modified if available
+            if "date_modified" in item:
+                form["date_modified"] = item.get("date_modified")
+            forms.append(form)
+
+        return forms
+
+    def get_form_submissions(self, form_id: str) -> Any:
+        """Retrieve submissions for a given form.
+
+        Args:
+            form_id: The ID of the form whose submissions should be pulled.
+        Returns:
+            Any: JSON parsed response containing submissions.
+
+        Raises:
+            InformAPIError: If the request fails.
+        """
+        if not form_id:
+            raise InformAPIError("form_id must be provided")
+        endpoint = self._data_endpoint_template.format(form_id=form_id)
+        response = self._get(endpoint)
+        try:
+            return response.json()
+        except ValueError as exc:  # pragma: no cover
+            logger.error("Failed to parse Inform submissions response: %s", exc)
+            raise InformAPIError("Invalid JSON in Inform submissions response")

--- a/src/hope/config/env.py
+++ b/src/hope/config/env.py
@@ -42,6 +42,20 @@ DEFAULTS = {
     "KOBO_URL": (str, "https://kobo-hope-trn.unitst.org"),
     "KOBO_MASTER_API_TOKEN": (str, "KOBO_TOKEN"),
     "KOBO_PROJECT_VIEWS_ID": (str, ""),
+
+    # Inform API configuration.  These settings control connectivity to the
+    # UNICEF Inform service used for data collection.  See
+    # hope/config/fragments/inform.py for more details.  A blank default means
+    # the integration will be disabled unless explicitly configured.
+    "INFORM_API_BASE_URL": (str, ""),
+    "INFORM_API_TOKEN": (str, ""),
+    # Prefix for the Authorization header.  Typically "Token".
+    "INFORM_API_AUTH_HEADER_PREFIX": (str, "Token"),
+    # Template for pulling data from a specific form.  Should include
+    # "{form_id}" placeholder.
+    "INFORM_DATA_ENDPOINT_TEMPLATE": (str, "/api/v1/data/{form_id}"),
+    # Endpoint for listing available forms.
+    "INFORM_FORMS_ENDPOINT": (str, "/api/v1/forms"),
     "AZURE_CLIENT_ID": (str, ""),
     "AZURE_CLIENT_SECRET": (str, ""),
     "AZURE_TENANT_ID": (str, ""),

--- a/src/hope/config/fragments/inform.py
+++ b/src/hope/config/fragments/inform.py
@@ -1,0 +1,36 @@
+"""
+Environment configuration for the Inform API integration.
+
+This fragment defines a handful of configuration variables that control how
+HOPE interacts with the UNICEF Inform service.  Values are loaded from
+environment variables using the project's SmartEnv wrapper.  If an
+environment variable is missing the default value will be used instead.
+
+Variables defined here:
+
+* INFORM_API_BASE_URL: Base URL for the Inform API (e.g. https://data.inform.unicef.org).
+* INFORM_API_TOKEN: API authentication token for requests to Inform.
+* INFORM_API_AUTH_HEADER_PREFIX: Prefix for the Authorization header (defaults to "Token").
+* INFORM_DATA_ENDPOINT_TEMPLATE: URL template for pulling data for a single form.
+  Defaults to "/api/v1/data/{form_id}".
+* INFORM_FORMS_ENDPOINT: Endpoint for listing all available forms.  Defaults to
+  "/api/v1/forms".
+
+To configure these variables set them in the environment (e.g. in your
+.env file or secret manager).  For example:
+
+    INFORM_API_BASE_URL=https://data.inform.unicef.org
+    INFORM_API_TOKEN=my-super-secret-token
+
+If any variable is unset the default will be used.
+"""
+
+from hope.config.env import env
+
+INFORM_API_BASE_URL = env("INFORM_API_BASE_URL")
+INFORM_API_TOKEN = env("INFORM_API_TOKEN")
+INFORM_API_AUTH_HEADER_PREFIX = env("INFORM_API_AUTH_HEADER_PREFIX", default="Token")
+INFORM_DATA_ENDPOINT_TEMPLATE = env(
+    "INFORM_DATA_ENDPOINT_TEMPLATE", default="/api/v1/data/{form_id}"
+)
+INFORM_FORMS_ENDPOINT = env("INFORM_FORMS_ENDPOINT", default="/api/v1/forms")

--- a/src/hope/config/settings.py
+++ b/src/hope/config/settings.py
@@ -503,6 +503,10 @@ from hope.config.fragments.drf_spectacular import *  # noqa: F403, F401, E402
 from hope.config.fragments.es import *  # noqa: F403, F401, E402
 from hope.config.fragments.hope import *  # noqa: F403, F401, E402
 from hope.config.fragments.kobo import *  # noqa: F403, F401, E402
+# Inform API configuration.  Importing this fragment exposes INFORM_* settings
+# such as INFORM_API_BASE_URL, INFORM_API_TOKEN, INFORM_DATA_ENDPOINT_TEMPLATE
+# and INFORM_FORMS_ENDPOINT.  See hope/config/fragments/inform.py for details.
+from hope.config.fragments.inform import *  # noqa: F403, F401, E402
 from hope.config.fragments.loggers import *  # noqa: F403, F401, E402
 from hope.config.fragments.mailjet import *  # noqa: F403, F401, E402
 from hope.config.fragments.matomo import *  # noqa: F403, F401, E402


### PR DESCRIPTION
## Summary

This PR adds an initial Inform API integration scaffold for HOPE Country Workspace RDI imports.

The main purpose is to allow country offices using UNICEF Inform for data collection to discover available Inform forms dynamically from HOPE, rather than manually exporting data and reshaping it outside the system.

## What this PR adds

- New Inform API configuration using environment variables.
- Inform API client for listing available Inform forms.
- Inform API client method for retrieving form submissions by form ID.
- New backend endpoint to return Inform forms available to the configured Inform user.
- Frontend-generated model/service additions for consuming the Inform forms list endpoint.

## Why this is needed

Some country offices and partners may use Inform as their primary data collection platform. At the moment, HOPE Country Workspace appears to support import flows mainly through KoBo, Aurora, and XLS/RDI.

This can create additional manual steps where ICT/IM teams export data from Inform, clean it in Excel, reshape it to match RDI requirements, and then import it into HOPE.

Adding Inform as an additional API-based source would improve interoperability and reduce manual handling.

## Notes

This PR intentionally keeps the implementation generic. It does not hard-code any Inform form ID. Forms are discovered dynamically through the configured Inform forms endpoint.

The Inform API token and base URL are configured via environment variables and are not stored in source code.

## Follow-up work

Further implementation may be needed to complete the end-to-end import flow, including:

- mapping Inform submissions to HOPE RDI structures;
- handling repeat groups for household members;
- adding import polling/status handling;
- adding validation messages for Inform-specific data issues;
- connecting the form selection UI into the full RDI import workflow.