### PR TITLE
Currency codes for api households

### DIFF
--- a/src/hope/api/endpoints/rdi/lax.py
+++ b/src/hope/api/endpoints/rdi/lax.py
@@ -54,6 +54,7 @@ from hope.models import (
     PendingIndividual,
     RegistrationDataImport,
 )
+from hope.models.currency import Currency
 
 if TYPE_CHECKING:
     from uuid import UUID
@@ -556,6 +557,12 @@ class HouseholdSerializer(serializers.ModelSerializer):
     consent_sharing = serializers.MultipleChoiceField(choices=DATA_SHARING_CHOICES, required=False)
     village = serializers.CharField(allow_blank=True, allow_null=True, required=False)
     consent_sign = serializers.CharField(allow_blank=True, required=False)
+    currency = serializers.SlugRelatedField(
+        slug_field="code",
+        required=False,
+        allow_null=True,
+        queryset=Currency.objects.all(),
+    )
     head_of_household_id = serializers.SlugRelatedField(
         source="head_of_household",
         slug_field="unicef_id",

--- a/src/hope/api/endpoints/rdi/push_people.py
+++ b/src/hope/api/endpoints/rdi/push_people.py
@@ -42,6 +42,7 @@ from hope.models import (
     PendingIndividual,
     RegistrationDataImport,
 )
+from hope.models.currency import Currency
 
 if TYPE_CHECKING:
     from rest_framework.request import Request
@@ -79,6 +80,12 @@ class PushPeopleSerializer(serializers.ModelSerializer):
     country = NullableChoiceField(choices=Countries(), required=False, allow_blank=True, allow_null=True)
     residence_status = serializers.ChoiceField(choices=RESIDENCE_STATUS_CHOICE, required=False, allow_blank=True)
     village = serializers.CharField(allow_blank=True, allow_null=True, required=False)
+    currency = serializers.SlugRelatedField(
+        slug_field="code",
+        required=False,
+        allow_null=True,
+        queryset=Currency.objects.all(),
+    )
 
     phone_no = serializers.CharField(allow_null=True, allow_blank=True, required=False)
     phone_no_alternative = serializers.CharField(allow_null=True, allow_blank=True, required=False)

--- a/src/hope/api/endpoints/rdi/upload.py
+++ b/src/hope/api/endpoints/rdi/upload.py
@@ -36,6 +36,7 @@ from hope.models import (
     Program,
     RegistrationDataImport,
 )
+from hope.models.currency import Currency
 
 if TYPE_CHECKING:
     from rest_framework.request import Request
@@ -182,6 +183,12 @@ class HouseholdSerializer(serializers.ModelSerializer):
     size = serializers.IntegerField(required=False, allow_null=True)
     consent_sharing = serializers.MultipleChoiceField(choices=DATA_SHARING_CHOICES, required=False)
     village = serializers.CharField(allow_blank=True, allow_null=True, required=False)
+    currency = serializers.SlugRelatedField(
+        slug_field="code",
+        required=False,
+        allow_null=True,
+        queryset=Currency.objects.all(),
+    )
 
     admin1 = serializers.SlugRelatedField(
         slug_field="p_code",

--- a/tests/unit/api/test_lax_households.py
+++ b/tests/unit/api/test_lax_households.py
@@ -37,6 +37,7 @@ from hope.models import (
     Program,
     RegistrationDataImport,
 )
+from hope.models.currency import Currency
 from hope.models.grant import Grant
 
 pytestmark = pytest.mark.django_db
@@ -662,6 +663,65 @@ def test_household_create_validation_facility_area(
     assert (
         "This field is required when facility_name is provided." in response.json()["results"][0]["facility_admin_area"]
     )
+
+
+def test_create_household_with_currency(
+    api_client: APIClient,
+    lax_households_url: str,
+    afghanistan_country: Country,
+    head_of_household: PendingIndividual,
+    primary_collector: PendingIndividual,
+    currency_usd: Currency,
+) -> None:
+    household_data = {
+        "country": "AF",
+        "country_origin": "AF",
+        "size": 1,
+        "consent_sharing": ["UNICEF"],
+        "village": "Test Village",
+        "head_of_household_id": head_of_household.unicef_id,
+        "primary_collector_id": primary_collector.unicef_id,
+        "members": [head_of_household.unicef_id, primary_collector.unicef_id],
+        "currency": "USD",
+    }
+
+    response = api_client.post(lax_households_url, [household_data], format="json")
+
+    assert response.status_code == status.HTTP_201_CREATED, str(response.json())
+    assert response.data["accepted"] == 1
+    assert response.data["errors"] == 0
+
+    household = PendingHousehold.objects.get(id=response.data["results"][0]["pk"])
+    assert household.currency == currency_usd
+    assert household.currency.code == "USD"
+
+
+def test_create_household_without_currency_is_null(
+    api_client: APIClient,
+    lax_households_url: str,
+    afghanistan_country: Country,
+    head_of_household: PendingIndividual,
+    primary_collector: PendingIndividual,
+) -> None:
+    household_data = {
+        "country": "AF",
+        "country_origin": "AF",
+        "size": 1,
+        "consent_sharing": ["UNICEF"],
+        "village": "Test Village",
+        "head_of_household_id": head_of_household.unicef_id,
+        "primary_collector_id": primary_collector.unicef_id,
+        "members": [head_of_household.unicef_id, primary_collector.unicef_id],
+    }
+
+    response = api_client.post(lax_households_url, [household_data], format="json")
+
+    assert response.status_code == status.HTTP_201_CREATED, str(response.json())
+    assert response.data["accepted"] == 1
+    assert response.data["errors"] == 0
+
+    household = PendingHousehold.objects.get(id=response.data["results"][0]["pk"])
+    assert household.currency is None
 
 
 def test_household_create_facility(

--- a/tests/unit/api/test_push_people.py
+++ b/tests/unit/api/test_push_people.py
@@ -354,6 +354,35 @@ def test_push_single_person_with_admin_areas(token_api_client, push_people_url, 
     assert ind.household.admin4 is None
 
 
+def test_push_single_person_with_currency(
+    token_api_client, push_people_url, program, rdi, afghanistan_country, currency_usd
+) -> None:
+    data = [
+        {
+            "residence_status": "IDP",
+            "village": "village1",
+            "country": "AF",
+            "full_name": "John Doe",
+            "birth_date": "2000-01-01",
+            "sex": "MALE",
+            "type": "",
+            "currency": "USD",
+            "program": str(program.id),
+            "country_workspace_id": "cw-currency-1",
+        }
+    ]
+    response = token_api_client.post(push_people_url, data, format="json")
+    assert response.status_code == status.HTTP_201_CREATED, str(response.json())
+    response_json = response.json()
+
+    rdi_obj = RegistrationDataImport.objects.filter(id=response_json["id"]).first()
+    assert rdi_obj is not None
+    ind = PendingIndividual.objects.filter(registration_data_import=rdi_obj).first()
+    assert ind is not None
+    assert ind.household.currency is not None
+    assert ind.household.currency.code == "USD"
+
+
 @pytest.fixture
 def base64_photo() -> tuple[str, str]:
     prefix = "data:image/png;base64,"

--- a/tests/unit/api/test_rdi.py
+++ b/tests/unit/api/test_rdi.py
@@ -21,6 +21,7 @@ from hope.models import (
     RegistrationDataImport,
     User,
 )
+from hope.models.currency import Currency
 
 pytestmark = pytest.mark.django_db
 
@@ -203,6 +204,97 @@ def test_push_creates_household_and_individuals(
     assert hh.head_of_household.program_id == program.id
     assert data["households"] == 1
     assert data["individuals"] == 2
+
+
+def test_push_creates_household_with_currency(
+    token_api_client: APIClient,
+    user_business_area: BusinessArea,
+    program: Program,
+    rdi_loading: RegistrationDataImport,
+    afghanistan_country,
+    currency_usd: Currency,
+) -> None:
+    url = reverse("api:rdi-push", args=[user_business_area.slug, str(rdi_loading.id)])
+    input_data = [
+        {
+            "residence_status": "",
+            "village": "village_currency",
+            "country": "AF",
+            "currency": "USD",
+            "members": [
+                {
+                    "relationship": HEAD,
+                    "full_name": "James Head",
+                    "birth_date": "2000-01-01",
+                    "sex": "MALE",
+                    "role": "",
+                },
+                {
+                    "relationship": NON_BENEFICIARY,
+                    "full_name": "Mary Primary",
+                    "birth_date": "2000-01-01",
+                    "role": ROLE_PRIMARY,
+                    "sex": "FEMALE",
+                },
+            ],
+            "size": 1,
+        }
+    ]
+
+    response = token_api_client.post(url, input_data, format="json")
+
+    assert response.status_code == status.HTTP_201_CREATED, str(response.json())
+    data = response.json()
+    rdi = RegistrationDataImport.objects.filter(id=data["id"]).first()
+    assert rdi is not None
+    hh = PendingHousehold.objects.filter(registration_data_import=rdi, village="village_currency").first()
+    assert hh is not None
+    assert hh.currency == currency_usd
+    assert hh.currency.code == "USD"
+
+
+def test_push_creates_household_without_currency_is_null(
+    token_api_client: APIClient,
+    user_business_area: BusinessArea,
+    program: Program,
+    rdi_loading: RegistrationDataImport,
+    afghanistan_country,
+) -> None:
+    url = reverse("api:rdi-push", args=[user_business_area.slug, str(rdi_loading.id)])
+    input_data = [
+        {
+            "residence_status": "",
+            "village": "village_no_currency",
+            "country": "AF",
+            "members": [
+                {
+                    "relationship": HEAD,
+                    "full_name": "James Head",
+                    "birth_date": "2000-01-01",
+                    "sex": "MALE",
+                    "role": "",
+                },
+                {
+                    "relationship": NON_BENEFICIARY,
+                    "full_name": "Mary Primary",
+                    "birth_date": "2000-01-01",
+                    "role": ROLE_PRIMARY,
+                    "sex": "FEMALE",
+                },
+            ],
+            "size": 1,
+        }
+    ]
+
+    response = token_api_client.post(url, input_data, format="json")
+
+    assert response.status_code == status.HTTP_201_CREATED, str(response.json())
+    data = response.json()
+    rdi = RegistrationDataImport.objects.filter(id=data["id"]).first()
+    assert rdi is not None
+    hh = PendingHousehold.objects.filter(registration_data_import=rdi, village="village_no_currency").first()
+    assert hh is not None
+    assert hh.currency is None
 
 
 @pytest.fixture

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = "==3.14.*"
 
 [manifest]
@@ -1981,7 +1981,7 @@ wheels = [
 
 [[package]]
 name = "hope"
-version = "4.15.3"
+version = "4.15.6"
 source = { editable = "." }
 dependencies = [
     { name = "black" },


### PR DESCRIPTION
When CW pushes Households to HOPE through API they get errors for `currency`: "got str, expected pk". This PR hotfixes it