### PR TITLE
Hotfix: DocumentSerializerLax fix type field choices

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [ "setuptools", "wheel" ]
 
 [project]
 name = "hope"
-version = "4.15.5"
+version = "4.15.6"
 description = "HCT MIS is UNICEF's humanitarian cash transfer platform."
 readme = "README.md"
 license = { text = "None" }

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "4.15.5",
+  "version": "4.15.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/hope/api/endpoints/rdi/lax.py
+++ b/src/hope/api/endpoints/rdi/lax.py
@@ -25,11 +25,9 @@ from hope.api.endpoints.rdi.common import (
 )
 from hope.api.endpoints.rdi.mixin import HouseholdUploadMixin, PhotoMixin
 from hope.api.endpoints.rdi.upload import BirthDateValidator
-from hope.apps.core.utils import IDENTIFICATION_TYPE_TO_KEY_MAPPING
 from hope.apps.household.const import (
     DATA_SHARING_CHOICES,
     DISABILITY_CHOICES,
-    IDENTIFICATION_TYPE_CHOICE,
     MARITAL_STATUS_CHOICE,
     NOT_COLLECTED,
     OBSERVED_DISABILITY_CHOICE,
@@ -80,11 +78,26 @@ class IndividualsBulkStaging:
     saved_image_paths: list[str] = field(default_factory=list)
 
 
+class DocumentTypeKeyField(serializers.CharField):
+    """Validate the incoming value against actual ``DocumentType.key`` values (FK target).
+
+    The value is kept as the key string so the bulk flow can resolve keys to ids in a
+    single query. Valid keys are looked up lazily (at validation time, not import time)
+    and cached, so no per-document N+1 is introduced.
+    """
+
+    default_error_messages = {"invalid_choice": '"{input}" is not a valid choice.'}
+
+    def to_internal_value(self, data: Any) -> str:
+        value = super().to_internal_value(data)
+        valid_keys = {key for key, _ in DocumentType.get_all_doc_types_choices()}
+        if value not in valid_keys:
+            self.fail("invalid_choice", input=value)
+        return value
+
+
 class DocumentSerializerLax(serializers.ModelSerializer):
-    type = serializers.ChoiceField(
-        choices=[(IDENTIFICATION_TYPE_TO_KEY_MAPPING[value], label) for (value, label) in IDENTIFICATION_TYPE_CHOICE],
-        required=True,
-    )
+    type = DocumentTypeKeyField(required=True)
     country = serializers.ChoiceField(choices=Countries())
     image = serializers.CharField(allow_blank=True, required=False)
     document_number = serializers.CharField(required=True)

--- a/src/hope/apps/household/signals.py
+++ b/src/hope/apps/household/signals.py
@@ -53,7 +53,10 @@ def increment_individual_list_cache_version(sender: type[Individual], instance: 
 def invalidate_doc_types_cache(sender: type[Any], instance: Any, **kwargs: Any) -> None:
     from django.core.cache import cache
 
-    cache.delete(instance.CACHE_KEY_ALL_DOC_TYPES)
+    cache_key = instance.CACHE_KEY_ALL_DOC_TYPES
+    # Defer to commit so the cache is cleared only after the new data is visible,
+    # avoiding repopulation with stale (pre-commit) data.
+    transaction.on_commit(lambda: cache.delete(cache_key))
 
 
 def increment_household_list_cache_version_from_bulk(

--- a/src/hope/apps/household/signals.py
+++ b/src/hope/apps/household/signals.py
@@ -48,6 +48,14 @@ def increment_individual_list_cache_version(sender: type[Individual], instance: 
     transaction.on_commit(lambda: increment_individual_list_program_key(program_id))
 
 
+@receiver(post_save, sender="household.DocumentType")
+@receiver(post_delete, sender="household.DocumentType")
+def invalidate_doc_types_cache(sender: type[Any], instance: Any, **kwargs: Any) -> None:
+    from django.core.cache import cache
+
+    cache.delete(instance.CACHE_KEY_ALL_DOC_TYPES)
+
+
 def increment_household_list_cache_version_from_bulk(
     sender: type[Household | Individual], instances: list[Any], **kwargs: Any
 ) -> None:

--- a/src/hope/models/document_type.py
+++ b/src/hope/models/document_type.py
@@ -1,3 +1,4 @@
+from django.core.cache import cache
 from django.db import models
 
 from hope.models.utils import TimeStampedUUIDModel
@@ -24,8 +25,12 @@ class DocumentType(TimeStampedUUIDModel):
 
     @classmethod
     def get_all_doc_types_choices(cls) -> list[tuple[str, str]]:
-        """Return list of Document Types choices."""
-        return [(obj.key, obj.label) for obj in cls.objects.all()]
+        """Return list of Document Types choices (key, label), cached."""
+        choices = cache.get(cls.CACHE_KEY_ALL_DOC_TYPES)
+        if choices is None:
+            choices = [(obj.key, obj.label) for obj in cls.objects.all()]
+            cache.set(cls.CACHE_KEY_ALL_DOC_TYPES, choices, cls.CACHE_TTL_SECONDS)
+        return choices
 
     @classmethod
     def get_all_doc_types(cls) -> list[str]:

--- a/tests/unit/api/test_lax_individuals.py
+++ b/tests/unit/api/test_lax_individuals.py
@@ -162,6 +162,62 @@ def test_create_single_individual_success(lax_api_client, lax_push_url, document
     assert individual.country_workspace_id == "42"
 
 
+def test_create_individual_with_custom_document_type_key(lax_api_client, lax_push_url, afghanistan_country):
+    # `type` is validated against actual DocumentType.key values, not the static
+    # IDENTIFICATION_TYPE_CHOICE list, so a non-standard key is accepted.
+    custom_doc_type = DocumentTypeFactory(key="test_type", label="Test Type")
+    individual_data = {
+        "individual_id": "IND001",
+        "full_name": "John Doe",
+        "given_name": "John",
+        "family_name": "Doe",
+        "birth_date": "1990-01-01",
+        "sex": "MALE",
+        "documents": [
+            {
+                "type": "test_type",
+                "country": "AF",
+                "document_number": "DOC123456",
+            }
+        ],
+    }
+
+    response = lax_api_client.post(lax_push_url, [individual_data], format="json")
+
+    assert response.status_code == status.HTTP_201_CREATED, str(response.json())
+    assert response.data["accepted"] == 1
+    assert response.data["errors"] == 0
+
+    document = PendingDocument.objects.get(document_number="DOC123456")
+    assert document.type_id == custom_doc_type.id
+
+
+def test_create_individual_with_invalid_document_type(lax_api_client, lax_push_url, document_type, afghanistan_country):
+    # A `type` that does not match any DocumentType.key is rejected by the serializer.
+    individual_data = {
+        "individual_id": "IND001",
+        "full_name": "John Doe",
+        "given_name": "John",
+        "family_name": "Doe",
+        "birth_date": "1990-01-01",
+        "sex": "MALE",
+        "documents": [
+            {
+                "type": "does_not_exist",
+                "country": "AF",
+                "document_number": "DOC123456",
+            }
+        ],
+    }
+
+    response = lax_api_client.post(lax_push_url, [individual_data], format="json")
+
+    assert response.status_code == status.HTTP_201_CREATED, str(response.json())
+    assert response.data["accepted"] == 0
+    assert response.data["errors"] == 1
+    assert not PendingDocument.objects.filter(document_number="DOC123456").exists()
+
+
 def test_create_single_individual_account_with_explicit_fi(
     lax_api_client, lax_push_url, bank_account_type, financial_institution
 ):

--- a/tests/unit/apps/household/test_models.py
+++ b/tests/unit/apps/household/test_models.py
@@ -392,7 +392,7 @@ def test_facility_str(business_area: BusinessArea, area_hierarchy: tuple[Area, A
 # --- DocumentType ---
 
 
-def test_get_all_doc_types_choices_is_cached_and_invalidated() -> None:
+def test_get_all_doc_types_choices_is_cached_and_invalidated(django_capture_on_commit_callbacks) -> None:
     from django.core.cache import cache
 
     cache.delete(DocumentType.CACHE_KEY_ALL_DOC_TYPES)
@@ -407,20 +407,22 @@ def test_get_all_doc_types_choices_is_cached_and_invalidated() -> None:
     DocumentType.objects.bulk_create([DocumentType(key="key_b", label="Label B")])
     assert ("key_b", "Label B") not in DocumentType.get_all_doc_types_choices()
 
-    # Saving a DocumentType invalidates the cache, so the next call is fresh.
-    DocumentTypeFactory(key="key_c", label="Label C")
+    # Saving a DocumentType invalidates the cache on commit, so the next call is fresh.
+    with django_capture_on_commit_callbacks(execute=True):
+        DocumentTypeFactory(key="key_c", label="Label C")
     refreshed = DocumentType.get_all_doc_types_choices()
     assert ("key_b", "Label B") in refreshed
     assert ("key_c", "Label C") in refreshed
 
 
-def test_get_all_doc_types_choices_cache_cleared_on_delete() -> None:
+def test_get_all_doc_types_choices_cache_cleared_on_delete(django_capture_on_commit_callbacks) -> None:
     from django.core.cache import cache
 
     cache.delete(DocumentType.CACHE_KEY_ALL_DOC_TYPES)
     doc_type = DocumentTypeFactory(key="key_to_delete", label="To Delete")
     assert ("key_to_delete", "To Delete") in DocumentType.get_all_doc_types_choices()
 
-    doc_type.delete()
+    with django_capture_on_commit_callbacks(execute=True):
+        doc_type.delete()
     assert cache.get(DocumentType.CACHE_KEY_ALL_DOC_TYPES) is None
     assert ("key_to_delete", "To Delete") not in DocumentType.get_all_doc_types_choices()

--- a/tests/unit/apps/household/test_models.py
+++ b/tests/unit/apps/household/test_models.py
@@ -387,3 +387,40 @@ def test_facility_str(business_area: BusinessArea, area_hierarchy: tuple[Area, A
     facility = Facility.objects.create(name="test facility", business_area=business_area, admin_area=area1)
 
     assert str(facility) == "TEST FACILITY"
+
+
+# --- DocumentType ---
+
+
+def test_get_all_doc_types_choices_is_cached_and_invalidated() -> None:
+    from django.core.cache import cache
+
+    cache.delete(DocumentType.CACHE_KEY_ALL_DOC_TYPES)
+    DocumentTypeFactory(key="key_a", label="Label A")
+
+    # First call populates the cache from the DB.
+    choices = DocumentType.get_all_doc_types_choices()
+    assert ("key_a", "Label A") in choices
+    assert cache.get(DocumentType.CACHE_KEY_ALL_DOC_TYPES) == choices
+
+    # While cached, a directly inserted row (bypassing signals) is not reflected.
+    DocumentType.objects.bulk_create([DocumentType(key="key_b", label="Label B")])
+    assert ("key_b", "Label B") not in DocumentType.get_all_doc_types_choices()
+
+    # Saving a DocumentType invalidates the cache, so the next call is fresh.
+    DocumentTypeFactory(key="key_c", label="Label C")
+    refreshed = DocumentType.get_all_doc_types_choices()
+    assert ("key_b", "Label B") in refreshed
+    assert ("key_c", "Label C") in refreshed
+
+
+def test_get_all_doc_types_choices_cache_cleared_on_delete() -> None:
+    from django.core.cache import cache
+
+    cache.delete(DocumentType.CACHE_KEY_ALL_DOC_TYPES)
+    doc_type = DocumentTypeFactory(key="key_to_delete", label="To Delete")
+    assert ("key_to_delete", "To Delete") in DocumentType.get_all_doc_types_choices()
+
+    doc_type.delete()
+    assert cache.get(DocumentType.CACHE_KEY_ALL_DOC_TYPES) is None
+    assert ("key_to_delete", "To Delete") not in DocumentType.get_all_doc_types_choices()


### PR DESCRIPTION
[AB#324518](https://unicef.visualstudio.com/ICTD-HCT-MIS/_workitems/edit/324518): CW cannot push new document types to HOPE