### PR TITLE
fix tests

### DIFF
--- a/src/hope/apps/core/backends.py
+++ b/src/hope/apps/core/backends.py
@@ -113,6 +113,12 @@ class PermissionsBackend(BaseBackend):
 
         return permissions_set
 
+    def get_user(self, user_id: int) -> User | None:
+        try:
+            return User.objects.get(pk=user_id)
+        except User.DoesNotExist:
+            return None
+
     def has_perm(self, user_obj: User | AnonymousUser, perm: str, obj: Model | None = None) -> bool:
         if user_obj.is_superuser:
             return True

--- a/tests/unit/apps/account/test_views_download_exported_users.py
+++ b/tests/unit/apps/account/test_views_download_exported_users.py
@@ -9,7 +9,7 @@ from extras.test_utils.factories import (
     UserFactory,
 )
 from hope.apps.account.views import download_exported_users
-from hope.models import BusinessArea
+from hope.models import BusinessArea, User
 
 pytestmark = pytest.mark.django_db
 
@@ -19,7 +19,15 @@ def business_area() -> BusinessArea:
     return BusinessAreaFactory(slug="afghanistan")
 
 
-def test_download_exported_users_returns_message_when_no_users(client: Client, business_area: BusinessArea) -> None:
+@pytest.fixture
+def user() -> User:
+    return UserFactory()
+
+
+def test_download_exported_users_returns_message_when_no_users(
+    client: Client, user: User, business_area: BusinessArea
+) -> None:
+    client.force_login(user)
     response = client.get(reverse(download_exported_users, args=[business_area.slug]))
 
     assert response.status_code == 200
@@ -28,8 +36,9 @@ def test_download_exported_users_returns_message_when_no_users(client: Client, b
 
 
 def test_download_exported_users_returns_xlsx_when_users_exist(client: Client, business_area: BusinessArea) -> None:
-    role = RoleFactory(name="Some role", permissions=[])
     user = UserFactory(is_superuser=False, first_name="Aaa")
+    client.force_login(user)
+    role = RoleFactory(name="Some role", permissions=[])
     RoleAssignmentFactory(business_area=business_area, user=user, partner=None, role=role, program=None)
 
     response = client.get(reverse(download_exported_users, args=[business_area.slug]))

--- a/tests/unit/apps/registration_data/test_views_download_template.py
+++ b/tests/unit/apps/registration_data/test_views_download_template.py
@@ -4,9 +4,9 @@ from django.test import Client
 from django.urls import reverse
 import pytest
 
-from extras.test_utils.factories import BusinessAreaFactory, ProgramFactory
+from extras.test_utils.factories import BusinessAreaFactory, ProgramFactory, UserFactory
 from hope.apps.registration_data.views import download_template
-from hope.models import BusinessArea, Program
+from hope.models import BusinessArea, Program, User
 
 pytestmark = pytest.mark.django_db
 
@@ -17,11 +17,17 @@ def afghanistan() -> BusinessArea:
 
 
 @pytest.fixture
+def user() -> User:
+    return UserFactory()
+
+
+@pytest.fixture
 def program(afghanistan: BusinessArea) -> Program:
     return ProgramFactory(business_area=afghanistan)
 
 
-def test_download_template_returns_xlsx_for_existing_program(client: Client, program: Program) -> None:
+def test_download_template_returns_xlsx_for_existing_program(client: Client, user: User, program: Program) -> None:
+    client.force_login(user)
     response = client.get(reverse(download_template, args=[str(program.id)]))
 
     assert response.status_code == 200
@@ -30,7 +36,8 @@ def test_download_template_returns_xlsx_for_existing_program(client: Client, pro
     assert len(response.content) > 0
 
 
-def test_download_template_returns_404_for_missing_program(client: Client) -> None:
+def test_download_template_returns_404_for_missing_program(client: Client, user: User) -> None:
+    client.force_login(user)
     response = client.get(reverse(download_template, args=[str(uuid.uuid4())]))
 
     assert response.status_code == 404


### PR DESCRIPTION
The root cause is clear: PermissionsBackend (src/hope/apps/core/backends.py) is missing a get_user() method, so client.force_login(user) stores its backend path in the session, but on the next request the backend returns None, making @login_required redirect.

The codebase has two patterns:
**- Option A — Fix PermissionsBackend to implement get_user() (proper fix, broader impact)**
- Option B — Pass backend=... in the test call (matches how most other tests work around this)