### PR TITLE
make payment plan group nullable for soft deleted payment plans

### DIFF
--- a/src/hope/apps/payment/migrations/0067_migration.py
+++ b/src/hope/apps/payment/migrations/0067_migration.py
@@ -207,13 +207,11 @@ class Migration(migrations.Migration):
             create_default_purpose_and_backfill,
             migrations.RunPython.noop,
         ),
-        migrations.AlterField(
+        migrations.AddConstraint(
             model_name="paymentplan",
-            name="payment_plan_group",
-            field=models.ForeignKey(
-                on_delete=django.db.models.deletion.PROTECT,
-                related_name="payment_plans",
-                to="payment.paymentplangroup",
+            constraint=models.CheckConstraint(
+                condition=models.Q(is_removed=True) | models.Q(payment_plan_group__isnull=False),
+                name="payment_plan_group_required_unless_removed",
             ),
         ),
         # --- source_payment_plan related_name rename ---

--- a/src/hope/apps/payment/services/payment_plan_services.py
+++ b/src/hope/apps/payment/services/payment_plan_services.py
@@ -856,12 +856,12 @@ class PaymentPlanService:
 
     @staticmethod
     def _check_group_fsp_consistency(
-        group: PaymentPlanGroup,
+        group: PaymentPlanGroup | None,
         fsp: FinancialServiceProvider | None,
         exclude_pk: "uuid.UUID | None" = None,
     ) -> None:
         """Raise ValidationError if fsp conflicts with another plan already in this group."""
-        if fsp is None:
+        if group is None or fsp is None:
             return
         qs = (
             PaymentPlan.objects.filter(payment_plan_group=group)

--- a/src/hope/models/payment_plan.py
+++ b/src/hope/models/payment_plan.py
@@ -287,6 +287,8 @@ class PaymentPlan(
         "payment.PaymentPlanGroup",
         on_delete=models.PROTECT,
         related_name="payment_plans",
+        null=True,
+        blank=True,
     )
     payment_plan_purposes = models.ManyToManyField(
         "payment.PaymentPlanPurpose",
@@ -641,6 +643,12 @@ class PaymentPlan(
             ("restart_exporting_payment_plan_list", "Can restart Exporting Payment Plans"),
             ("restart_importing_reconciliation_xlsx_file", "Can restart Importing Reconciliation XLSX File"),
         )
+        constraints = [
+            models.CheckConstraint(
+                condition=Q(is_removed=True) | Q(payment_plan_group__isnull=False),
+                name="payment_plan_group_required_unless_removed",
+            ),
+        ]
 
     def __str__(self) -> str:
         return self.unicef_id or ""

--- a/tests/unit/apps/payment/test_model_payment_plan.py
+++ b/tests/unit/apps/payment/test_model_payment_plan.py
@@ -8,6 +8,7 @@ from dateutil.relativedelta import relativedelta
 from django.contrib.admin.options import get_content_type_for_model
 from django.core.exceptions import ValidationError
 from django.core.files.base import ContentFile
+from django.db import IntegrityError, transaction
 from django.utils import timezone
 from django.utils.timezone import now
 import pytest
@@ -937,3 +938,24 @@ def test_remove_export_files_removes_delivery_when_finished_with_file() -> None:
         payment_plan.remove_export_files()
 
     assert not FileTemp.objects.filter(pk=file_temp.pk).exists()
+
+
+def test_live_payment_plan_without_group_violates_constraint(program_cycle):
+    with pytest.raises(IntegrityError, match="payment_plan_group_required_unless_removed"):
+        with transaction.atomic():
+            PaymentPlanFactory(program_cycle=program_cycle, payment_plan_group=None, is_removed=False)
+
+
+def test_removed_payment_plan_without_group_is_allowed(program_cycle):
+    payment_plan = PaymentPlanFactory(program_cycle=program_cycle, payment_plan_group=None, is_removed=True)
+
+    assert payment_plan.payment_plan_group_id is None
+    assert payment_plan.is_removed is True
+
+
+def test_live_payment_plan_with_group_is_allowed(program_cycle):
+    group = program_cycle.payment_plan_groups.first()
+
+    payment_plan = PaymentPlanFactory(program_cycle=program_cycle, payment_plan_group=group, is_removed=False)
+
+    assert payment_plan.payment_plan_group_id == group.id

--- a/tests/unit/apps/payment/test_model_payment_plan.py
+++ b/tests/unit/apps/payment/test_model_payment_plan.py
@@ -8,7 +8,7 @@ from dateutil.relativedelta import relativedelta
 from django.contrib.admin.options import get_content_type_for_model
 from django.core.exceptions import ValidationError
 from django.core.files.base import ContentFile
-from django.db import IntegrityError, transaction
+from django.db import IntegrityError
 from django.utils import timezone
 from django.utils.timezone import now
 import pytest
@@ -940,22 +940,18 @@ def test_remove_export_files_removes_delivery_when_finished_with_file() -> None:
     assert not FileTemp.objects.filter(pk=file_temp.pk).exists()
 
 
-def test_live_payment_plan_without_group_violates_constraint(program_cycle):
+@pytest.fixture
+def removed_payment_plan_without_group(program_cycle):
+    return PaymentPlanFactory(program_cycle=program_cycle, payment_plan_group=None, is_removed=True)
+
+
+def test_live_payment_plan_without_group_violates_constraint(payment_plan):
+    payment_plan.payment_plan_group = None
+
     with pytest.raises(IntegrityError, match="payment_plan_group_required_unless_removed"):
-        with transaction.atomic():
-            PaymentPlanFactory(program_cycle=program_cycle, payment_plan_group=None, is_removed=False)
+        payment_plan.save()
 
 
-def test_removed_payment_plan_without_group_is_allowed(program_cycle):
-    payment_plan = PaymentPlanFactory(program_cycle=program_cycle, payment_plan_group=None, is_removed=True)
-
-    assert payment_plan.payment_plan_group_id is None
-    assert payment_plan.is_removed is True
-
-
-def test_live_payment_plan_with_group_is_allowed(program_cycle):
-    group = program_cycle.payment_plan_groups.first()
-
-    payment_plan = PaymentPlanFactory(program_cycle=program_cycle, payment_plan_group=group, is_removed=False)
-
-    assert payment_plan.payment_plan_group_id == group.id
+def test_removed_payment_plan_without_group_is_allowed(removed_payment_plan_without_group):
+    assert removed_payment_plan_without_group.payment_plan_group_id is None
+    assert removed_payment_plan_without_group.is_removed is True


### PR DESCRIPTION
[AB#309719](https://unicef.visualstudio.com/4e044e8d-bc28-4768-8074-f80ff6e4a0e5/_workitems/edit/309719)

make payment plan group nullable for deleted payment plans