### PR TITLE
Revert wokspace and dedupe

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,9 +17,10 @@ repos:
             -   id: tox-ini-fmt
                 args: [ "-p", "lint" ]
     -   repo: https://github.com/tox-dev/pyproject-fmt
-        rev: "v2.20.0"
+        rev: "v2.21.2"
         hooks:
             -   id: pyproject-fmt
+                additional_dependencies: ["toml-fmt-common<1.3"]
     -   repo: https://github.com/astral-sh/ruff-pre-commit
         rev: "v0.15.7"
         hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [ "setuptools", "wheel" ]
 
 [project]
 name = "hope"
-version = "4.16.0"
+version = "4.15.0"
 description = "HCT MIS is UNICEF's humanitarian cash transfer platform."
 readme = "README.md"
 license = { text = "None" }

--- a/src/hope/api/endpoints/rdi/base.py
+++ b/src/hope/api/endpoints/rdi/base.py
@@ -29,7 +29,7 @@ class RDISerializer(serializers.ModelSerializer):
     )
     imported_by_email = serializers.EmailField(required=True, write_only=True)
     country_workspace_id = serializers.CharField(
-        required=True,
+        required=False,
         allow_blank=False,
         max_length=255,
     )
@@ -37,11 +37,6 @@ class RDISerializer(serializers.ModelSerializer):
     class Meta:
         model = RegistrationDataImport
         fields = ("name", "program", "imported_by_email", "country_workspace_id")
-
-    def validate_country_workspace_id(self, value: str) -> str:
-        if RegistrationDataImport.objects.filter(country_workspace_id=value).exists():
-            raise serializers.ValidationError("country_workspace_id must be unique")
-        return value
 
     def create(self, validated_data: dict) -> None:
         validated_data.pop("imported_by_email", None)

--- a/src/hope/api/endpoints/rdi/lax.py
+++ b/src/hope/api/endpoints/rdi/lax.py
@@ -20,7 +20,6 @@ from rest_framework.response import Response
 
 from hope.api.endpoints.base import HOPEAPIBusinessAreaView
 from hope.api.endpoints.rdi.common import (
-    CountryWorkspaceIdConditionalMixin,
     DisabilityChoiceField,
     NullableChoiceField,
 )
@@ -122,7 +121,7 @@ class AccountLaxSerializer(serializers.ModelSerializer):
         return attrs
 
 
-class IndividualSerializer(CountryWorkspaceIdConditionalMixin, serializers.ModelSerializer):
+class IndividualSerializer(serializers.ModelSerializer):
     first_registration_date = serializers.DateTimeField(default=timezone.now)
     last_registration_date = serializers.DateTimeField(default=timezone.now)
     household = serializers.ReadOnlyField()

--- a/src/hope/api/endpoints/rdi/push_people.py
+++ b/src/hope/api/endpoints/rdi/push_people.py
@@ -1,4 +1,3 @@
-from collections import Counter
 from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
@@ -13,7 +12,6 @@ from rest_framework.response import Response
 
 from hope.api.endpoints.base import HOPEAPIBusinessAreaView, HOPEAPIView
 from hope.api.endpoints.rdi.common import (
-    CountryWorkspaceIdConditionalMixin,
     DisabilityChoiceField,
     NullableChoiceField,
 )
@@ -58,22 +56,7 @@ class DynamicAreaChoiceField(serializers.ChoiceField):
     pass
 
 
-class PushPeopleListSerializer(serializers.ListSerializer):
-    def validate(self, attrs: list[dict]) -> list[dict]:
-        cw_ids = [item["country_workspace_id"] for item in attrs if item.get("country_workspace_id")]
-        duplicates = sorted(cw_id for cw_id, count in Counter(cw_ids).items() if count > 1)
-        if duplicates:
-            raise serializers.ValidationError(
-                {
-                    "country_workspace_id": [
-                        f"Duplicate country_workspace_id values in payload: {', '.join(duplicates)}."
-                    ]
-                }
-            )
-        return attrs
-
-
-class PushPeopleSerializer(CountryWorkspaceIdConditionalMixin, serializers.ModelSerializer):
+class PushPeopleSerializer(serializers.ModelSerializer):
     first_registration_date = serializers.DateTimeField(default=timezone.now)
     last_registration_date = serializers.DateTimeField(default=timezone.now)
     observed_disability = serializers.MultipleChoiceField(
@@ -120,7 +103,6 @@ class PushPeopleSerializer(CountryWorkspaceIdConditionalMixin, serializers.Model
 
     class Meta:
         model = PendingIndividual
-        list_serializer_class = PushPeopleListSerializer
         exclude = [
             "id",
             "registration_data_import",

--- a/tests/unit/api/test_push_people_country_workspace_id.py
+++ b/tests/unit/api/test_push_people_country_workspace_id.py
@@ -13,7 +13,7 @@ from hope.models import (
     RegistrationDataImport,
 )
 
-pytestmark = [pytest.mark.django_db]
+pytestmark = pytest.mark.django_db
 
 
 @pytest.fixture

--- a/tests/unit/api/test_push_people_country_workspace_id.py
+++ b/tests/unit/api/test_push_people_country_workspace_id.py
@@ -13,7 +13,7 @@ from hope.models import (
     RegistrationDataImport,
 )
 
-pytestmark = [pytest.mark.django_db, pytest.mark.skip(reason="country_workspace_id temporarily disabled")]
+pytestmark = [pytest.mark.django_db]
 
 
 @pytest.fixture
@@ -83,6 +83,7 @@ def test_cw_individual_push_with_country_workspace_id_persists(
     assert ind.country_workspace_id == "cw-ind-001"
 
 
+@pytest.mark.skip(reason="country_workspace_id temporarily disabled")
 def test_cw_individual_push_without_country_workspace_id_returns_400(
     token_api_client,
     push_people_url: str,
@@ -99,6 +100,7 @@ def test_cw_individual_push_without_country_workspace_id_returns_400(
     assert PendingIndividual.objects.filter(registration_data_import=rdi).count() == 0
 
 
+@pytest.mark.skip(reason="country_workspace_id temporarily disabled")
 def test_cw_individual_push_blank_country_workspace_id_returns_400(
     token_api_client,
     push_people_url: str,
@@ -116,6 +118,7 @@ def test_cw_individual_push_blank_country_workspace_id_returns_400(
     ]
 
 
+@pytest.mark.skip(reason="country_workspace_id temporarily disabled")
 def test_cw_individual_push_partial_failure_when_one_missing_field(
     token_api_client,
     push_people_url: str,
@@ -138,6 +141,7 @@ def test_cw_individual_push_partial_failure_when_one_missing_field(
     assert PendingIndividual.objects.filter(registration_data_import=rdi).count() == 0
 
 
+@pytest.mark.skip(reason="country_workspace_id temporarily disabled")
 def test_cw_individual_push_duplicate_country_workspace_id_in_same_payload_returns_400(
     token_api_client,
     push_people_url: str,
@@ -159,6 +163,7 @@ def test_cw_individual_push_duplicate_country_workspace_id_in_same_payload_retur
     assert PendingIndividual.objects.filter(registration_data_import=rdi).count() == 0
 
 
+@pytest.mark.skip(reason="country_workspace_id temporarily disabled")
 def test_cw_individual_push_multiple_duplicate_groups_lists_all_sorted(
     token_api_client,
     push_people_url: str,

--- a/tests/unit/api/test_push_people_country_workspace_id.py
+++ b/tests/unit/api/test_push_people_country_workspace_id.py
@@ -13,7 +13,7 @@ from hope.models import (
     RegistrationDataImport,
 )
 
-pytestmark = pytest.mark.django_db
+pytestmark = [pytest.mark.django_db, pytest.mark.skip(reason="country_workspace_id temporarily disabled")]
 
 
 @pytest.fixture

--- a/tests/unit/api/test_rdi_cw_country_workspace_id.py
+++ b/tests/unit/api/test_rdi_cw_country_workspace_id.py
@@ -9,7 +9,7 @@ from rest_framework.test import APIClient
 from extras.test_utils.factories.registration_data import RegistrationDataImportFactory
 from hope.models import BusinessArea, Program, RegistrationDataImport, User
 
-pytestmark = pytest.mark.django_db
+pytestmark = [pytest.mark.django_db, pytest.mark.skip(reason="country_workspace_id temporarily disabled")]
 
 
 @pytest.fixture

--- a/tests/unit/api/test_rdi_cw_country_workspace_id.py
+++ b/tests/unit/api/test_rdi_cw_country_workspace_id.py
@@ -9,7 +9,7 @@ from rest_framework.test import APIClient
 from extras.test_utils.factories.registration_data import RegistrationDataImportFactory
 from hope.models import BusinessArea, Program, RegistrationDataImport, User
 
-pytestmark = [pytest.mark.django_db, pytest.mark.skip(reason="country_workspace_id temporarily disabled")]
+pytestmark = [pytest.mark.django_db]
 
 
 @pytest.fixture
@@ -35,7 +35,7 @@ def test_cw_push_payload_country_workspace_id_maps_to_country_workspace_id(
 ) -> None:
     payload = {**cw_create_payload, "country_workspace_id": "cw-correlation-abc-123"}
 
-    with django_assert_num_queries(10):
+    with django_assert_num_queries(9):
         response = token_api_client.post(cw_create_url, payload, format="json")
 
     assert response.status_code == status.HTTP_201_CREATED, str(response.json())
@@ -43,6 +43,7 @@ def test_cw_push_payload_country_workspace_id_maps_to_country_workspace_id(
     assert rdi.country_workspace_id == "cw-correlation-abc-123"
 
 
+@pytest.mark.skip(reason="country_workspace_id temporarily disabled")
 def test_cw_push_without_country_workspace_id_returns_400(
     token_api_client: APIClient,
     cw_create_url: str,
@@ -55,6 +56,7 @@ def test_cw_push_without_country_workspace_id_returns_400(
     assert RegistrationDataImport.objects.filter(name=cw_create_payload["name"]).count() == 0
 
 
+@pytest.mark.skip(reason="country_workspace_id temporarily disabled")
 def test_cw_push_with_blank_country_workspace_id_returns_400(
     token_api_client: APIClient,
     cw_create_url: str,
@@ -68,6 +70,7 @@ def test_cw_push_with_blank_country_workspace_id_returns_400(
     assert "country_workspace_id" in response.json()
 
 
+@pytest.mark.skip(reason="country_workspace_id temporarily disabled")
 def test_cw_push_duplicate_country_workspace_id_rejected(
     token_api_client: APIClient,
     cw_create_url: str,

--- a/tests/unit/api/test_rdi_cw_country_workspace_id.py
+++ b/tests/unit/api/test_rdi_cw_country_workspace_id.py
@@ -9,7 +9,7 @@ from rest_framework.test import APIClient
 from extras.test_utils.factories.registration_data import RegistrationDataImportFactory
 from hope.models import BusinessArea, Program, RegistrationDataImport, User
 
-pytestmark = [pytest.mark.django_db]
+pytestmark = pytest.mark.django_db
 
 
 @pytest.fixture

--- a/tests/unit/apps/household/test_individual_filter_views.py
+++ b/tests/unit/apps/household/test_individual_filter_views.py
@@ -34,7 +34,7 @@ from hope.apps.household.const import (
 from hope.apps.utils.elasticsearch_utils import rebuild_search_index
 from hope.models import BusinessArea, Individual, MergeStatusModel, Program
 
-pytestmark = [pytest.mark.django_db]
+pytestmark = pytest.mark.django_db
 
 
 def _create_test_individuals(

--- a/tests/unit/contrib/aurora/test_utils.py
+++ b/tests/unit/contrib/aurora/test_utils.py
@@ -10,7 +10,7 @@ from extras.test_utils.factories import RecordFactory
 from hope.contrib.aurora.models import Organization, Project, Record, Registration
 from hope.contrib.aurora.utils import fetch_metadata, fetch_records, get_metadata
 
-pytestmark = [pytest.mark.django_db]
+pytestmark = pytest.mark.django_db
 
 
 @pytest.fixture

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = "==3.14.*"
 
 [manifest]
@@ -1981,7 +1981,7 @@ wheels = [
 
 [[package]]
 name = "hope"
-version = "4.16.0"
+version = "4.15.0"
 source = { editable = "." }
 dependencies = [
     { name = "black" },

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = "==3.14.*"
 
 [manifest]


### PR DESCRIPTION
-  Temporarily disabled the country_workspace_id validation requirements across the RDI serializers. 
- Reverted the project version bump in pyproject.toml from 4.16.0 back to 4.15.0. 
- Fixed the test suite by skipping the disabled feature tests