### PR TITLE
auth to fix

### DIFF
--- a/src/hope/apps/core/api/views.py
+++ b/src/hope/apps/core/api/views.py
@@ -7,7 +7,7 @@ from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework.decorators import action
 from rest_framework.filters import OrderingFilter
 from rest_framework.mixins import ListModelMixin, RetrieveModelMixin
-from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
@@ -141,8 +141,6 @@ class ChoicesViewSet(ViewSet):
 
     Response([{"value": k, "name": v} for k, v in PaymentPlan.Status.choices])
     """
-
-    permission_classes = [AllowAny]
 
     @extend_schema(responses={200: CurrencyChoiceSerializer(many=True)})
     @action(detail=False, methods=["get"], url_path="currencies")

--- a/tests/unit/apps/core/test_choices.py
+++ b/tests/unit/apps/core/test_choices.py
@@ -158,12 +158,10 @@ def test_choices_permissions_returns_full_permission_catalog(authenticated_clien
 
 
 @pytest.mark.django_db
-def test_choices_permissions_allows_unauthenticated_access(anonymous_client):
-    # FE type generation (enhance_and_camelize_openapi.js) fetches this endpoint without credentials
+def test_choices_permissions_denies_unauthenticated_access(anonymous_client):
     response = anonymous_client.get(reverse("api:choices-permissions"))
 
-    assert response.status_code == 200
-    assert len(response.data) == len(Permissions)
+    assert response.status_code == 403
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Remove the `AllowAny` override from `ChoicesViewSet` so `/api/rest/choices/*` now requires authentication (project default `IsAuthenticated`).

It was only there to let FE type generation fetch the endpoints anonymously; 
that's no longer needed since type generation loads enum choices from a file
instead of the live API.