### PR TITLE
[AB#319588]-Show admin link to staff users, not only superusers

### DIFF
--- a/src/hope/apps/core/api/mixins.py
+++ b/src/hope/apps/core/api/mixins.py
@@ -288,7 +288,7 @@ class AdminUrlSerializerMixin(serializers.Serializer):
 
     def get_admin_url(self, obj: Any) -> str | None:
         request = self.context.get("request")
-        if request and request.user.is_superuser:
+        if request and request.user.is_staff:
             return obj.admin_url
         return None
 

--- a/src/hope/apps/program/api/serializers.py
+++ b/src/hope/apps/program/api/serializers.py
@@ -152,7 +152,7 @@ class ProgramCycleListSerializer(serializers.ModelSerializer):
 
     def get_admin_url(self, obj: ProgramCycle) -> str | None:
         user = self.context["request"].user
-        return obj.admin_url if user.is_superuser else None
+        return obj.admin_url if user.is_staff else None
 
     def get_can_remove_cycle(self, obj: ProgramCycle) -> bool:
         return obj.can_remove_cycle

--- a/tests/unit/apps/accountability/test_feedback_viewset.py
+++ b/tests/unit/apps/accountability/test_feedback_viewset.py
@@ -48,7 +48,7 @@ def authenticated_client(api_client, user):
 
 @pytest.fixture
 def superuser(partner, business_area):
-    u = UserFactory(partner=partner, first_name="Super", last_name="User", is_superuser=True)
+    u = UserFactory(partner=partner, first_name="Super", last_name="User", is_staff=True, is_superuser=True)
     partner.allowed_business_areas.add(business_area)
     return u
 

--- a/tests/unit/apps/accountability/test_message_viewset.py
+++ b/tests/unit/apps/accountability/test_message_viewset.py
@@ -47,7 +47,7 @@ def user(partner):
 
 @pytest.fixture
 def superuser(partner):
-    return UserFactory(partner=partner, first_name="Super", last_name="User", is_superuser=True)
+    return UserFactory(partner=partner, first_name="Super", last_name="User", is_staff=True, is_superuser=True)
 
 
 @pytest.fixture

--- a/tests/unit/apps/household/test_household_list_views.py
+++ b/tests/unit/apps/household/test_household_list_views.py
@@ -800,8 +800,9 @@ def test_household_detail_with_permissions(
 
 def test_household_detail_admin_url(household_detail_context: dict[str, Any]) -> None:
     user = household_detail_context["user"]
+    user.is_staff = True
     user.is_superuser = True
-    user.save(update_fields=["is_superuser"])
+    user.save(update_fields=["is_staff", "is_superuser"])
 
     response = household_detail_context["api_client"].get(
         reverse(

--- a/tests/unit/apps/household/test_individual_list_views.py
+++ b/tests/unit/apps/household/test_individual_list_views.py
@@ -1051,6 +1051,7 @@ def test_individual_detail(detail_context: dict, create_user_role_with_permissio
 
 def test_individual_detail_admin_url(detail_context: dict) -> None:
     ctx = detail_context
+    ctx["user"].is_staff = True
     ctx["user"].is_superuser = True
     ctx["user"].save()
     response = ctx["client"].get(

--- a/tests/unit/apps/program/test_views_program_cycle.py
+++ b/tests/unit/apps/program/test_views_program_cycle.py
@@ -186,6 +186,49 @@ def test_retrieve_program_cycle_with_permission(
     assert response.status_code == status.HTTP_200_OK
 
 
+def test_retrieve_program_cycle_admin_url_for_staff_user(
+    authenticated_client: Any,
+    user: User,
+    afghanistan: BusinessArea,
+    program: Program,
+    cycle1: ProgramCycle,
+    cycle_1_detail_url: str,
+    create_user_role_with_permissions: Callable,
+) -> None:
+    create_user_role_with_permissions(
+        user=user,
+        permissions=[Permissions.PM_PROGRAMME_CYCLE_VIEW_DETAILS],
+        business_area=afghanistan,
+        program=program,
+    )
+    user.is_staff = True
+    user.save(update_fields=["is_staff"])
+
+    response = authenticated_client.get(cycle_1_detail_url)
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["admin_url"] == cycle1.admin_url
+
+
+def test_retrieve_program_cycle_admin_url_hidden_for_non_staff_user(
+    authenticated_client: Any,
+    user: User,
+    afghanistan: BusinessArea,
+    program: Program,
+    cycle_1_detail_url: str,
+    create_user_role_with_permissions: Callable,
+) -> None:
+    create_user_role_with_permissions(
+        user=user,
+        permissions=[Permissions.PM_PROGRAMME_CYCLE_VIEW_DETAILS],
+        business_area=afghanistan,
+        program=program,
+    )
+
+    response = authenticated_client.get(cycle_1_detail_url)
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["admin_url"] is None
+
+
 def test_retrieve_program_cycle_without_permission(
     authenticated_client: Any,
     user: User,


### PR DESCRIPTION
[AB#319588](https://dev.azure.com/unicef/ICTD-HCT-MIS/_workitems/edit/319588): Admin button should be available to all users with is_staff=True

The admin link (`AdminButton`) is rendered only when the backend returns a non-null `admin_url`. Previously that field was gated on `is_superuser`, so only superusers saw the link. This changes the gate to `is_staff`, so any staff user — i.e. anyone who can actually access the Django admin — sees the link.

## Changes
- `AdminUrlSerializerMixin.get_admin_url` (`core/api/mixins.py`) and the program-cycle `get_admin_url` (`program/api/serializers.py`): check `user.is_staff` instead of `user.is_superuser`.
- Tests: added program-cycle tests proving a staff non-superuser receives `admin_url` and a non-staff user gets `None`; updated existing privileged-user fixtures to set `is_staff=True` (as Django's `createsuperuser` always does).

No frontend changes required — the component already renders purely on `adminUrl` presence, and the REST schema is unchanged (`string | null`).