### PR TITLE
309534_WesterUnion_invoice_log_data_matching_parse_fix

### DIFF
--- a/src/hope/admin/western_union_payment_plan_report.py
+++ b/src/hope/admin/western_union_payment_plan_report.py
@@ -1,17 +1,32 @@
 from adminfilters.autocomplete import AutoCompleteFilter
 from adminfilters.mixin import AdminFiltersMixin
 from django.contrib import admin
+from django.forms import ModelForm
 from django.utils.html import format_html
 
 from hope.admin.utils import AutocompleteForeignKeyMixin
 from hope.models import WesternUnionPaymentPlanReport
 
 
+class WesternUnionPaymentPlanReportAdminForm(ModelForm):
+    class Meta:
+        model = WesternUnionPaymentPlanReport
+        fields = ["qcf_file", "report_file", "payment_plan", "sent"]
+        labels = {"qcf_file": "Invoice"}
+
+
 @admin.register(WesternUnionPaymentPlanReport)
 class WesternUnionPaymentPlanReportAdmin(AutocompleteForeignKeyMixin, AdminFiltersMixin, admin.ModelAdmin):
-    list_display = ["id", "qcf_file", "payment_plan"]
+    form = WesternUnionPaymentPlanReportAdminForm
+    list_display = ["id", "invoice", "payment_plan"]
     list_filter = [("payment_plan", AutoCompleteFilter)]
     readonly_fields = ["download_link"]
+
+    def invoice(self, obj: WesternUnionPaymentPlanReport) -> str:
+        return str(obj.qcf_file)
+
+    invoice.short_description = "Invoice"
+    invoice.admin_order_field = "qcf_file"
 
     def download_link(self, obj: WesternUnionPaymentPlanReport) -> str:  # pragma: no cover
         if not obj.report_file:

--- a/src/hope/admin/western_union_payment_plan_report.py
+++ b/src/hope/admin/western_union_payment_plan_report.py
@@ -1,32 +1,17 @@
 from adminfilters.autocomplete import AutoCompleteFilter
 from adminfilters.mixin import AdminFiltersMixin
 from django.contrib import admin
-from django.forms import ModelForm
 from django.utils.html import format_html
 
 from hope.admin.utils import AutocompleteForeignKeyMixin
 from hope.models import WesternUnionPaymentPlanReport
 
 
-class WesternUnionPaymentPlanReportAdminForm(ModelForm):
-    class Meta:
-        model = WesternUnionPaymentPlanReport
-        fields = ["qcf_file", "report_file", "payment_plan", "sent"]
-        labels = {"qcf_file": "Invoice"}
-
-
 @admin.register(WesternUnionPaymentPlanReport)
 class WesternUnionPaymentPlanReportAdmin(AutocompleteForeignKeyMixin, AdminFiltersMixin, admin.ModelAdmin):
-    form = WesternUnionPaymentPlanReportAdminForm
-    list_display = ["id", "invoice", "payment_plan"]
+    list_display = ["id", "qcf_file", "payment_plan"]
     list_filter = [("payment_plan", AutoCompleteFilter)]
     readonly_fields = ["download_link"]
-
-    def invoice(self, obj: WesternUnionPaymentPlanReport) -> str:
-        return str(obj.qcf_file)
-
-    invoice.short_description = "Invoice"
-    invoice.admin_order_field = "qcf_file"
 
     def download_link(self, obj: WesternUnionPaymentPlanReport) -> str:  # pragma: no cover
         if not obj.report_file:

--- a/src/hope/apps/payment/services/qcf_reports_service.py
+++ b/src/hope/apps/payment/services/qcf_reports_service.py
@@ -137,8 +137,10 @@ class QCFReportsService:
 
     FILENAME_DATE_FORMAT = "%Y%m%d"
     FILENAME_DATE_PATTERN = re.compile(r"(\d{8})(?=[^0-9]*\.[^.]+$)")
-    DATA_PDF_PRINCIPAL_PATTERN = re.compile(r"Principal\s+([\d,]+\.\d{2})", re.MULTILINE)
-    DATA_PDF_CHARGES_PATTERN = re.compile(r"Charges\s+([\d,]+\.\d{2})", re.MULTILINE)
+    DATA_PDF_PARTNER_TOTAL_PATTERN = re.compile(
+        r"Partner\s+Total\s+[A-Z]{3}\s+(-?[\d,]+\.\d{2})\s+(-?[\d,]+\.\d{2})\s+(-?[\d,]+\.\d{2})\s+(-?[\d,]+\.\d{2})",
+        re.MULTILINE,
+    )
 
     def __init__(self) -> None:
         self._ftp_client: WesternUnionFTPClient | None = None
@@ -490,7 +492,7 @@ class QCFReportsService:
         advice_name, pdf_bytes = self.extract_pdf_from_archive(filename, file_like.read())
         pdf_text = self.extract_text_from_pdf(filename, pdf_bytes)
         net_amount = self.parse_principal_amount_from_pdf_text(pdf_text, filename)
-        charges = self.parse_charges_amount_from_pdf_text(pdf_text)
+        charges = self.parse_charges_amount_from_pdf_text(pdf_text, filename)
         if not advice_name:
             raise self.QCFReportsServiceError(f"No advice filename found in invoice file {filename}")
 
@@ -631,16 +633,16 @@ class QCFReportsService:
             raise self.QCFReportsServiceError(f"Could not parse decimal value {value}") from exc
 
     def parse_principal_amount_from_pdf_text(self, pdf_text: str, filename: str) -> Decimal:
-        match = self.DATA_PDF_PRINCIPAL_PATTERN.search(pdf_text)
+        match = self.DATA_PDF_PARTNER_TOTAL_PATTERN.search(pdf_text)
         if not match:
             raise self.QCFReportsServiceError(f"Could not parse principal amount from AD PDF in {filename}")
         return self.to_decimal(match.group(1).replace(",", ""))
 
-    def parse_charges_amount_from_pdf_text(self, pdf_text: str) -> Decimal:
-        match = self.DATA_PDF_CHARGES_PATTERN.search(pdf_text)
+    def parse_charges_amount_from_pdf_text(self, pdf_text: str, filename: str) -> Decimal:
+        match = self.DATA_PDF_PARTNER_TOTAL_PATTERN.search(pdf_text)
         if not match:
-            return Decimal("0.00")
-        return self.to_decimal(match.group(1).replace(",", ""))
+            raise self.QCFReportsServiceError(f"Could not parse charges amount from AD PDF in {filename}")
+        return self.to_decimal(match.group(2).replace(",", ""))
 
     def generate_report(
         self,

--- a/tests/unit/apps/payment/test_qcf_reports_service.py
+++ b/tests/unit/apps/payment/test_qcf_reports_service.py
@@ -1564,7 +1564,9 @@ def test_parse_principal_amount_from_pdf_text(
     build_zip_file: Callable[[str, str | bytes], io.BytesIO],
     build_payment_row: Callable[[], MatchedDataPaymentRow],
 ) -> None:
-    assert service.parse_principal_amount_from_pdf_text("Principal 1,190.32", "ad.zip") == Decimal("1190.32")
+    pdf_text = "Partner Total USD -1,190.32 35.72 0.00 -1,154.60"
+
+    assert service.parse_principal_amount_from_pdf_text(pdf_text, "ad.zip") == Decimal("-1190.32")
     with pytest.raises(
         service.QCFReportsServiceError, match=re.escape("Could not parse principal amount from AD PDF in ad.zip")
     ):
@@ -1578,8 +1580,13 @@ def test_parse_charges_amount_from_pdf_text(
     build_zip_file: Callable[[str, str | bytes], io.BytesIO],
     build_payment_row: Callable[[], MatchedDataPaymentRow],
 ) -> None:
-    assert service.parse_charges_amount_from_pdf_text("Charges 35.72") == Decimal("35.72")
-    assert service.parse_charges_amount_from_pdf_text("missing") == Decimal("0.00")
+    pdf_text = "Partner Total USD 1,190.32 -35.72 0.00 1,154.60"
+
+    assert service.parse_charges_amount_from_pdf_text(pdf_text, "ad.zip") == Decimal("-35.72")
+    with pytest.raises(
+        service.QCFReportsServiceError, match=re.escape("Could not parse charges amount from AD PDF in ad.zip")
+    ):
+        service.parse_charges_amount_from_pdf_text("missing", "ad.zip")
 
 
 def test_payment_plan_data_post_init_tracks_principal_charges_refunds_and_fees(


### PR DESCRIPTION
[AB#309534](https://unicef.visualstudio.com/4e044e8d-bc28-4768-8074-f80ff6e4a0e5/_workitems/edit/309534)

  This branch updates Western Union AD invoice parsing to read principal and charges from the PDF Partner Total row, including negative amounts used in 2026 settlement files.

  It also updates the related parser tests and renames the misleading qcf_file admin label in WesternUnionPaymentPlanReport to Invoice in the list and detail views.