### PR TITLE
Hotfix change wu ftp parse window

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [ "setuptools", "wheel" ]
 
 [project]
 name = "hope"
-version = "4.15.3"
+version = "4.15.4"
 description = "HCT MIS is UNICEF's humanitarian cash transfer platform."
 readme = "README.md"
 license = { text = "None" }

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "4.15.3",
+  "version": "4.15.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/hope/apps/payment/celery_tasks.py
+++ b/src/hope/apps/payment/celery_tasks.py
@@ -1329,10 +1329,12 @@ class CheckRapidProVerificationTask:
 def periodic_sync_payment_plan_invoices_western_union_ftp_async_task_action(job: AsyncRetryJob | None = None) -> None:
     from datetime import datetime, timedelta
 
+    from constance import config
+
     from hope.apps.payment.services.qcf_reports_service import QCFReportsService
 
     service = QCFReportsService()
-    service.process_files_since(datetime.now() - timedelta(hours=24))
+    service.process_files_since(datetime.now() - timedelta(days=config.WU_FTP_SYNC_LOOKBACK_DAYS))
 
 
 @app.task()

--- a/src/hope/config/fragments/constance.py
+++ b/src/hope/config/fragments/constance.py
@@ -76,6 +76,11 @@ CONSTANCE_CONFIG = {
         "Batch size for image upload",
         "positive_integers",
     ),
+    "WU_FTP_SYNC_LOOKBACK_DAYS": (
+        31,
+        "Number of days back to scan Western Union FTP for AD/QCF files during periodic sync",
+        "positive_integers",
+    ),
     "PRODUCTION_SERVER": ("https://hope.unicef.org/api/admin", "", str),
     "KOBO_ADMIN_CREDENTIALS": (
         "",


### PR DESCRIPTION
Increase the Western Union FTP sync lookback window to a configurable Constance setting with a 31-day default to avoid missing delayed AD/QCF files.