### PR TITLE
Ephemeral deployments skip long running jobs

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -19,11 +19,15 @@ jobs:
   generate-types:
     uses: ./.github/workflows/generate-types.yml
   frontend:
+    # Skip on ephemeral-* deploys — only generate-types + build + deploy run there.
+    if: ${{ !startsWith(github.ref_name, 'ephemeral-') }}
     needs: [generate-types]
     uses: ./.github/workflows/frontend-checks.yml
   lint:
+    if: ${{ !startsWith(github.ref_name, 'ephemeral-') }}
     uses: ./.github/workflows/lint.yml
   tests:
+    if: ${{ !startsWith(github.ref_name, 'ephemeral-') }}
     needs: [generate-types]
     uses: ./.github/workflows/tests.yml
     secrets: inherit
@@ -33,6 +37,14 @@ jobs:
       - lint
       - tests
       - frontend
+    # Run once generate-types succeeds and no gate job FAILED. On ephemeral-*
+    # the gate jobs are 'skipped' (not 'failure') so build proceeds; on real
+    # branches a test failure flips this to skip build (and therefore deploy).
+    if: ${{ !cancelled()
+        && needs.generate-types.result == 'success'
+        && needs.lint.result != 'failure'
+        && needs.tests.result != 'failure'
+        && needs.frontend.result != 'failure' }}
     uses: ./.github/workflows/build-and-push.yml
     secrets: inherit
   # trivy:

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -21,17 +21,24 @@ jobs:
   generate-types:
     uses: ./.github/workflows/generate-types.yml
   frontend:
+    # Skip on PRs targeting ephemeral-*. NOTE: use base_ref, not ref_name —
+    # on pull_request events ref_name is "<pr#>/merge" and never matches.
+    if: ${{ !startsWith(github.base_ref, 'ephemeral-') }}
     needs: [generate-types]
     uses: ./.github/workflows/frontend-checks.yml
   lint:
+    if: ${{ !startsWith(github.base_ref, 'ephemeral-') }}
     uses: ./.github/workflows/lint.yml
   mypy:
+    if: ${{ !startsWith(github.base_ref, 'ephemeral-') }}
     uses: ./.github/workflows/mypy.yml
   tests:
+    if: ${{ !startsWith(github.base_ref, 'ephemeral-') }}
     needs: [generate-types]
     uses: ./.github/workflows/tests.yml
     secrets: inherit
   pragma:
+    if: ${{ !startsWith(github.base_ref, 'ephemeral-') }}
     uses: ./.github/workflows/pragma.yml
   build:
     needs: [generate-types]


### PR DESCRIPTION
I'm currently testing stuff on ephemeral two, but the loop of 

```
find the issue -> do the fix -> push & deploy on eph2
```

Takes ages, mostly because of the time spent on CI checks for ephemeral deployment. Ephemeral environments serves for testing stuff and CI checks don't need to fire there. They'd be fired in many other places down the road:
- PR Open,
- develop deployment,
- staging deployment,
- production deployment.

This PR introduces skipping unnecessary jobs ONLY for ephemeral environments (eph[1-2-3]).