### PR TITLE
chore: add Dependabot config and bun.lock regeneration workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/src/frontend"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "frontend"

--- a/.github/workflows/dependabot-bun-lockfile.yml
+++ b/.github/workflows/dependabot-bun-lockfile.yml
@@ -1,0 +1,36 @@
+name: Dependabot — regenerate bun.lock
+on:
+  pull_request:
+    branches:
+      - develop
+    paths:
+      - "src/frontend/package.json"
+
+permissions:
+  contents: write
+
+jobs:
+  regenerate-lockfile:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Regenerate bun.lock
+        run: bun install
+        working-directory: src/frontend
+
+      - name: Commit updated lockfile
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add src/frontend/bun.lock
+          git diff --cached --quiet || git commit -m "chore: regenerate bun.lock after dependency update"
+          git push


### PR DESCRIPTION
## Summary

- Adds `.github/dependabot.yml` to configure Dependabot to watch `src/frontend/` weekly for npm dependency updates
- Adds `.github/workflows/dependabot-bun-lockfile.yml` — a workflow that triggers on Dependabot PRs touching `src/frontend/package.json`, runs `bun install` to regenerate `bun.lock`, and commits the updated lockfile back to the PR branch

## Why

Dependabot only edits `package.json` when bumping a dependency — it does not regenerate `bun.lock`. Without this setup, Dependabot PRs would leave the lockfile out of sync, causing `bun install --frozen-lockfile` to fail in CI.



