### PR TITLE
PP fixes after dev tests

### DIFF
--- a/src/frontend/src/containers/tables/paymentmodule/PaymentPlansTable/PaymentPlansFilters.tsx
+++ b/src/frontend/src/containers/tables/paymentmodule/PaymentPlansTable/PaymentPlansFilters.tsx
@@ -3,7 +3,6 @@ import moment from 'moment';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { PaymentPlanStatusEnum } from '@restgenerated/models/PaymentPlanStatusEnum';
-import { PlanTypeEnum } from '@restgenerated/models/PlanTypeEnum';
 import { DatePickerFilter } from '@components/core/DatePickerFilter';
 import { FiltersSection } from '@components/core/FiltersSection';
 import { NumberTextField } from '@components/core/NumberTextField';
@@ -81,6 +80,11 @@ export function PaymentPlansFilters({
     [...(statusChoicesData || [])]?.filter((el) =>
       allowedStatusChoices.includes(el.value as any),
     ) || [];
+
+  const { data: planTypeChoicesData } = useQuery<Array<Choice>>({
+    queryKey: ['choicesPaymentPlanTypeList'],
+    queryFn: () => RestService.restChoicesPaymentPlanTypeList(),
+  });
 
   return (
     <FiltersSection
@@ -188,8 +192,11 @@ export function PaymentPlansFilters({
             value={filter.planType ?? ''}
             fullWidth
           >
-            <MenuItem value={PlanTypeEnum.FOLLOW_UP}>{t('Follow Up')}</MenuItem>
-            <MenuItem value={PlanTypeEnum.TOP_UP}>{t('Top Up')}</MenuItem>
+            {(planTypeChoicesData || []).map((item) => (
+              <MenuItem key={item.value} value={item.value}>
+                {item.name}
+              </MenuItem>
+            ))}
           </SelectFilter>
         </Grid>
       </Grid>

--- a/src/hope/apps/payment/api/views.py
+++ b/src/hope/apps/payment/api/views.py
@@ -130,6 +130,10 @@ from hope.apps.payment.utils import calculate_counts, from_received_to_status
 from hope.apps.payment.xlsx.xlsx_follow_up_instruction_reconciliation_import_service import (
     XlsxFollowUpInstructionReconciliationImportService,
 )
+from hope.apps.payment.xlsx.xlsx_payment_plan_group_delivery_export_service import (
+    EmptyDeliveryExportError,
+    XlsxPaymentPlanGroupDeliveryExportService,
+)
 from hope.apps.payment.xlsx.xlsx_payment_plan_group_delivery_import_service import (
     XlsxPaymentPlanGroupDeliveryImportService,
 )
@@ -2597,11 +2601,6 @@ class PaymentPlanGroupViewSet(
 
             # Reject up-front if every plan would be filtered out (e.g. no FSP XLSX template mapping),
             # so the user gets the error on click instead of a silently failing background task.
-            from hope.apps.payment.xlsx.xlsx_payment_plan_group_delivery_export_service import (
-                EmptyDeliveryExportError,
-                XlsxPaymentPlanGroupDeliveryExportService,
-            )
-
             exportable_ids = XlsxPaymentPlanGroupDeliveryExportService(
                 payment_plan_group, fsp_xlsx_template_id=fsp_xlsx_template_id, export_tag=export_tag
             ).preview_export()

--- a/src/hope/apps/payment/api/views.py
+++ b/src/hope/apps/payment/api/views.py
@@ -2595,6 +2595,19 @@ class PaymentPlanGroupViewSet(
             if not Payment.objects.filter(parent__in=exportable_plans).eligible().exists():
                 raise ValidationError("Export failed: there are no eligible payments to export.")
 
+            # Reject up-front if every plan would be filtered out (e.g. no FSP XLSX template mapping),
+            # so the user gets the error on click instead of a silently failing background task.
+            from hope.apps.payment.xlsx.xlsx_payment_plan_group_delivery_export_service import (
+                EmptyDeliveryExportError,
+                XlsxPaymentPlanGroupDeliveryExportService,
+            )
+
+            exportable_ids = XlsxPaymentPlanGroupDeliveryExportService(
+                payment_plan_group, fsp_xlsx_template_id=fsp_xlsx_template_id, export_tag=export_tag
+            ).preview_export()
+            if not exportable_ids:
+                raise ValidationError(EmptyDeliveryExportError.MESSAGE)
+
         payment_plan_group.background_action_status = PaymentPlanGroup.BackgroundActionStatus.XLSX_EXPORTING
         payment_plan_group.save(update_fields=["background_action_status"])
         transaction.on_commit(

--- a/src/hope/apps/payment/celery_tasks.py
+++ b/src/hope/apps/payment/celery_tasks.py
@@ -227,7 +227,9 @@ def create_follow_up_instruction_delivery_xlsx_async_task(
 
 
 def export_payment_plan_group_delivery_xlsx_async_task_action(job: AsyncRetryJob) -> None:
+    from hope.apps.core.celery_tasks import NonRetriableTaskError
     from hope.apps.payment.xlsx.xlsx_payment_plan_group_delivery_export_service import (
+        EmptyDeliveryExportError,
         XlsxPaymentPlanGroupDeliveryExportService,
     )
     from hope.models import PaymentPlanGroup, User
@@ -268,6 +270,14 @@ def export_payment_plan_group_delivery_xlsx_async_task_action(job: AsyncRetryJob
                 and payment_plan_group.cycle.program.business_area.enable_email_notification
             ):
                 send_email_notification(service, user)
+        except EmptyDeliveryExportError as exc:
+            # Nothing was exportable (every plan skipped).
+            logger.warning(f"{exc} {' '.join(exc.skipped_reasons)}")
+            payment_plan_group.background_action_status = PaymentPlanGroup.BackgroundActionStatus.XLSX_EXPORT_ERROR
+            payment_plan_group.save(update_fields=["background_action_status", "updated_at"])
+            job.errors = {**job.errors, "export_skipped_payment_plans": exc.skipped_reasons}
+            job.save(update_fields=["errors"])
+            raise NonRetriableTaskError(str(exc)) from exc
         except Exception:
             logger.exception("Export Payment Plan Group Delivery XLSX Error")
             payment_plan_group.background_action_status = PaymentPlanGroup.BackgroundActionStatus.XLSX_EXPORT_ERROR

--- a/src/hope/apps/payment/migrations/0067_migration.py
+++ b/src/hope/apps/payment/migrations/0067_migration.py
@@ -53,7 +53,9 @@ def create_default_purpose_and_backfill(apps, schema_editor):
     )
 
     ungrouped_pps = list(
-        PaymentPlan.objects.filter(payment_plan_group__isnull=True).values_list("id", "name", "program_cycle_id")
+        PaymentPlan.objects.filter(payment_plan_group__isnull=True, is_removed=False).values_list(
+            "id", "name", "program_cycle_id"
+        )
     )
     _bulk_create_in_batches(
         PaymentPlanGroup,

--- a/src/hope/apps/payment/xlsx/xlsx_payment_plan_group_delivery_export_service.py
+++ b/src/hope/apps/payment/xlsx/xlsx_payment_plan_group_delivery_export_service.py
@@ -15,7 +15,13 @@ import pyzipper
 
 from hope.apps.payment.xlsx.base_xlsx_export_service import XlsxExportBaseService
 from hope.apps.payment.xlsx.xlsx_payment_plan_delivery_export_service import XlsxPaymentPlanDeliveryExportService
-from hope.models import FileTemp, FinancialServiceProviderXlsxTemplate, FspXlsxTemplatePerDeliveryMechanism, PaymentPlan
+from hope.models import (
+    FileTemp,
+    FinancialServiceProviderXlsxTemplate,
+    FspXlsxTemplatePerDeliveryMechanism,
+    Payment,
+    PaymentPlan,
+)
 
 if TYPE_CHECKING:
     from hope.models import PaymentPlanGroup, Program, User
@@ -67,7 +73,9 @@ class XlsxPaymentPlanGroupDeliveryExportService(XlsxExportBaseService):
                 plan_type=PaymentPlan.PlanType.REGULAR,
                 export_tag__isnull=True,
             )
-        self.payment_plans = list(plan_qs.order_by("unicef_id"))
+        self.payment_plans = list(
+            plan_qs.select_related("financial_service_provider", "delivery_mechanism").order_by("unicef_id")
+        )
         self.exported_plan_ids: list = []
         self.skipped_reasons: list[str] = []
         self.fsp_xlsx_template: FinancialServiceProviderXlsxTemplate | None = (
@@ -75,19 +83,51 @@ class XlsxPaymentPlanGroupDeliveryExportService(XlsxExportBaseService):
             if fsp_xlsx_template_id
             else None
         )
+        self._template_map: dict[tuple, FinancialServiceProviderXlsxTemplate] | None = None
+        self._plans_with_blocking_payments: set | None = None
+
+    def _get_template_map(self) -> dict[tuple, FinancialServiceProviderXlsxTemplate]:
+        """Resolve every plan's (fsp, delivery_mechanism) -> xlsx_template in a single query."""
+        if self._template_map is None:
+            pairs = {
+                (pp.financial_service_provider_id, pp.delivery_mechanism_id)
+                for pp in self.payment_plans
+                if pp.financial_service_provider_id and pp.delivery_mechanism_id
+            }
+            mappings = FspXlsxTemplatePerDeliveryMechanism.objects.filter(
+                financial_service_provider_id__in={fsp_id for fsp_id, _ in pairs},
+                delivery_mechanism_id__in={dm_id for _, dm_id in pairs},
+            ).select_related("xlsx_template")
+            self._template_map = {
+                (m.financial_service_provider_id, m.delivery_mechanism_id): m.xlsx_template
+                for m in mappings
+                if (m.financial_service_provider_id, m.delivery_mechanism_id) in pairs
+            }
+        return self._template_map
+
+    def _get_plans_with_blocking_payments(self) -> set:
+        """Plan ids that still have eligible payments not yet sent to the payment gateway.
+
+        Equivalent to PaymentPlan.is_payment_gateway_and_all_sent_to_fsp.
+        """
+        if self._plans_with_blocking_payments is None:
+            self._plans_with_blocking_payments = set(
+                Payment.objects.filter(parent__in=self.payment_plans)
+                .eligible()
+                .filter(status__in=(Payment.STATUS_PENDING, Payment.STATUS_SENT_TO_PG))
+                .values_list("parent_id", flat=True)
+                .distinct()
+            )
+        return self._plans_with_blocking_payments
 
     def _resolve_template(self, payment_plan: PaymentPlan) -> FinancialServiceProviderXlsxTemplate | None:
         if self.fsp_xlsx_template is not None:
             return self.fsp_xlsx_template
-        fsp = payment_plan.financial_service_provider
-        delivery_mechanism = payment_plan.delivery_mechanism
-        if not fsp or not delivery_mechanism:
+        if not payment_plan.financial_service_provider_id or not payment_plan.delivery_mechanism_id:
             return None
-        mapping = FspXlsxTemplatePerDeliveryMechanism.objects.filter(
-            financial_service_provider=fsp,
-            delivery_mechanism=delivery_mechanism,
-        ).first()
-        return mapping.xlsx_template if mapping else None
+        return self._get_template_map().get(
+            (payment_plan.financial_service_provider_id, payment_plan.delivery_mechanism_id)
+        )
 
     def _skip_reason(
         self, payment_plan: PaymentPlan, template: FinancialServiceProviderXlsxTemplate | None
@@ -98,7 +138,7 @@ class XlsxPaymentPlanGroupDeliveryExportService(XlsxExportBaseService):
         if (
             payment_plan.is_payment_gateway
             and "fsp_auth_code" in template.columns
-            and not payment_plan.is_payment_gateway_and_all_sent_to_fsp
+            and payment_plan.id in self._get_plans_with_blocking_payments()
         ):
             return (
                 f"Payment Plan {payment_plan.unicef_id}: template requires fsp_auth_code "
@@ -115,8 +155,6 @@ class XlsxPaymentPlanGroupDeliveryExportService(XlsxExportBaseService):
         ]
 
     def generate_token_and_order_numbers(self, program: "Program") -> None:
-        from hope.models import Payment
-
         all_eligible = Payment.objects.filter(parent__in=self.payment_plans).eligible()
         XlsxPaymentPlanDeliveryExportService.generate_token_and_order_numbers(all_eligible, program)
 

--- a/src/hope/apps/payment/xlsx/xlsx_payment_plan_group_delivery_export_service.py
+++ b/src/hope/apps/payment/xlsx/xlsx_payment_plan_group_delivery_export_service.py
@@ -107,11 +107,7 @@ class XlsxPaymentPlanGroupDeliveryExportService(XlsxExportBaseService):
         return None
 
     def preview_export(self) -> list:
-        """Return the ids of plans that would be exported (empty if every plan would be skipped).
-
-        Lets callers (e.g. the export endpoint) detect up-front that an export would produce
-        no rows and reject the request synchronously instead of failing later in the task.
-        """
+        """Return the ids of plans that would be exported (empty if every plan would be skipped)."""
         return [
             payment_plan.id
             for payment_plan in self.payment_plans

--- a/src/hope/apps/payment/xlsx/xlsx_payment_plan_group_delivery_export_service.py
+++ b/src/hope/apps/payment/xlsx/xlsx_payment_plan_group_delivery_export_service.py
@@ -1,6 +1,6 @@
 import logging
 from tempfile import NamedTemporaryFile
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from django.contrib.admin.options import get_content_type_for_model
 from django.core.files import File
@@ -158,7 +158,7 @@ class XlsxPaymentPlanGroupDeliveryExportService(XlsxExportBaseService):
                 self.skipped_reasons.append(reason)
                 continue
             per_fsp_service = XlsxPaymentPlanDeliveryExportService(payment_plan, shared_lookups=shared_lookups)
-            per_fsp_service.prepare_headers(template)
+            per_fsp_service.prepare_headers(cast("FinancialServiceProviderXlsxTemplate", template))
             if not header:
                 header = per_fsp_service.header_list
                 self.allow_export_fsp_auth_code = per_fsp_service.allow_export_fsp_auth_code

--- a/src/hope/apps/payment/xlsx/xlsx_payment_plan_group_delivery_export_service.py
+++ b/src/hope/apps/payment/xlsx/xlsx_payment_plan_group_delivery_export_service.py
@@ -23,6 +23,16 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+class EmptyDeliveryExportError(Exception):
+    """Raised when an export batch would produce no rows because every payment plan was skipped."""
+
+    MESSAGE = "Nothing to export: no payment plan is currently exportable."
+
+    def __init__(self, skipped_reasons: list[str]) -> None:
+        self.skipped_reasons = skipped_reasons
+        super().__init__(self.MESSAGE)
+
+
 class XlsxPaymentPlanGroupDeliveryExportService(XlsxExportBaseService):
     """Export one batch of a group's payment plans into a single-sheet xlsx.
 
@@ -59,6 +69,7 @@ class XlsxPaymentPlanGroupDeliveryExportService(XlsxExportBaseService):
             )
         self.payment_plans = list(plan_qs.order_by("unicef_id"))
         self.exported_plan_ids: list = []
+        self.skipped_reasons: list[str] = []
         self.fsp_xlsx_template: FinancialServiceProviderXlsxTemplate | None = (
             get_object_or_404(FinancialServiceProviderXlsxTemplate, pk=fsp_xlsx_template_id)
             if fsp_xlsx_template_id
@@ -77,6 +88,35 @@ class XlsxPaymentPlanGroupDeliveryExportService(XlsxExportBaseService):
             delivery_mechanism=delivery_mechanism,
         ).first()
         return mapping.xlsx_template if mapping else None
+
+    def _skip_reason(
+        self, payment_plan: PaymentPlan, template: FinancialServiceProviderXlsxTemplate | None
+    ) -> str | None:
+        """Return why `payment_plan` would be left out of the export, or None if it would be included."""
+        if template is None:
+            return f"Payment Plan {payment_plan.unicef_id}: no FSP XLSX Template for its FSP and delivery mechanism."
+        if (
+            payment_plan.is_payment_gateway
+            and "fsp_auth_code" in template.columns
+            and not payment_plan.is_payment_gateway_and_all_sent_to_fsp
+        ):
+            return (
+                f"Payment Plan {payment_plan.unicef_id}: template requires fsp_auth_code "
+                f"but not all payments have been sent to the payment gateway yet."
+            )
+        return None
+
+    def preview_export(self) -> list:
+        """Return the ids of plans that would be exported (empty if every plan would be skipped).
+
+        Lets callers (e.g. the export endpoint) detect up-front that an export would produce
+        no rows and reject the request synchronously instead of failing later in the task.
+        """
+        return [
+            payment_plan.id
+            for payment_plan in self.payment_plans
+            if self._skip_reason(payment_plan, self._resolve_template(payment_plan)) is None
+        ]
 
     def generate_token_and_order_numbers(self, program: "Program") -> None:
         from hope.models import Payment
@@ -110,26 +150,16 @@ class XlsxPaymentPlanGroupDeliveryExportService(XlsxExportBaseService):
         header: list[str] = []
         prepared_services: list[XlsxPaymentPlanDeliveryExportService] = []
         self.exported_plan_ids = []
+        self.skipped_reasons = []
 
         shared_lookups = XlsxPaymentPlanDeliveryExportService.build_shared_lookups()
 
         for payment_plan in self.payment_plans:
             template = self._resolve_template(payment_plan)
-            if template is None:
-                logger.warning(
-                    f"Skipping Payment Plan {payment_plan.unicef_id}: no FSP XLSX Template for its FSP "
-                    f"and delivery mechanism."
-                )
-                continue
-            if (
-                payment_plan.is_payment_gateway
-                and "fsp_auth_code" in template.columns
-                and not payment_plan.is_payment_gateway_and_all_sent_to_fsp
-            ):
-                logger.warning(
-                    f"Skipping Payment Plan {payment_plan.unicef_id}: template requires fsp_auth_code "
-                    f"but not all payments have been sent to the payment gateway yet."
-                )
+            reason = self._skip_reason(payment_plan, template)
+            if reason:
+                logger.warning(f"Skipping {reason}")
+                self.skipped_reasons.append(reason)
                 continue
             per_fsp_service = XlsxPaymentPlanDeliveryExportService(payment_plan, shared_lookups=shared_lookups)
             per_fsp_service.prepare_headers(template)
@@ -155,7 +185,7 @@ class XlsxPaymentPlanGroupDeliveryExportService(XlsxExportBaseService):
         group = self.payment_plan_group
         self.generate_workbook()
         if not self.exported_plan_ids:
-            return
+            raise EmptyDeliveryExportError(self.skipped_reasons)
         if self.export_tag is not None:
             tag = self.export_tag
         else:

--- a/src/hope/models/payment_plan.py
+++ b/src/hope/models/payment_plan.py
@@ -997,7 +997,11 @@ class PaymentPlan(
 
     @property
     def is_payment_gateway_and_all_sent_to_fsp(self) -> bool:
-        """Export MTCN file xlsx file with password."""
+        """Export MTCN file xlsx file with password.
+
+        Note: change XlsxPaymentPlanGroupDeliveryExportService._get_plans_with_blocking_payments
+        when changing this function.
+        """
         has_blocking_payments = self.eligible_payments.filter(
             status__in=(Payment.STATUS_PENDING, Payment.STATUS_SENT_TO_PG)
         ).exists()

--- a/tests/unit/apps/payment/test_filters.py
+++ b/tests/unit/apps/payment/test_filters.py
@@ -565,6 +565,38 @@ def test_payment_plan_filter_is_follow_up(business_area):
     assert list(filtered.values_list("pk", flat=True)) == [follow_up.pk]
 
 
+def test_payment_plan_filter_plan_type_regular(business_area):
+    regular = PaymentPlanFactory(business_area=business_area, plan_type=PaymentPlan.PlanType.REGULAR)
+    PaymentPlanFactory(business_area=business_area, plan_type=PaymentPlan.PlanType.FOLLOW_UP)
+
+    qs = PaymentPlan.objects.all()
+    filtered = PaymentPlanFilter(data={"business_area": business_area.slug, "plan_type": "REGULAR"}, queryset=qs).qs
+
+    assert list(filtered.values_list("pk", flat=True)) == [regular.pk]
+
+
+def test_payment_plan_filter_plan_type_top_up(business_area):
+    top_up = PaymentPlanFactory(business_area=business_area, plan_type=PaymentPlan.PlanType.TOP_UP)
+    PaymentPlanFactory(business_area=business_area, plan_type=PaymentPlan.PlanType.REGULAR)
+
+    qs = PaymentPlan.objects.all()
+    filtered = PaymentPlanFilter(data={"business_area": business_area.slug, "plan_type": "TOP_UP"}, queryset=qs).qs
+
+    assert list(filtered.values_list("pk", flat=True)) == [top_up.pk]
+
+
+def test_payment_plan_filter_plan_type_top_up_amendment(business_area):
+    top_up_amendment = PaymentPlanFactory(business_area=business_area, plan_type=PaymentPlan.PlanType.TOP_UP_AMENDMENT)
+    PaymentPlanFactory(business_area=business_area, plan_type=PaymentPlan.PlanType.REGULAR)
+
+    qs = PaymentPlan.objects.all()
+    filtered = PaymentPlanFilter(
+        data={"business_area": business_area.slug, "plan_type": "TOP_UP_AMENDMENT"}, queryset=qs
+    ).qs
+
+    assert list(filtered.values_list("pk", flat=True)) == [top_up_amendment.pk]
+
+
 def test_payment_plan_filter_is_payment_plan_true_excludes_pre_payment(business_area):
     real_plan = PaymentPlanFactory(business_area=business_area, status=PaymentPlan.Status.OPEN)
     PaymentPlanFactory(business_area=business_area, status=PaymentPlan.Status.DRAFT)

--- a/tests/unit/apps/payment/test_payment_celery_tasks.py
+++ b/tests/unit/apps/payment/test_payment_celery_tasks.py
@@ -1856,6 +1856,36 @@ def test_export_delivery_task_skips_token_generation_when_disabled(
     mock_send_email.assert_not_called()
 
 
+@patch(
+    "hope.apps.payment.xlsx.xlsx_payment_plan_group_delivery_export_service.XlsxPaymentPlanGroupDeliveryExportService"
+)
+def test_export_delivery_task_marks_error_without_retry_when_nothing_exportable(
+    mock_service_cls: Mock,
+    payment_plan_group_with_accepted_plan,
+    user,
+) -> None:
+    from hope.apps.core.celery_tasks import NonRetriableTaskError
+    from hope.apps.payment.xlsx.xlsx_payment_plan_group_delivery_export_service import EmptyDeliveryExportError
+
+    group = payment_plan_group_with_accepted_plan
+    mock_service = mock_service_cls.return_value
+    mock_service.payment_generate_token_and_order_numbers = False
+    mock_service.save_xlsx_file.side_effect = EmptyDeliveryExportError(["PP-1: no FSP XLSX Template"])
+    job = AsyncRetryJob.objects.create(
+        type=AsyncJobModel.JobType.JOB_TASK,
+        action="hope.apps.payment.celery_tasks.export_payment_plan_group_delivery_xlsx_async_task_action",
+        config={"payment_plan_group_id": str(group.pk), "user_id": str(user.pk)},
+    )
+
+    with pytest.raises(NonRetriableTaskError):
+        export_payment_plan_group_delivery_xlsx_async_task_action(job)
+
+    group.refresh_from_db()
+    assert group.background_action_status == PaymentPlanGroup.BackgroundActionStatus.XLSX_EXPORT_ERROR
+    job.refresh_from_db()
+    assert job.errors["export_skipped_payment_plans"] == ["PP-1: no FSP XLSX Template"]
+
+
 def test_import_delivery_group_task_clears_status_on_success(group_with_accepted_plan_and_import_file, user) -> None:
     group = group_with_accepted_plan_and_import_file
 

--- a/tests/unit/apps/payment/test_payment_plan_group_views.py
+++ b/tests/unit/apps/payment/test_payment_plan_group_views.py
@@ -178,6 +178,29 @@ def group_with_accepted_plan(business_area: Any, cycle: Any) -> Any:
 @pytest.fixture
 def group_with_accepted_plan_and_payment(business_area: Any, cycle: Any) -> Any:
     group = cycle.payment_plan_groups.first()
+    fsp = FinancialServiceProviderFactory()
+    delivery_mechanism = DeliveryMechanismFactory()
+    FspXlsxTemplatePerDeliveryMechanismFactory(
+        financial_service_provider=fsp,
+        delivery_mechanism=delivery_mechanism,
+    )
+    plan = PaymentPlanFactory(
+        business_area=business_area,
+        program_cycle=cycle,
+        payment_plan_group=group,
+        financial_service_provider=fsp,
+        delivery_mechanism=delivery_mechanism,
+        status=PaymentPlan.Status.ACCEPTED,
+    )
+    payment = PaymentFactory(parent=plan, financial_service_provider=fsp, delivery_type=delivery_mechanism)
+    PaymentHouseholdSnapshotFactory(payment=payment, snapshot_data={})
+    return group
+
+
+@pytest.fixture
+def group_with_accepted_plan_and_payment_no_template(business_area: Any, cycle: Any) -> Any:
+    """Accepted plan with an eligible payment but no resolvable FSP XLSX template - export yields no rows."""
+    group = cycle.payment_plan_groups.first()
     plan = PaymentPlanFactory(
         business_area=business_area,
         program_cycle=cycle,
@@ -1154,6 +1177,29 @@ def test_export_without_eligible_payments_returns_400(
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert "there are no eligible payments to export." in str(response.json())
+    mocked_task.assert_not_called()
+    group.refresh_from_db()
+    assert group.background_action_status is None
+
+
+def test_export_without_resolvable_template_returns_400(
+    client: Any,
+    user: Any,
+    business_area: Any,
+    program: Any,
+    group_with_accepted_plan_and_payment_no_template: Any,
+    create_user_role_with_permissions: Any,
+) -> None:
+    create_user_role_with_permissions(
+        user, [Permissions.PM_PAYMENT_PLAN_GROUP_EXPORT_XLSX], business_area, program=program
+    )
+    group = group_with_accepted_plan_and_payment_no_template
+
+    with patch("hope.apps.payment.api.views.export_payment_plan_group_delivery_xlsx_async_task") as mocked_task:
+        response = client.post(_export_url(business_area.slug, program.code, group.id))
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json()[0].startswith("Nothing to export:")
     mocked_task.assert_not_called()
     group.refresh_from_db()
     assert group.background_action_status is None

--- a/tests/unit/apps/payment/test_xlsx_payment_plan_group_delivery_export_service.py
+++ b/tests/unit/apps/payment/test_xlsx_payment_plan_group_delivery_export_service.py
@@ -1,5 +1,7 @@
 from decimal import Decimal
 
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 import pytest
 
@@ -96,6 +98,26 @@ def fsp_no_template():
         communication_channel=FinancialServiceProvider.COMMUNICATION_CHANNEL_XLSX,
         vision_vendor_number="987654321",
     )
+
+
+@pytest.fixture
+def payment_gateway_fsp():
+    return FinancialServiceProviderFactory(
+        communication_channel=FinancialServiceProvider.COMMUNICATION_CHANNEL_API,
+        payment_gateway_id="pg-1",
+    )
+
+
+@pytest.fixture
+def auth_code_template(payment_gateway_fsp, delivery_mechanism):
+    """Payment-gateway template requiring fsp_auth_code, mapped to the gateway FSP + delivery mechanism."""
+    template = FinancialServiceProviderXlsxTemplateFactory(columns=["payment_id", "fsp_auth_code"])
+    FspXlsxTemplatePerDeliveryMechanismFactory(
+        financial_service_provider=payment_gateway_fsp,
+        delivery_mechanism=delivery_mechanism,
+        xlsx_template=template,
+    )
+    return template
 
 
 @pytest.fixture
@@ -338,6 +360,31 @@ def group_with_two_plans_and_payments(program_cycle, business_area, fsp, deliver
     )
     PaymentHouseholdSnapshotFactory(payment=payment_three, snapshot_data={})
     return group
+
+
+@pytest.fixture
+def make_payment_gateway_group(
+    program_cycle, business_area, payment_gateway_fsp, delivery_mechanism, auth_code_template
+):
+    """Build a group with `plan_count` exportable payment-gateway plans (all payments already sent)."""
+
+    def build_group(plan_count):
+        group = PaymentPlanGroupFactory(cycle=program_cycle)
+        for _ in range(plan_count):
+            plan = PaymentPlanFactory(
+                program_cycle=program_cycle,
+                payment_plan_group=group,
+                business_area=business_area,
+                financial_service_provider=payment_gateway_fsp,
+                delivery_mechanism=delivery_mechanism,
+                status=PaymentPlan.Status.ACCEPTED,
+            )
+            PaymentFactory(
+                parent=plan, financial_service_provider=payment_gateway_fsp, status=Payment.STATUS_DISTRIBUTION_SUCCESS
+            )
+        return group
+
+    return build_group
 
 
 def test_workbook_has_single_sheet_with_group_title(group_with_one_accepted_plan):
@@ -669,27 +716,20 @@ def test_save_xlsx_file_does_not_tag_plan_whose_fsp_has_no_template(group_with_p
     assert plan.export_tag is None
 
 
-def test_plan_with_unprocessed_payments_is_skipped_when_template_requires_auth_code(program_cycle, business_area, user):
-    pg_fsp = FinancialServiceProviderFactory(
-        communication_channel=FinancialServiceProvider.COMMUNICATION_CHANNEL_API,
-        payment_gateway_id="pg-1",
-    )
-    delivery_mechanism = DeliveryMechanismFactory()
-    template = FinancialServiceProviderXlsxTemplateFactory(columns=["payment_id", "fsp_auth_code"])
-    FspXlsxTemplatePerDeliveryMechanismFactory(
-        financial_service_provider=pg_fsp, delivery_mechanism=delivery_mechanism, xlsx_template=template
-    )
+def test_plan_with_unprocessed_payments_is_skipped_when_template_requires_auth_code(
+    program_cycle, business_area, user, payment_gateway_fsp, delivery_mechanism, auth_code_template
+):
     group = PaymentPlanGroupFactory(cycle=program_cycle)
     plan = PaymentPlanFactory(
         program_cycle=program_cycle,
         payment_plan_group=group,
         business_area=business_area,
-        financial_service_provider=pg_fsp,
+        financial_service_provider=payment_gateway_fsp,
         delivery_mechanism=delivery_mechanism,
         status=PaymentPlan.Status.ACCEPTED,
     )
     # payment still PENDING → is_payment_gateway_and_all_sent_to_fsp=False
-    PaymentFactory(parent=plan, financial_service_provider=pg_fsp, status=Payment.STATUS_PENDING)
+    PaymentFactory(parent=plan, financial_service_provider=payment_gateway_fsp, status=Payment.STATUS_PENDING)
 
     with pytest.raises(EmptyDeliveryExportError):
         XlsxPaymentPlanGroupDeliveryExportService(group).save_xlsx_file(user)
@@ -699,29 +739,22 @@ def test_plan_with_unprocessed_payments_is_skipped_when_template_requires_auth_c
     assert plan.export_file_delivery is None
 
 
-def test_save_xlsx_file_with_auth_code_produces_encrypted_zip(program_cycle, business_area, user):
-    pg_fsp = FinancialServiceProviderFactory(
-        communication_channel=FinancialServiceProvider.COMMUNICATION_CHANNEL_API,
-        payment_gateway_id="pg-2",
-    )
-    delivery_mechanism = DeliveryMechanismFactory()
-    template = FinancialServiceProviderXlsxTemplateFactory(columns=["payment_id", "fsp_auth_code"])
-    FspXlsxTemplatePerDeliveryMechanismFactory(
-        financial_service_provider=pg_fsp, delivery_mechanism=delivery_mechanism, xlsx_template=template
-    )
+def test_save_xlsx_file_with_auth_code_produces_encrypted_zip(
+    program_cycle, business_area, user, payment_gateway_fsp, delivery_mechanism, auth_code_template
+):
     group = PaymentPlanGroupFactory(cycle=program_cycle)
     plan = PaymentPlanFactory(
         program_cycle=program_cycle,
         payment_plan_group=group,
         business_area=business_area,
-        financial_service_provider=pg_fsp,
+        financial_service_provider=payment_gateway_fsp,
         delivery_mechanism=delivery_mechanism,
         status=PaymentPlan.Status.ACCEPTED,
     )
     # payment in DISTRIBUTION_SUCCESS → not blocking → is_payment_gateway_and_all_sent_to_fsp=True
     PaymentFactory(
         parent=plan,
-        financial_service_provider=pg_fsp,
+        financial_service_provider=payment_gateway_fsp,
         status=Payment.STATUS_DISTRIBUTION_SUCCESS,
     )
 
@@ -737,27 +770,20 @@ def test_save_xlsx_file_with_auth_code_produces_encrypted_zip(program_cycle, bus
 
 
 def test_save_xlsx_file_with_auth_code_reexport_with_export_tag_replaces_file_and_keeps_tag(
-    program_cycle, business_area, user
+    program_cycle, business_area, user, payment_gateway_fsp, delivery_mechanism, auth_code_template
 ):
-    pg_fsp = FinancialServiceProviderFactory(
-        communication_channel=FinancialServiceProvider.COMMUNICATION_CHANNEL_API,
-        payment_gateway_id="pg-3",
-    )
-    delivery_mechanism = DeliveryMechanismFactory()
-    template = FinancialServiceProviderXlsxTemplateFactory(columns=["payment_id", "fsp_auth_code"])
-    FspXlsxTemplatePerDeliveryMechanismFactory(
-        financial_service_provider=pg_fsp, delivery_mechanism=delivery_mechanism, xlsx_template=template
-    )
     group = PaymentPlanGroupFactory(cycle=program_cycle)
     plan = PaymentPlanFactory(
         program_cycle=program_cycle,
         payment_plan_group=group,
         business_area=business_area,
-        financial_service_provider=pg_fsp,
+        financial_service_provider=payment_gateway_fsp,
         delivery_mechanism=delivery_mechanism,
         status=PaymentPlan.Status.ACCEPTED,
     )
-    PaymentFactory(parent=plan, financial_service_provider=pg_fsp, status=Payment.STATUS_DISTRIBUTION_SUCCESS)
+    PaymentFactory(
+        parent=plan, financial_service_provider=payment_gateway_fsp, status=Payment.STATUS_DISTRIBUTION_SUCCESS
+    )
 
     XlsxPaymentPlanGroupDeliveryExportService(group).save_xlsx_file(user)
     plan.refresh_from_db()
@@ -846,3 +872,30 @@ def test_group_export_builds_shared_lookups_once_for_multiple_plans(group_with_t
     XlsxPaymentPlanGroupDeliveryExportService(group_with_two_plans_and_payments).generate_workbook()
 
     assert build_spy.call_count == 1
+
+
+def test_preview_export_query_count_is_independent_of_plan_count(make_payment_gateway_group):
+    service_two_plans = XlsxPaymentPlanGroupDeliveryExportService(make_payment_gateway_group(2))
+    service_three_plans = XlsxPaymentPlanGroupDeliveryExportService(make_payment_gateway_group(3))
+
+    with CaptureQueriesContext(connection) as queries_two_plans:
+        exported_two_plans = service_two_plans.preview_export()
+    with CaptureQueriesContext(connection) as queries_three_plans:
+        exported_three_plans = service_three_plans.preview_export()
+
+    assert len(exported_two_plans) == 2
+    assert len(exported_three_plans) == 3
+    # one query for the template map + one for the blocking-payments set, regardless of plan count
+    assert len(queries_two_plans.captured_queries) == 2
+    assert len(queries_three_plans.captured_queries) == 2
+
+
+def test_preview_export_runs_single_query_for_non_gateway_plans(group_with_two_plans_and_payments):
+    # XLSX (non-payment-gateway) FSPs short-circuit before the blocking-payments query, leaving only the template map
+    service = XlsxPaymentPlanGroupDeliveryExportService(group_with_two_plans_and_payments)
+
+    with CaptureQueriesContext(connection) as queries:
+        exported = service.preview_export()
+
+    assert len(exported) == 2
+    assert len(queries.captured_queries) == 1

--- a/tests/unit/apps/payment/test_xlsx_payment_plan_group_delivery_export_service.py
+++ b/tests/unit/apps/payment/test_xlsx_payment_plan_group_delivery_export_service.py
@@ -18,6 +18,7 @@ from extras.test_utils.factories.payment import (
 from extras.test_utils.factories.program import ProgramCycleFactory, ProgramFactory
 from hope.apps.payment.xlsx.xlsx_payment_plan_delivery_export_service import XlsxPaymentPlanDeliveryExportService
 from hope.apps.payment.xlsx.xlsx_payment_plan_group_delivery_export_service import (
+    EmptyDeliveryExportError,
     XlsxPaymentPlanGroupDeliveryExportService,
 )
 from hope.models import (
@@ -84,6 +85,112 @@ def group_with_one_accepted_plan(program_cycle, business_area, fsp, delivery_mec
         financial_service_provider=fsp,
         delivery_mechanism=delivery_mechanism,
         status=PaymentPlan.Status.ACCEPTED,
+    )
+    return group
+
+
+@pytest.fixture
+def fsp_no_template():
+    return FinancialServiceProviderFactory(
+        name="Test FSP No Template",
+        communication_channel=FinancialServiceProvider.COMMUNICATION_CHANNEL_XLSX,
+        vision_vendor_number="987654321",
+    )
+
+
+@pytest.fixture
+def group_one_exportable_two_skipped(
+    program_cycle, business_area, fsp, fsp_no_template, delivery_mechanism, fsp_template
+):
+    """One ACCEPTED plan whose FSP has a template (exports) plus two whose FSP has none (skipped)."""
+    group = PaymentPlanGroupFactory(cycle=program_cycle)
+    exportable_plan = PaymentPlanFactory(
+        program_cycle=program_cycle,
+        payment_plan_group=group,
+        business_area=business_area,
+        financial_service_provider=fsp,
+        delivery_mechanism=delivery_mechanism,
+        status=PaymentPlan.Status.ACCEPTED,
+    )
+    exportable_payment = PaymentFactory(
+        parent=exportable_plan,
+        financial_service_provider=fsp,
+        delivery_type=delivery_mechanism,
+        program=exportable_plan.program,
+        entitlement_quantity=Decimal("100.00"),
+        entitlement_quantity_usd=Decimal("10.00"),
+    )
+    PaymentHouseholdSnapshotFactory(payment=exportable_payment, snapshot_data={})
+    skipped_plan_one = PaymentPlanFactory(
+        program_cycle=program_cycle,
+        payment_plan_group=group,
+        business_area=business_area,
+        financial_service_provider=fsp_no_template,
+        delivery_mechanism=delivery_mechanism,
+        status=PaymentPlan.Status.ACCEPTED,
+    )
+    PaymentFactory(
+        parent=skipped_plan_one,
+        financial_service_provider=fsp_no_template,
+        delivery_type=delivery_mechanism,
+        program=skipped_plan_one.program,
+        entitlement_quantity=Decimal("100.00"),
+        entitlement_quantity_usd=Decimal("10.00"),
+    )
+    skipped_plan_two = PaymentPlanFactory(
+        program_cycle=program_cycle,
+        payment_plan_group=group,
+        business_area=business_area,
+        financial_service_provider=fsp_no_template,
+        delivery_mechanism=delivery_mechanism,
+        status=PaymentPlan.Status.ACCEPTED,
+    )
+    PaymentFactory(
+        parent=skipped_plan_two,
+        financial_service_provider=fsp_no_template,
+        delivery_type=delivery_mechanism,
+        program=skipped_plan_two.program,
+        entitlement_quantity=Decimal("100.00"),
+        entitlement_quantity_usd=Decimal("10.00"),
+    )
+    return group, exportable_plan, skipped_plan_one, skipped_plan_two
+
+
+@pytest.fixture
+def group_with_two_plans_without_template(program_cycle, business_area, fsp_no_template, delivery_mechanism):
+    """Two ACCEPTED plans whose FSP has no template - both skipped, so the export is empty."""
+    group = PaymentPlanGroupFactory(cycle=program_cycle)
+    plan_one = PaymentPlanFactory(
+        program_cycle=program_cycle,
+        payment_plan_group=group,
+        business_area=business_area,
+        financial_service_provider=fsp_no_template,
+        delivery_mechanism=delivery_mechanism,
+        status=PaymentPlan.Status.ACCEPTED,
+    )
+    PaymentFactory(
+        parent=plan_one,
+        financial_service_provider=fsp_no_template,
+        delivery_type=delivery_mechanism,
+        program=plan_one.program,
+        entitlement_quantity=Decimal("100.00"),
+        entitlement_quantity_usd=Decimal("10.00"),
+    )
+    plan_two = PaymentPlanFactory(
+        program_cycle=program_cycle,
+        payment_plan_group=group,
+        business_area=business_area,
+        financial_service_provider=fsp_no_template,
+        delivery_mechanism=delivery_mechanism,
+        status=PaymentPlan.Status.ACCEPTED,
+    )
+    PaymentFactory(
+        parent=plan_two,
+        financial_service_provider=fsp_no_template,
+        delivery_type=delivery_mechanism,
+        program=plan_two.program,
+        entitlement_quantity=Decimal("100.00"),
+        entitlement_quantity_usd=Decimal("10.00"),
     )
     return group
 
@@ -415,13 +522,53 @@ def test_save_xlsx_file_stores_batch_file_on_plan(group_with_one_accepted_plan, 
 
     plan.refresh_from_db()
     assert plan.export_file_delivery is not None
-    assert plan.export_file_delivery.file.name.endswith("_batch_1.xlsx")
+    assert "_batch_1" in plan.export_file_delivery.file.name
+    assert plan.export_file_delivery.file.name.endswith(".xlsx")
 
 
-def test_save_xlsx_file_no_eligible_plans_creates_no_file(empty_group, user):
-    XlsxPaymentPlanGroupDeliveryExportService(empty_group).save_xlsx_file(user)
+def test_save_xlsx_file_no_eligible_plans_raises_and_creates_no_file(empty_group, user):
+    with pytest.raises(EmptyDeliveryExportError):
+        XlsxPaymentPlanGroupDeliveryExportService(empty_group).save_xlsx_file(user)
 
     assert not empty_group.payment_plans.filter(export_file_delivery__isnull=False).exists()
+
+
+def test_save_xlsx_file_all_plans_skipped_reports_reasons(group_with_plan_without_template, user):
+    service = XlsxPaymentPlanGroupDeliveryExportService(group_with_plan_without_template)
+
+    with pytest.raises(EmptyDeliveryExportError) as exc_info:
+        service.save_xlsx_file(user)
+
+    assert str(exc_info.value) == EmptyDeliveryExportError.MESSAGE
+    assert len(exc_info.value.skipped_reasons) == 1
+    assert "no FSP XLSX Template" in exc_info.value.skipped_reasons[0]
+
+
+def test_save_xlsx_file_exports_mapped_plan_and_leaves_skipped_untouched(group_one_exportable_two_skipped, user):
+    group, exportable_plan, skipped_plan_one, skipped_plan_two = group_one_exportable_two_skipped
+
+    XlsxPaymentPlanGroupDeliveryExportService(group).save_xlsx_file(user)
+
+    exportable_plan.refresh_from_db()
+    skipped_plan_one.refresh_from_db()
+    skipped_plan_two.refresh_from_db()
+    assert exportable_plan.export_tag == 1
+    assert exportable_plan.export_file_delivery is not None
+    assert skipped_plan_one.export_tag is None
+    assert skipped_plan_one.export_file_delivery is None
+    assert skipped_plan_two.export_tag is None
+    assert skipped_plan_two.export_file_delivery is None
+
+
+def test_save_xlsx_file_multiple_plans_all_skipped_raises_with_all_reasons(group_with_two_plans_without_template, user):
+    service = XlsxPaymentPlanGroupDeliveryExportService(group_with_two_plans_without_template)
+
+    with pytest.raises(EmptyDeliveryExportError) as exc_info:
+        service.save_xlsx_file(user)
+
+    assert str(exc_info.value) == EmptyDeliveryExportError.MESSAGE
+    assert len(exc_info.value.skipped_reasons) == 2
+    assert not group_with_two_plans_without_template.payment_plans.filter(export_tag__isnull=False).exists()
 
 
 def test_save_xlsx_file_one_batch_tags_all_plans_and_shares_file(group_with_two_plans_and_payments, user):
@@ -515,7 +662,8 @@ def test_save_xlsx_file_reexport_with_export_tag_replaces_file_and_keeps_tag(gro
 def test_save_xlsx_file_does_not_tag_plan_whose_fsp_has_no_template(group_with_plan_without_template, user):
     plan = group_with_plan_without_template.payment_plans.first()
 
-    XlsxPaymentPlanGroupDeliveryExportService(group_with_plan_without_template).save_xlsx_file(user)
+    with pytest.raises(EmptyDeliveryExportError):
+        XlsxPaymentPlanGroupDeliveryExportService(group_with_plan_without_template).save_xlsx_file(user)
 
     plan.refresh_from_db()
     assert plan.export_tag is None
@@ -543,7 +691,8 @@ def test_plan_with_unprocessed_payments_is_skipped_when_template_requires_auth_c
     # payment still PENDING → is_payment_gateway_and_all_sent_to_fsp=False
     PaymentFactory(parent=plan, financial_service_provider=pg_fsp, status=Payment.STATUS_PENDING)
 
-    XlsxPaymentPlanGroupDeliveryExportService(group).save_xlsx_file(user)
+    with pytest.raises(EmptyDeliveryExportError):
+        XlsxPaymentPlanGroupDeliveryExportService(group).save_xlsx_file(user)
 
     plan.refresh_from_db()
     assert plan.export_tag is None


### PR DESCRIPTION
- do not create groups for PPs that are soft deleted
- pp type choices - fetch from BE instead of hardcoded + allow filter by all 4
<img width="653" height="225" alt="image" src="https://github.com/user-attachments/assets/906ae060-1625-4010-839f-3fe28d396712" />

- Problem: Clicking Export on a payment plan group where no plan was actually exportable did nothing — no file, no error. Fix: Export now shows an immediate error ("Nothing to export: no payment plan is currently exportable.") instead of silently failing.
