### PR TITLE
fix(universal-update-script): scope program picker to saveable programmes

### DIFF
--- a/src/hope/admin/universal_update_script.py
+++ b/src/hope/admin/universal_update_script.py
@@ -4,11 +4,12 @@ from admin_extra_buttons.buttons import ButtonWidget
 from admin_extra_buttons.decorators import button
 from django import forms
 from django.contrib import admin
-from django.contrib.admin.widgets import FilteredSelectMultiple
+from django.contrib.admin.widgets import AutocompleteSelect, FilteredSelectMultiple
 from django.contrib.postgres.forms import SimpleArrayField
-from django.db.models import QuerySet
-from django.http import HttpRequest
+from django.db.models import Q, QuerySet
+from django.http import HttpRequest, JsonResponse
 from django.shortcuts import get_object_or_404
+from django.urls import path, reverse
 
 from hope.admin.utils import HOPEModelAdminBase
 from hope.apps.universal_update_script.celery_tasks import (
@@ -21,7 +22,35 @@ from hope.apps.universal_update_script.universal_individual_update_service.all_u
     household_fields,
     individual_fields,
 )
-from hope.models import AccountType, DocumentType, UniversalUpdate
+from hope.models import AccountType, DocumentType, Program, UniversalUpdate
+
+PROGRAM_AUTOCOMPLETE_URL_SUFFIX = "program_autocomplete"
+
+
+def format_program_label(program: Program) -> str:
+    """Disambiguate same-named programmes across business areas."""
+    return f"{program.name} — {program.business_area.name} ({program.code})"
+
+
+class ProgramAutocompleteSelect(AutocompleteSelect):
+    """Program autocomplete scoped to UniversalUpdateAdmin.
+
+    The stock admin autocomplete is served by ProgramAdmin, which lists removed
+    programmes (SoftDeletableAdminMixin uses ``all_objects``) — picking one then
+    fails save validation. This widget targets a UniversalUpdateAdmin-local
+    endpoint backed by ``Program.objects``, so only saveable programmes appear.
+    """
+
+    def get_url(self) -> str:
+        meta = UniversalUpdate._meta
+        return reverse(f"admin:{meta.app_label}_{meta.model_name}_{PROGRAM_AUTOCOMPLETE_URL_SUFFIX}")
+
+
+class ProgramChoiceField(forms.ModelChoiceField):
+    """Programme choice field whose option labels carry the business area."""
+
+    def label_from_instance(self, obj: Any) -> str:
+        return format_program_label(obj)
 
 
 class ArrayFieldFilteredSelectMultiple(FilteredSelectMultiple):
@@ -174,6 +203,45 @@ class UniversalUpdateAdmin(HOPEModelAdminBase):
             },
         ),
     )
+
+    def formfield_for_foreignkey(self, db_field: Any, request: HttpRequest, **kwargs: Any) -> Any:
+        if db_field.name == "program":
+            kwargs["queryset"] = Program.objects.select_related("business_area")
+            kwargs["widget"] = ProgramAutocompleteSelect(db_field, self.admin_site)
+            kwargs["form_class"] = ProgramChoiceField
+        return super().formfield_for_foreignkey(db_field, request, **kwargs)
+
+    def get_urls(self) -> list[Any]:
+        info = self.model._meta.app_label, self.model._meta.model_name
+        custom_urls = [
+            path(
+                "program-autocomplete/",
+                self.admin_site.admin_view(self.program_autocomplete_view),
+                name=f"{info[0]}_{info[1]}_{PROGRAM_AUTOCOMPLETE_URL_SUFFIX}",
+            ),
+        ]
+        return custom_urls + super().get_urls()
+
+    def program_autocomplete_view(self, request: HttpRequest) -> JsonResponse:
+        # Backed by Program.objects (excludes removed/invisible) so the picker
+        # only ever offers programmes that will pass save validation.
+        page_size = 20
+        programs = Program.objects.select_related("business_area").order_by("business_area__name", "name", "code")
+        if term := request.GET.get("term"):
+            # AND the words, OR across name / code / business area — mirrors the
+            # multi-word behaviour of the stock admin autocomplete search.
+            for word in term.split():
+                programs = programs.filter(
+                    Q(name__icontains=word) | Q(code__icontains=word) | Q(business_area__name__icontains=word)
+                )
+        try:
+            page = max(int(request.GET.get("page", 1)), 1)
+        except (TypeError, ValueError):
+            page = 1
+        start = (page - 1) * page_size
+        chunk = list(programs[start : start + page_size + 1])
+        results = [{"id": str(program.pk), "text": format_program_label(program)} for program in chunk[:page_size]]
+        return JsonResponse({"results": results, "pagination": {"more": len(chunk) > page_size}})
 
     def logs_property(self, obj: UniversalUpdate) -> str:
         return obj.logs or "-"

--- a/tests/unit/apps/universal_update_script/test_admin.py
+++ b/tests/unit/apps/universal_update_script/test_admin.py
@@ -1,7 +1,16 @@
+import json
+
+from django.contrib import admin
 from django.urls import reverse
 import pytest
 
 from extras.test_utils.factories import BusinessAreaFactory, ProgramFactory
+from hope.admin.universal_update_script import (
+    ProgramAutocompleteSelect,
+    ProgramChoiceField,
+    UniversalUpdateAdmin,
+    format_program_label,
+)
 from hope.models import Program, UniversalUpdate, User
 
 pytestmark = pytest.mark.django_db
@@ -36,6 +45,26 @@ def program(business_area):
     )
 
 
+@pytest.fixture
+def removed_program(business_area):
+    removed = ProgramFactory(
+        name="Disability Cash Transfers",
+        status=Program.DRAFT,
+        business_area=business_area,
+    )
+    removed.delete()
+    return removed
+
+
+@pytest.fixture
+def active_program(business_area, removed_program):
+    return ProgramFactory(
+        name="Disability Cash Transfers",
+        status=Program.ACTIVE,
+        business_area=business_area,
+    )
+
+
 def test_universal_update_admin_edit_page_loads(client_logged, program):
     universal_update = UniversalUpdate.objects.create(
         program=program,
@@ -50,4 +79,80 @@ def test_universal_update_admin_edit_page_loads(client_logged, program):
     response = client_logged.get(url)
 
     assert response.status_code == 200
-    assert "Test Program for Household" in response.content.decode()
+    assert format_program_label(program) in response.content.decode()
+
+
+def test_add_page_program_field_uses_scoped_autocomplete(client_logged):
+    autocomplete_url = reverse("admin:universal_update_script_universalupdate_program_autocomplete")
+
+    response = client_logged.get(reverse("admin:universal_update_script_universalupdate_add"))
+
+    assert response.status_code == 200
+    assert autocomplete_url in response.content.decode()
+
+
+def test_program_autocomplete_excludes_removed_and_shows_business_area(client_logged, active_program, removed_program):
+    response = client_logged.get(
+        reverse("admin:universal_update_script_universalupdate_program_autocomplete"),
+        data={"term": "Disability Cash Transfers"},
+    )
+
+    assert response.status_code == 200
+    results_by_id = {item["id"]: item["text"] for item in response.json()["results"]}
+    assert str(active_program.pk) in results_by_id
+    assert str(removed_program.pk) not in results_by_id
+    assert active_program.business_area.name in results_by_id[str(active_program.pk)]
+
+
+def test_program_autocomplete_without_term_lists_saveable_programmes(client_logged, active_program, removed_program):
+    response = client_logged.get(
+        reverse("admin:universal_update_script_universalupdate_program_autocomplete"),
+    )
+
+    assert response.status_code == 200
+    result_ids = {item["id"] for item in response.json()["results"]}
+    assert str(active_program.pk) in result_ids
+    assert str(removed_program.pk) not in result_ids
+
+
+def test_program_autocomplete_handles_invalid_page(client_logged, active_program):
+    response = client_logged.get(
+        reverse("admin:universal_update_script_universalupdate_program_autocomplete"),
+        data={"page": "not-a-number"},
+    )
+
+    assert response.status_code == 200
+    result_ids = {item["id"] for item in response.json()["results"]}
+    assert str(active_program.pk) in result_ids
+
+
+def test_program_autocomplete_view_runs_single_query(rf, django_assert_num_queries, active_program, removed_program):
+    model_admin = UniversalUpdateAdmin(UniversalUpdate, admin.site)
+    request = rf.get("/", data={"term": "Disability"})
+
+    with django_assert_num_queries(1):
+        response = model_admin.program_autocomplete_view(request)
+
+    assert response.status_code == 200
+    assert json.loads(response.content)["results"]
+
+
+def test_program_autocomplete_matches_business_area_name(client_logged, active_program, removed_program):
+    response = client_logged.get(
+        reverse("admin:universal_update_script_universalupdate_program_autocomplete"),
+        data={"term": active_program.business_area.name},
+    )
+
+    assert response.status_code == 200
+    result_ids = {item["id"] for item in response.json()["results"]}
+    assert str(active_program.pk) in result_ids
+
+
+def test_formfield_for_foreignkey_leaves_non_program_relations_unchanged(rf):
+    model_admin = UniversalUpdateAdmin(UniversalUpdate, admin.site)
+    business_area_fk = Program._meta.get_field("business_area")
+
+    formfield = model_admin.formfield_for_foreignkey(business_area_fk, rf.get("/"))
+
+    assert not isinstance(formfield.widget, ProgramAutocompleteSelect)
+    assert not isinstance(formfield, ProgramChoiceField)


### PR DESCRIPTION
- add UniversalUpdateAdmin-local autocomplete backed by Program.objects so removed programmes are excluded
- show business area in program option labels to disambiguate same-named programmes
- add tests covering autocomplete scoping, search, paging, and query count