### PR TITLE
feat: add SENTRY_TRACES_SAMPLE_RATE

### DIFF
--- a/src/hope/config/env.py
+++ b/src/hope/config/env.py
@@ -58,6 +58,7 @@ DEFAULTS = {
     "SENTRY_DSN": (str, ""),
     "SENTRY_ENVIRONMENT": (str, ""),
     "SENTRY_ENABLE_TRACING": (bool, False),
+    "SENTRY_TRACES_SAMPLE_RATE": (float, 1.0),
     "CELERY_BROKER_URL": (str, ""),
     "CELERY_BROKER_VISIBILITY_TIMEOUT": (int, 0),
     "CELERY_RESULT_BACKEND": (str, ""),

--- a/src/hope/config/fragments/sentry.py
+++ b/src/hope/config/fragments/sentry.py
@@ -5,6 +5,7 @@ from hope.config.env import env
 SENTRY_DSN = env("SENTRY_DSN")
 SENTRY_ENVIRONMENT = env("SENTRY_ENVIRONMENT")
 SENTRY_ENABLE_TRACING = env("SENTRY_ENABLE_TRACING")
+SENTRY_TRACES_SAMPLE_RATE = env("SENTRY_TRACES_SAMPLE_RATE")
 
 if SENTRY_DSN:
     import sentry_sdk
@@ -28,7 +29,7 @@ if SENTRY_DSN:
         ],
         release=get_full_version(),
         enable_tracing=SENTRY_ENABLE_TRACING,
-        traces_sample_rate=1.0,
+        traces_sample_rate=SENTRY_TRACES_SAMPLE_RATE,
         send_default_pii=True,
         ignore_errors=[
             "ValidationError",


### PR DESCRIPTION
Changing SENTRY_TRACES_SAMPLE_RATE in Sentry affects how many performance traces your application sends to Sentry.

What it does

SENTRY_TRACES_SAMPLE_RATE is a value between 0 and 1:

0.0 → sends no traces (performance monitoring effectively off)
1.0 → sends 100% of traces
0.1 → sends 10% of traces, etc.