### PR TITLE
Missing migration check fix for docker setup

### DIFF
--- a/scripts/precommit_check_migrations.sh
+++ b/scripts/precommit_check_migrations.sh
@@ -3,8 +3,13 @@ set -euo pipefail
 
 COMPOSE=(docker compose -f development_tools/compose.yml -f development_tools/compose.override.yml)
 
+# Computed on the host (which has .git); passed into the container so the
+# Django command never needs git itself. Empty value = no untracked files.
+UNTRACKED_MIGRATIONS=$(git ls-files --others --exclude-standard -- src/hope/ 2>/dev/null || true)
+export UNTRACKED_MIGRATIONS
+
 if "${COMPOSE[@]}" ps --status running --services 2>/dev/null | grep -qx backend; then
-    exec "${COMPOSE[@]}" exec -T backend python manage.py check_missing_migrations
+    exec "${COMPOSE[@]}" exec -T -e UNTRACKED_MIGRATIONS backend python manage.py check_missing_migrations
 elif command -v uv >/dev/null 2>&1; then
     exec uv run python manage.py check_missing_migrations
 else

--- a/src/hope/apps/core/management/commands/check_missing_migrations.py
+++ b/src/hope/apps/core/management/commands/check_missing_migrations.py
@@ -1,5 +1,5 @@
+import os
 import re
-import subprocess
 from typing import Any
 
 from django.apps import apps
@@ -35,13 +35,8 @@ class Command(BaseCommand):
             *labels,
         )
 
-        result = subprocess.run(
-            ["git", "ls-files", "--others", "--exclude-standard", "--", "src/hope/"],  # noqa: S607
-            check=True,
-            capture_output=True,
-            text=True,
-        )
-        untracked = [line for line in result.stdout.splitlines() if _MIGRATION_FILE_RE.search(line)]
+        raw = os.environ.get("UNTRACKED_MIGRATIONS", "")
+        untracked = [line for line in raw.splitlines() if _MIGRATION_FILE_RE.search(line)]
         if untracked:
             raise CommandError(
                 "migration files present on disk but not tracked in git:\n"


### PR DESCRIPTION
Missing migration check on precommit did not work properly for docker setup. In order to fix that I moved git command to be runned on local environment and just pass its output for further processing scripts, that can be executed both locally and in docker container.