### PR TITLE
319585_Service_Provider_Code_should_not_come_from_registration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [ "setuptools", "wheel" ]
 
 [project]
 name = "hope"
-version = "4.15.4"
+version = "4.15.5"
 description = "HCT MIS is UNICEF's humanitarian cash transfer platform."
 readme = "README.md"
 license = { text = "None" }

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "4.15.4",
+  "version": "4.15.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/hope/apps/payment/services/payment_gateway.py
+++ b/src/hope/apps/payment/services/payment_gateway.py
@@ -120,7 +120,7 @@ class PaymentSerializer(ReadOnlyModelSerializer):
     def _map_financial_institution(self, obj: Payment, account_data: dict) -> dict:
         financial_institution_pk = account_data.get("financial_institution_pk") or account_data.get(
             "financial_institution"
-        )  # TODO remove account_data.get("financial_institution") later
+        )
         if financial_institution_pk:
             financial_institution = FinancialInstitution.objects.get(pk=financial_institution_pk)
             if financial_institution.is_generic:
@@ -197,7 +197,9 @@ class PaymentSerializer(ReadOnlyModelSerializer):
         }
 
         if account_data:
-            if account_type == "bank":
+            account_data = account_data.copy()
+            if not account_data.get("service_provider_code"):
+                # Backward-compatible fallback for snapshots created before service_provider_code was resolved.
                 account_data = self._map_financial_institution(obj, account_data)
             payload_data["account"] = account_data
 

--- a/src/hope/models/payment_data_collector.py
+++ b/src/hope/models/payment_data_collector.py
@@ -54,10 +54,14 @@ class PaymentDataCollector(Account):
         if financial_institution.is_generic:
             return None
 
-        return FinancialInstitutionMapping.objects.filter(
-            financial_institution=financial_institution,
-            financial_service_provider=fsp,
-        ).values_list("code", flat=True).first()
+        return (
+            FinancialInstitutionMapping.objects.filter(
+                financial_institution=financial_institution,
+                financial_service_provider=fsp,
+            )
+            .values_list("code", flat=True)
+            .first()
+        )
 
     @classmethod
     def resolve_required_field(

--- a/src/hope/models/payment_data_collector.py
+++ b/src/hope/models/payment_data_collector.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Any
 
 from hope.models.account import Account
 from hope.models.delivery_mechanism_config import DeliveryMechanismConfig
+from hope.models.financial_institution_mapping import FinancialInstitutionMapping
 from hope.models.fsp_name_mapping import FspNameMapping
 from hope.models.individual import Individual
 
@@ -11,6 +12,8 @@ if TYPE_CHECKING:
 
 
 class PaymentDataCollector(Account):
+    SERVICE_PROVIDER_CODE = "service_provider_code"
+
     @classmethod
     def get_associated_object(
         cls,
@@ -26,6 +29,65 @@ class PaymentDataCollector(Account):
         return associated_objects.get(associated_with)
 
     @classmethod
+    def get_delivery_mechanism_config(
+        cls,
+        fsp: "FinancialServiceProvider",
+        delivery_mechanism: "DeliveryMechanism",
+        collector: Individual,
+    ) -> DeliveryMechanismConfig | None:
+        dm_configs = DeliveryMechanismConfig.objects.filter(fsp=fsp, delivery_mechanism=delivery_mechanism)
+        collector_country = collector.household and collector.household.country
+        if collector_country and (country_config := dm_configs.filter(country=collector_country).first()):
+            return country_config
+        return dm_configs.first()
+
+    @classmethod
+    def resolve_financial_institution_code(
+        cls,
+        fsp: "FinancialServiceProvider",
+        account: Account | None,
+    ) -> str | None:
+        if not account or not account.financial_institution:
+            return None
+
+        financial_institution = account.financial_institution
+        if financial_institution.is_generic:
+            return None
+
+        return FinancialInstitutionMapping.objects.filter(
+            financial_institution=financial_institution,
+            financial_service_provider=fsp,
+        ).values_list("code", flat=True).first()
+
+    @classmethod
+    def resolve_required_field(
+        cls,
+        fsp: "FinancialServiceProvider",
+        collector: Individual,
+        account: Account | None,
+        output_field: str,
+        fsp_name_mapping: FspNameMapping | None,
+    ) -> Any:
+        if fsp_name_mapping:
+            internal_field = fsp_name_mapping.hope_name
+            associated_object = cls.get_associated_object(fsp_name_mapping.source, collector, account)
+        else:
+            internal_field = output_field
+            associated_object = account.account_data if account else {}
+
+        if isinstance(associated_object, dict):
+            value = associated_object.get(internal_field, None)
+        else:
+            value = getattr(associated_object, internal_field, None)
+
+        if cls.SERVICE_PROVIDER_CODE in (output_field, internal_field):
+            financial_institution_code = cls.resolve_financial_institution_code(fsp, account)
+            if financial_institution_code not in [None, ""]:
+                return financial_institution_code
+
+        return value
+
+    @classmethod
     def delivery_data(
         cls,
         fsp: "FinancialServiceProvider",
@@ -33,32 +95,21 @@ class PaymentDataCollector(Account):
         collector: "Individual",
     ) -> dict:
         delivery_data = {}
-        account = collector.accounts.filter(account_type=delivery_mechanism.account_type).first()
+        account = (
+            collector.accounts.select_related("financial_institution")
+            .filter(account_type=delivery_mechanism.account_type)
+            .first()
+        )
 
-        dm_configs = DeliveryMechanismConfig.objects.filter(fsp=fsp, delivery_mechanism=delivery_mechanism)
-        collector_country = collector.household and collector.household.country
-        dm_config: DeliveryMechanismConfig | None
-        if collector_country and (country_config := dm_configs.filter(country=collector_country).first()):
-            dm_config = country_config
-        else:
-            dm_config = dm_configs.first()
+        dm_config = cls.get_delivery_mechanism_config(fsp, delivery_mechanism, collector)
         if not dm_config:
             return account.account_data if account else {}
 
         fsp_names_mappings = {x.external_name: x for x in fsp.names_mappings.all()}
 
         for field in dm_config.required_fields:
-            if fsp_name_mapping := fsp_names_mappings.get(field):
-                internal_field = fsp_name_mapping.hope_name
-                associated_object = cls.get_associated_object(fsp_name_mapping.source, collector, account)
-            else:
-                internal_field = field
-                associated_object = account.account_data if account else {}
-            if isinstance(associated_object, dict):
-                value = associated_object.get(internal_field, None)
-                delivery_data[field] = value and str(value)
-            else:
-                delivery_data[field] = getattr(associated_object, internal_field, None)
+            value = cls.resolve_required_field(fsp, collector, account, field, fsp_names_mappings.get(field))
+            delivery_data[field] = value and str(value)
 
         if account:
             delivery_data.setdefault("number", account.number)
@@ -78,31 +129,25 @@ class PaymentDataCollector(Account):
             # ex. "cash" - doesn't need any validation
             return True
 
-        account = collector.accounts.filter(account_type=delivery_mechanism.account_type).first()
+        account = (
+            collector.accounts.select_related("financial_institution")
+            .filter(account_type=delivery_mechanism.account_type)
+            .first()
+        )
 
         fsp_names_mappings = {x.external_name: x for x in fsp.names_mappings.all()}
-        dm_configs = DeliveryMechanismConfig.objects.filter(fsp=fsp, delivery_mechanism=delivery_mechanism)
-
-        collector_country = collector.household and collector.household.country
-        dm_config: DeliveryMechanismConfig | None
-        if collector_country and (country_config := dm_configs.filter(country=collector_country).first()):
-            dm_config = country_config
-        else:
-            dm_config = dm_configs.first()
+        dm_config = cls.get_delivery_mechanism_config(fsp, delivery_mechanism, collector)
         if not dm_config:
             return True
 
         for field_value in dm_config.required_fields:
-            field = field_value
-            if fsp_name_mapping := fsp_names_mappings.get(field):
-                field = fsp_name_mapping.hope_name
-                associated_object = cls.get_associated_object(fsp_name_mapping.source, collector, account)
-            else:
-                associated_object = account.account_data if account else {}
-            if isinstance(associated_object, dict):
-                value = associated_object.get(field, None)
-            else:
-                value = getattr(associated_object, field, None)
+            value = cls.resolve_required_field(
+                fsp,
+                collector,
+                account,
+                field_value,
+                fsp_names_mappings.get(field_value),
+            )
 
             if value in [None, ""]:
                 return False

--- a/tests/unit/apps/payment/test_model_payment_data_collector.py
+++ b/tests/unit/apps/payment/test_model_payment_data_collector.py
@@ -211,10 +211,13 @@ def test_delivery_data_setter(account_setup):
 
 
 def test_get_delivery_mechanism_config_uses_country_specific_config(account_setup):
+    country = CountryFactory()
+    account_setup["household"].country = country
+    account_setup["household"].save(update_fields=["country"])
     country_config = DeliveryMechanismConfig.objects.create(
         fsp=account_setup["fsp"],
         delivery_mechanism=account_setup["dm_atm_card"],
-        country=account_setup["household"].country,
+        country=country,
         required_fields=["country_specific_field"],
     )
 

--- a/tests/unit/apps/payment/test_model_payment_data_collector.py
+++ b/tests/unit/apps/payment/test_model_payment_data_collector.py
@@ -210,6 +210,50 @@ def test_delivery_data_setter(account_setup):
     }
 
 
+def test_get_delivery_mechanism_config_uses_country_specific_config(account_setup):
+    country_config = DeliveryMechanismConfig.objects.create(
+        fsp=account_setup["fsp"],
+        delivery_mechanism=account_setup["dm_atm_card"],
+        country=account_setup["household"].country,
+        required_fields=["country_specific_field"],
+    )
+
+    assert (
+        PaymentDataCollector.get_delivery_mechanism_config(
+            account_setup["fsp"],
+            account_setup["dm_atm_card"],
+            account_setup["individual"],
+        )
+        == country_config
+    )
+
+
+def test_resolve_financial_institution_code_returns_none_without_account_or_financial_institution(account_setup):
+    account = AccountFactory(
+        individual=account_setup["individual"],
+        account_type=account_setup["account_type_bank"],
+        financial_institution=None,
+        rdi_merge_status=MergeStatusModel.MERGED,
+    )
+
+    assert PaymentDataCollector.resolve_financial_institution_code(account_setup["fsp"], None) is None
+    assert PaymentDataCollector.resolve_financial_institution_code(account_setup["fsp"], account) is None
+
+
+def test_delivery_data_without_account_does_not_add_account_defaults(account_setup):
+    dm_config = account_setup["dm_config"]
+    dm_config.required_fields = ["service_provider_code"]
+    dm_config.save(update_fields=["required_fields"])
+
+    assert PaymentDataCollector.delivery_data(
+        account_setup["fsp"],
+        account_setup["dm_atm_card"],
+        account_setup["individual"],
+    ) == {
+        "service_provider_code": None,
+    }
+
+
 def test_validate_account(account_setup):
     fsp = account_setup["fsp"]
     collector = account_setup["individual"]

--- a/tests/unit/apps/payment/test_model_payment_data_collector.py
+++ b/tests/unit/apps/payment/test_model_payment_data_collector.py
@@ -2,11 +2,13 @@ from typing import Any
 
 import pytest
 
+from extras.test_utils.factories.geo import CountryFactory
 from extras.test_utils.factories.household import HouseholdFactory, IndividualFactory
 from extras.test_utils.factories.payment import (
     AccountFactory,
     AccountTypeFactory,
     DeliveryMechanismFactory,
+    FinancialInstitutionMappingFactory,
     FinancialServiceProviderFactory,
 )
 from extras.test_utils.factories.program import ProgramFactory
@@ -273,3 +275,90 @@ def test_validate_account(account_setup):
     collector.phone_no = ""
     collector.save(update_fields=["phone_no"])
     assert PaymentDataCollector.validate_account(fsp, account_setup["dm_atm_card"], collector) is False
+
+
+def test_validate_account_resolves_service_provider_code_from_financial_institution(account_setup):
+    fsp = account_setup["fsp"]
+    collector = account_setup["individual"]
+    financial_institution = account_setup["financial_institution"]
+    financial_institution.country = CountryFactory()
+    financial_institution.save(update_fields=["country"])
+    dm_config = account_setup["dm_config"]
+    dm_config.required_fields = ["service_provider_code"]
+    dm_config.save(update_fields=["required_fields"])
+
+    AccountFactory(
+        number="test",
+        data={"provider": "woop"},
+        individual=collector,
+        account_type=account_setup["account_type_bank"],
+        financial_institution=financial_institution,
+        rdi_merge_status=MergeStatusModel.MERGED,
+    )
+
+    assert PaymentDataCollector.validate_account(fsp, account_setup["dm_atm_card"], collector) is False
+
+    FinancialInstitutionMappingFactory(
+        financial_institution=financial_institution,
+        financial_service_provider=fsp,
+        code="WOOP-WU",
+    )
+
+    assert PaymentDataCollector.validate_account(fsp, account_setup["dm_atm_card"], collector) is True
+
+
+def test_delivery_data_stores_resolved_service_provider_code(account_setup):
+    fsp = account_setup["fsp"]
+    collector = account_setup["individual"]
+    financial_institution = account_setup["financial_institution"]
+    financial_institution.country = CountryFactory()
+    financial_institution.save(update_fields=["country"])
+    dm_config = account_setup["dm_config"]
+    dm_config.required_fields = ["provider", "service_provider_code"]
+    dm_config.save(update_fields=["required_fields"])
+
+    account = AccountFactory(
+        number="test",
+        data={"provider": "woop", "service_provider_code": "STALE-CODE"},
+        individual=collector,
+        account_type=account_setup["account_type_bank"],
+        financial_institution=financial_institution,
+        rdi_merge_status=MergeStatusModel.MERGED,
+    )
+    FinancialInstitutionMappingFactory(
+        financial_institution=financial_institution,
+        financial_service_provider=fsp,
+        code="WOOP-WU",
+    )
+
+    assert PaymentDataCollector.delivery_data(fsp, account_setup["dm_atm_card"], collector) == {
+        "provider": "woop",
+        "service_provider_code": "WOOP-WU",
+        "number": account.number,
+        "financial_institution_name": str(financial_institution.name),
+        "financial_institution_pk": str(financial_institution.id),
+    }
+
+
+def test_delivery_data_uses_existing_service_provider_code_when_financial_institution_code_missing(account_setup):
+    fsp = account_setup["fsp"]
+    collector = account_setup["individual"]
+    dm_config = account_setup["dm_config"]
+    dm_config.required_fields = ["service_provider_code"]
+    dm_config.save(update_fields=["required_fields"])
+
+    account = AccountFactory(
+        number="test",
+        data={"service_provider_code": "EXISTING-CODE"},
+        individual=collector,
+        account_type=account_setup["account_type_bank"],
+        financial_institution=account_setup["financial_institution"],
+        rdi_merge_status=MergeStatusModel.MERGED,
+    )
+
+    assert PaymentDataCollector.delivery_data(fsp, account_setup["dm_atm_card"], collector) == {
+        "service_provider_code": "EXISTING-CODE",
+        "number": account.number,
+        "financial_institution_name": str(account_setup["financial_institution"].name),
+        "financial_institution_pk": str(account_setup["financial_institution"].id),
+    }

--- a/tests/unit/apps/payment/test_payment_gateway_service.py
+++ b/tests/unit/apps/payment/test_payment_gateway_service.py
@@ -1788,6 +1788,25 @@ def test_map_financial_institution_pk_and_mapping_found(payment_gateway_setup: d
     assert result["number"] == "123"
 
 
+def test_payment_payload_uses_service_provider_code_from_snapshot(payment_gateway_setup: dict) -> None:
+    payment = payment_gateway_setup["payments"][0]
+    payment.delivery_type = payment_gateway_setup["delivery_mechanisms"]["transfer"]
+    payment.save(update_fields=["delivery_type"])
+    snapshot = payment.household_snapshot
+    snapshot.snapshot_data["primary_collector"]["account_data"] = {
+        "number": "123",
+        "financial_institution_pk": "999",
+        "service_provider_code": "SNAPSHOT_CODE",
+    }
+    snapshot.save(update_fields=["snapshot_data"])
+
+    with patch.object(PaymentSerializer, "_map_financial_institution") as map_financial_institution_mock:
+        payload = PaymentSerializer().get_payload(payment)
+
+    map_financial_institution_mock.assert_not_called()
+    assert payload["account"]["service_provider_code"] == "SNAPSHOT_CODE"
+
+
 def test_map_financial_institution_pk_and_mapping_missing_logs_and_returns_original_data(
     payment_gateway_setup: dict,
 ) -> None:


### PR DESCRIPTION
[AB#319585](https://unicef.visualstudio.com/4e044e8d-bc28-4768-8074-f80ff6e4a0e5/_workitems/edit/319585)

This PR changes service_provider_code handling so it is resolved during payment account validation and snapshot creation, instead of relying on Payment Gateway export-time mapping as the main path.

service_provider_code remains an FSP-required field, but it is now treated as FSP-specific derived data. HOPE first tries to calculate it from the selected FSP and the account’s financial_institution via
FinancialInstitutionMapping.code. If no calculated code is available, existing account data is used as fallback.

  Flow

  - Imports continue storing raw account data and financial_institution.
  - Targeting validation resolves service_provider_code from financial_institution + FSP.
  - Missing mapping means validation fails when the field is required.
  - Snapshot creation stores the resolved service_provider_code in payment snapshot account data.
  - Payment Gateway export uses the snapshot value first.
  - Export-time mapping remains only as a backward-compatible fallback for older snapshots.