### PR TITLE
fix(grievance): offer to close linked Needs Adjudication ticket when its Data Change fix closes

### DIFF
--- a/src/frontend/src/components/grievances/GrievanceDetailsToolbar.tsx
+++ b/src/frontend/src/components/grievances/GrievanceDetailsToolbar.tsx
@@ -118,28 +118,6 @@ export const GrievanceDetailsToolbar = ({
     },
   });
 
-  const { mutateAsync: closeAsUniqueAsync, isPending: closingAsUnique } =
-    useMutation({
-      mutationFn: () =>
-        RestService.restBusinessAreasGrievanceTicketsCloseAsUniqueCreate({
-          businessAreaSlug: businessArea,
-          id: ticket.id,
-          formData: {},
-        }),
-      onError: (e: any) => {
-        showApiErrorMessages(e, showMessage);
-      },
-      onSuccess: () => {
-        queryClient.invalidateQueries({
-          queryKey: [
-            'businessAreasGrievanceTicketsRetrieve',
-            businessArea,
-            ticket.id,
-          ],
-        });
-      },
-    });
-
   const isNew = ticket.status === GRIEVANCE_TICKET_STATES.NEW;
   const isAssigned = ticket.status === GRIEVANCE_TICKET_STATES.ASSIGNED;
   const isInProgress = ticket.status === GRIEVANCE_TICKET_STATES.IN_PROGRESS;
@@ -281,6 +259,47 @@ export const GrievanceDetailsToolbar = ({
     await mutateAsync({ status });
   };
 
+  const offerLinkedNeedsAdjudicationClose = async (): Promise<void> => {
+    const linkedId = ticket?.ticketDetails?.linkedNeedsAdjudicationTicketId;
+    if (!linkedId) {
+      return;
+    }
+    try {
+      const linkedTicket =
+        await RestService.restBusinessAreasGrievanceTicketsRetrieve({
+          businessAreaSlug: businessArea,
+          id: linkedId,
+        });
+      if (!linkedTicket?.ticketDetails?.canCloseAsUnique) {
+        return;
+      }
+      confirm({
+        title: t('Close linked ticket as unique'),
+        content: t(
+          `The individuals on linked ticket ${linkedTicket.unicefId} no longer share a document number. Do you want to mark them as unique and close that ticket too?`,
+        ),
+        continueText: t('mark as unique and close'),
+      }).then(async () => {
+        try {
+          await RestService.restBusinessAreasGrievanceTicketsCloseAsUniqueCreate(
+            { businessAreaSlug: businessArea, id: linkedId, formData: {} },
+          );
+          queryClient.invalidateQueries({
+            queryKey: [
+              'businessAreasGrievanceTicketsRetrieve',
+              businessArea,
+              linkedId,
+            ],
+          });
+        } catch (e) {
+          showApiErrorMessages(e, showMessage);
+        }
+      });
+    } catch (e) {
+      showApiErrorMessages(e, showMessage);
+    }
+  };
+
   const getClosingConfirmationText = (): string => {
     const isDeduplicationCategory =
       ticket.category.toString() === GRIEVANCE_CATEGORIES.NEEDS_ADJUDICATION;
@@ -317,8 +336,9 @@ export const GrievanceDetailsToolbar = ({
 
   const isDeduplicationCategory =
     ticket.category.toString() === GRIEVANCE_CATEGORIES.NEEDS_ADJUDICATION;
+  const isDataChangeCategory =
+    ticket.category.toString() === GRIEVANCE_CATEGORIES.DATA_CHANGE;
   const hasDuplicatedDocument = ticket?.ticketDetails?.hasDuplicatedDocument;
-  const canCloseAsUnique = ticket?.ticketDetails?.canCloseAsUnique;
   const isMultipleDuplicatesVersion =
     ticket?.ticketDetails?.isMultipleDuplicatesVersion;
   const selectedIndividual = ticket?.ticketDetails?.selectedIndividual;
@@ -367,39 +387,28 @@ export const GrievanceDetailsToolbar = ({
     />
   ) : (
     <LoadingButton
-      loading={loading || closingAsUnique}
+      loading={loading}
       color="primary"
       variant="contained"
       onClick={() =>
-        isDeduplicationCategory && canCloseAsUnique
-          ? confirm({
-              title: t('Close ticket as unique'),
-              content: t(
-                `The ${beneficiaryGroup?.memberLabelPlural} on this ticket no longer share a document number. Do you want to mark them as unique and close the ticket?`,
-              ),
-              continueText: t('mark as unique and close'),
-            }).then(async () => {
-              try {
-                await closeAsUniqueAsync();
-              } catch {
-                // Error handling is done in the mutation onError callback
-              }
-            })
-          : confirm({
-              title: t('Close ticket'),
-              extraContent: isDeduplicationCategory
-                ? closingConfirmationText
-                : getClosingConfirmationExtraText(),
-              content: getClosingConfirmationText(),
-              warningContent: closingWarningText,
-              continueText: t('close ticket'),
-            }).then(async () => {
-              try {
-                await changeState(GRIEVANCE_TICKET_STATES.CLOSED);
-              } catch {
-                // Error handling is done in the mutation onError callback
-              }
-            })
+        confirm({
+          title: t('Close ticket'),
+          extraContent: isDeduplicationCategory
+            ? closingConfirmationText
+            : getClosingConfirmationExtraText(),
+          content: getClosingConfirmationText(),
+          warningContent: closingWarningText,
+          continueText: t('close ticket'),
+        }).then(async () => {
+          try {
+            await changeState(GRIEVANCE_TICKET_STATES.CLOSED);
+            if (isDataChangeCategory) {
+              await offerLinkedNeedsAdjudicationClose();
+            }
+          } catch {
+            // Error handling is done in the mutation onError callback
+          }
+        })
       }
       data-cy="button-close-ticket"
       disabled={!isActiveProgram || disableCloseDueToPrimaryNotReassigned}

--- a/src/frontend/src/components/grievances/GrievanceDetailsToolbar.tsx
+++ b/src/frontend/src/components/grievances/GrievanceDetailsToolbar.tsx
@@ -22,7 +22,10 @@ import { Link, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import { useProgramContext } from '../../programContext';
 import { MiśTheme } from '../../theme';
-import { getGrievanceEditPath } from './utils/createGrievanceUtils';
+import {
+  getGrievanceDetailsPath,
+  getGrievanceEditPath,
+} from './utils/createGrievanceUtils';
 import { showApiErrorMessages } from '@utils/utils';
 import { PERMISSIONS } from 'src/config/permissions';
 
@@ -275,8 +278,24 @@ export const GrievanceDetailsToolbar = ({
       }
       confirm({
         title: t('Close linked ticket as unique'),
-        content: t(
-          `The individuals on linked ticket ${linkedTicket.unicefId} no longer share a document number. Do you want to mark them as unique and close that ticket too?`,
+        content: (
+          <>
+            {t('The individuals on linked ticket')}{' '}
+            <a
+              href={getGrievanceDetailsPath(
+                linkedTicket.id,
+                linkedTicket.category,
+                baseUrl,
+              )}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {linkedTicket.unicefId}
+            </a>{' '}
+            {t(
+              'no longer share a document number. Do you want to mark them as unique and close that ticket too?',
+            )}
+          </>
         ),
         continueText: t('mark as unique and close'),
       }).then(async () => {

--- a/src/frontend/src/components/grievances/GrievanceDetailsToolbar.tsx
+++ b/src/frontend/src/components/grievances/GrievanceDetailsToolbar.tsx
@@ -118,6 +118,28 @@ export const GrievanceDetailsToolbar = ({
     },
   });
 
+  const { mutateAsync: closeAsUniqueAsync, isPending: closingAsUnique } =
+    useMutation({
+      mutationFn: () =>
+        RestService.restBusinessAreasGrievanceTicketsCloseAsUniqueCreate({
+          businessAreaSlug: businessArea,
+          id: ticket.id,
+          formData: {},
+        }),
+      onError: (e: any) => {
+        showApiErrorMessages(e, showMessage);
+      },
+      onSuccess: () => {
+        queryClient.invalidateQueries({
+          queryKey: [
+            'businessAreasGrievanceTicketsRetrieve',
+            businessArea,
+            ticket.id,
+          ],
+        });
+      },
+    });
+
   const isNew = ticket.status === GRIEVANCE_TICKET_STATES.NEW;
   const isAssigned = ticket.status === GRIEVANCE_TICKET_STATES.ASSIGNED;
   const isInProgress = ticket.status === GRIEVANCE_TICKET_STATES.IN_PROGRESS;
@@ -296,6 +318,7 @@ export const GrievanceDetailsToolbar = ({
   const isDeduplicationCategory =
     ticket.category.toString() === GRIEVANCE_CATEGORIES.NEEDS_ADJUDICATION;
   const hasDuplicatedDocument = ticket?.ticketDetails?.hasDuplicatedDocument;
+  const canCloseAsUnique = ticket?.ticketDetails?.canCloseAsUnique;
   const isMultipleDuplicatesVersion =
     ticket?.ticketDetails?.isMultipleDuplicatesVersion;
   const selectedIndividual = ticket?.ticketDetails?.selectedIndividual;
@@ -344,25 +367,39 @@ export const GrievanceDetailsToolbar = ({
     />
   ) : (
     <LoadingButton
-      loading={loading}
+      loading={loading || closingAsUnique}
       color="primary"
       variant="contained"
       onClick={() =>
-        confirm({
-          title: t('Close ticket'),
-          extraContent: isDeduplicationCategory
-            ? closingConfirmationText
-            : getClosingConfirmationExtraText(),
-          content: getClosingConfirmationText(),
-          warningContent: closingWarningText,
-          continueText: t('close ticket'),
-        }).then(async () => {
-          try {
-            await changeState(GRIEVANCE_TICKET_STATES.CLOSED);
-          } catch {
-            // Error handling is done in the mutation onError callback
-          }
-        })
+        isDeduplicationCategory && canCloseAsUnique
+          ? confirm({
+              title: t('Close ticket as unique'),
+              content: t(
+                `The ${beneficiaryGroup?.memberLabelPlural} on this ticket no longer share a document number. Do you want to mark them as unique and close the ticket?`,
+              ),
+              continueText: t('mark as unique and close'),
+            }).then(async () => {
+              try {
+                await closeAsUniqueAsync();
+              } catch {
+                // Error handling is done in the mutation onError callback
+              }
+            })
+          : confirm({
+              title: t('Close ticket'),
+              extraContent: isDeduplicationCategory
+                ? closingConfirmationText
+                : getClosingConfirmationExtraText(),
+              content: getClosingConfirmationText(),
+              warningContent: closingWarningText,
+              continueText: t('close ticket'),
+            }).then(async () => {
+              try {
+                await changeState(GRIEVANCE_TICKET_STATES.CLOSED);
+              } catch {
+                // Error handling is done in the mutation onError callback
+              }
+            })
       }
       data-cy="button-close-ticket"
       disabled={!isActiveProgram || disableCloseDueToPrimaryNotReassigned}

--- a/src/hope/apps/grievance/api/serializers/grievance_ticket.py
+++ b/src/hope/apps/grievance/api/serializers/grievance_ticket.py
@@ -693,6 +693,10 @@ class GrievanceStatusChangeSerializer(serializers.Serializer):
     version = serializers.IntegerField(required=False)
 
 
+class GrievanceCloseAsUniqueSerializer(serializers.Serializer):
+    version = serializers.IntegerField(required=False)
+
+
 class GrievanceCreateNoteSerializer(serializers.Serializer):
     description = serializers.CharField()
     version = serializers.IntegerField(required=False)

--- a/src/hope/apps/grievance/api/serializers/ticket_detail.py
+++ b/src/hope/apps/grievance/api/serializers/ticket_detail.py
@@ -18,6 +18,9 @@ from hope.apps.grievance.models import (
     TicketPaymentVerificationDetails,
     TicketSystemFlaggingDetails,
 )
+from hope.apps.grievance.services.needs_adjudication_ticket_services import (
+    can_close_as_unique,
+)
 from hope.apps.household.api.serializers.individual import (
     HouseholdSimpleSerializer,
     IndividualForTicketSerializer,
@@ -202,6 +205,7 @@ class TicketNeedsAdjudicationDetailsExtraDataSerializer(serializers.Serializer):
 
 class NeedsAdjudicationTicketDetailsSerializer(serializers.ModelSerializer):
     has_duplicated_document = serializers.SerializerMethodField()
+    can_close_as_unique = serializers.SerializerMethodField()
     golden_records_individual = IndividualForTicketSerializer()
     extra_data = serializers.SerializerMethodField()
     possible_duplicate = IndividualForTicketSerializer()
@@ -215,6 +219,7 @@ class NeedsAdjudicationTicketDetailsSerializer(serializers.ModelSerializer):
         fields = (
             "id",
             "has_duplicated_document",
+            "can_close_as_unique",
             "is_multiple_duplicates_version",
             "golden_records_individual",
             "possible_duplicate",
@@ -228,6 +233,9 @@ class NeedsAdjudicationTicketDetailsSerializer(serializers.ModelSerializer):
 
     def get_has_duplicated_document(self, obj: TicketNeedsAdjudicationDetails) -> bool:
         return obj.has_duplicated_document
+
+    def get_can_close_as_unique(self, obj: TicketNeedsAdjudicationDetails) -> bool:
+        return can_close_as_unique(obj)
 
     def get_extra_data(self, obj: TicketSystemFlaggingDetails) -> dict:
         return TicketNeedsAdjudicationDetailsExtraDataSerializer(

--- a/src/hope/apps/grievance/api/serializers/ticket_detail.py
+++ b/src/hope/apps/grievance/api/serializers/ticket_detail.py
@@ -20,6 +20,7 @@ from hope.apps.grievance.models import (
 )
 from hope.apps.grievance.services.needs_adjudication_ticket_services import (
     can_close_as_unique,
+    find_open_unique_identifiers_ticket_for_individual,
 )
 from hope.apps.household.api.serializers.individual import (
     HouseholdSimpleSerializer,
@@ -41,6 +42,7 @@ class HouseholdDataUpdateTicketDetailsSerializer(serializers.ModelSerializer):
 
 class IndividualDataUpdateTicketDetailsSerializer(serializers.ModelSerializer):
     individual_data = serializers.SerializerMethodField()
+    linked_needs_adjudication_ticket_id = serializers.SerializerMethodField()
 
     class Meta:
         model = TicketIndividualDataUpdateDetails
@@ -48,6 +50,7 @@ class IndividualDataUpdateTicketDetailsSerializer(serializers.ModelSerializer):
             "id",
             "individual_data",
             "role_reassign_data",
+            "linked_needs_adjudication_ticket_id",
         )
 
     def get_individual_data(self, obj: TicketIndividualDataUpdateDetails) -> dict | None:
@@ -62,6 +65,10 @@ class IndividualDataUpdateTicketDetailsSerializer(serializers.ModelSerializer):
             if photo_data.get("previous_value"):
                 photo_data["previous_value"] = default_storage.url(photo_data["previous_value"])
         return data
+
+    def get_linked_needs_adjudication_ticket_id(self, obj: TicketIndividualDataUpdateDetails) -> str | None:
+        linked = find_open_unique_identifiers_ticket_for_individual(obj.individual)
+        return str(linked.ticket_id) if linked else None
 
 
 class AddIndividualTicketDetailsSerializer(serializers.ModelSerializer):

--- a/src/hope/apps/grievance/api/views.py
+++ b/src/hope/apps/grievance/api/views.py
@@ -72,6 +72,7 @@ from hope.apps.grievance.api.serializers.grievance_ticket import (
     BulkUpdateGrievanceTicketsUrgencySerializer,
     CreateGrievanceTicketSerializer,
     GrievanceChoicesSerializer,
+    GrievanceCloseAsUniqueSerializer,
     GrievanceCreateNoteSerializer,
     GrievanceDeleteHouseholdApproveStatusSerializer,
     GrievanceHouseholdDataChangeApproveSerializer,
@@ -95,6 +96,9 @@ from hope.apps.grievance.models import (
 from hope.apps.grievance.notifications import GrievanceNotification
 from hope.apps.grievance.services.bulk_action_service import BulkActionService
 from hope.apps.grievance.services.data_change_services import update_data_change_extras
+from hope.apps.grievance.services.needs_adjudication_ticket_services import (
+    mark_unique_and_close,
+)
 from hope.apps.grievance.services.payment_verification_services import (
     update_ticket_payment_verification_service,
 )
@@ -409,6 +413,7 @@ class GrievanceTicketGlobalViewSet(
         "create": CreateGrievanceTicketSerializer,
         "partial_update": UpdateGrievanceTicketSerializer,
         "status_change": GrievanceStatusChangeSerializer,
+        "close_as_unique": GrievanceCloseAsUniqueSerializer,
         "create_note": GrievanceCreateNoteSerializer,
         "approve_individual_data_change": GrievanceIndividualDataChangeApproveSerializer,
         "approve_household_data_change": GrievanceHouseholdDataChangeApproveSerializer,
@@ -482,6 +487,11 @@ class GrievanceTicketGlobalViewSet(
             Permissions.GRIEVANCES_CLOSE_TICKET_FEEDBACK,
             Permissions.GRIEVANCES_CLOSE_TICKET_FEEDBACK_AS_CREATOR,
             Permissions.GRIEVANCES_CLOSE_TICKET_FEEDBACK_AS_OWNER,
+            Permissions.GRIEVANCES_CLOSE_TICKET_EXCLUDING_FEEDBACK,
+            Permissions.GRIEVANCES_CLOSE_TICKET_EXCLUDING_FEEDBACK_AS_CREATOR,
+            Permissions.GRIEVANCES_CLOSE_TICKET_EXCLUDING_FEEDBACK_AS_OWNER,
+        ],
+        "close_as_unique": [
             Permissions.GRIEVANCES_CLOSE_TICKET_EXCLUDING_FEEDBACK,
             Permissions.GRIEVANCES_CLOSE_TICKET_EXCLUDING_FEEDBACK_AS_CREATOR,
             Permissions.GRIEVANCES_CLOSE_TICKET_EXCLUDING_FEEDBACK_AS_OWNER,
@@ -827,6 +837,59 @@ class GrievanceTicketGlobalViewSet(
         )
 
         GrievanceNotification.send_all_notifications(notifications)
+        return Response(
+            GrievanceTicketDetailSerializer(grievance_ticket, context={"request": request}).data,
+            status=status.HTTP_202_ACCEPTED,
+        )
+
+    @transaction.atomic
+    @extend_schema(request=GrievanceCloseAsUniqueSerializer, responses={202: GrievanceTicketDetailSerializer})
+    @action(detail=True, methods=["post"], url_path="close-as-unique")
+    def close_as_unique(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        grievance_ticket = self.get_object()
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        input_data = serializer.validated_data
+        user = request.user
+
+        check_concurrency_version_in_mutation(input_data.get("version"), grievance_ticket)
+
+        ticket_details = grievance_ticket.ticket_details
+        if not isinstance(ticket_details, TicketNeedsAdjudicationDetails):
+            raise ValidationError("Ticket is not a Needs Adjudication ticket.")
+
+        partner = user.partner
+        all_individuals = [
+            ticket_details.golden_records_individual,
+            *ticket_details.possible_duplicates.select_related("household__admin2", "program").all(),
+        ]
+        for individual in all_individuals:
+            household = individual.household
+            if (
+                household
+                and household.admin2
+                and not partner.has_area_access(
+                    area_id=household.admin2.id,
+                    program_id=individual.program.id,
+                )
+            ):
+                raise PermissionDenied("Permission Denied: User does not have access to close ticket")
+
+        old_grievance_ticket = get_object_or_404(GrievanceTicket, id=grievance_ticket.pk)
+
+        mark_unique_and_close(ticket_details, user)  # type: ignore[arg-type]
+        grievance_ticket.refresh_from_db()
+
+        clear_cache(grievance_ticket.ticket_details, grievance_ticket.business_area.slug)
+
+        log_create(
+            GrievanceTicket.ACTIVITY_LOG_MAPPING,
+            "business_area",
+            user,
+            grievance_ticket.programs.all(),
+            old_object=old_grievance_ticket,
+            new_object=grievance_ticket,
+        )
         return Response(
             GrievanceTicketDetailSerializer(grievance_ticket, context={"request": request}).data,
             status=status.HTTP_202_ACCEPTED,

--- a/src/hope/apps/grievance/api/views.py
+++ b/src/hope/apps/grievance/api/views.py
@@ -575,7 +575,13 @@ class GrievanceTicketGlobalViewSet(
             .get_queryset()
             .filter(self.grievance_permissions_query)
             .select_related("admin2", "assigned_to", "created_by")
-            .prefetch_related("programs", *to_prefetch)
+            .prefetch_related(
+                "programs",
+                *to_prefetch,
+                # feeds TicketNeedsAdjudicationDetails.documents_no_longer_conflict() (can_close_as_unique)
+                "needs_adjudication_ticket_details__golden_records_individual__documents__type",
+                "needs_adjudication_ticket_details__possible_duplicates__documents__type",
+            )
             .annotate(
                 has_social_worker_program_annotated=Exists(
                     Program.objects.filter(
@@ -858,11 +864,25 @@ class GrievanceTicketGlobalViewSet(
         if not isinstance(ticket_details, TicketNeedsAdjudicationDetails):
             raise ValidationError("Ticket is not a Needs Adjudication ticket.")
 
+        check_creator_or_owner_permission(
+            user,
+            [
+                Permissions.GRIEVANCES_CLOSE_TICKET_EXCLUDING_FEEDBACK,
+                Permissions.GRIEVANCES_CLOSE_TICKET_EXCLUDING_FEEDBACK_AS_CREATOR,
+                Permissions.GRIEVANCES_CLOSE_TICKET_EXCLUDING_FEEDBACK_AS_OWNER,
+            ],
+            self.business_area,
+            grievance_ticket,
+        )
+
         partner = user.partner
-        all_individuals = [
-            ticket_details.golden_records_individual,
-            *ticket_details.possible_duplicates.select_related("household__admin2", "program").all(),
+        individual_ids = [
+            ticket_details.golden_records_individual_id,
+            *ticket_details.possible_duplicates.values_list("id", flat=True),
         ]
+        all_individuals = Individual.objects.filter(id__in=individual_ids).select_related(
+            "household__admin2", "program"
+        )
         for individual in all_individuals:
             household = individual.household
             if (

--- a/src/hope/apps/grievance/models.py
+++ b/src/hope/apps/grievance/models.py
@@ -952,6 +952,37 @@ class TicketNeedsAdjudicationDetails(TimeStampedUUIDModel):
             return bool(set.intersection(*documents))
         return False
 
+    def documents_no_longer_conflict(self) -> bool:
+        """Return True when no two unresolved individuals on the ticket still share a document signature.
+
+        Unlike ``has_duplicated_document`` this uses the real dedup signature
+        (``Document.dedup_signature``) and detects conflicts pairwise, so a partial
+        resolution (e.g. A and B separated while C still shares the id) is correctly
+        reported as a remaining conflict. Invalidated documents are ignored. Callers
+        should prefetch ``documents__type``.
+        """
+        from hope.models import Document
+
+        selected_duplicates = set(self.selected_individuals.all())
+        unresolved = [
+            individual
+            for individual in [self.golden_records_individual, *self.possible_duplicates.all()]
+            if individual not in selected_duplicates
+        ]
+        if len(unresolved) < 2:
+            return True
+        seen_signatures: set[str] = set()
+        for individual in unresolved:
+            signatures = {
+                document.dedup_signature
+                for document in individual.documents.all()
+                if document.status != Document.STATUS_INVALID
+            }
+            if signatures & seen_signatures:
+                return False
+            seen_signatures |= signatures
+        return True
+
     @property
     def household(self) -> "Household | None":
         return self.golden_records_individual.household

--- a/src/hope/apps/grievance/models.py
+++ b/src/hope/apps/grievance/models.py
@@ -953,26 +953,23 @@ class TicketNeedsAdjudicationDetails(TimeStampedUUIDModel):
         return False
 
     def documents_no_longer_conflict(self) -> bool:
-        """Return True when no two unresolved individuals on the ticket still share a document signature.
+        """Return True when no two individuals on the ticket still share a document signature.
 
         Unlike ``has_duplicated_document`` this uses the real dedup signature
         (``Document.dedup_signature``) and detects conflicts pairwise, so a partial
         resolution (e.g. A and B separated while C still shares the id) is correctly
-        reported as a remaining conflict. Invalidated documents are ignored. Callers
-        should prefetch ``documents__type``.
+        reported as a remaining conflict. All parties are compared, including any
+        ``selected_individuals``: close-as-unique marks *everyone* distinct, so a
+        selected duplicate that still shares a document is a genuine remaining conflict.
+        Invalidated documents are ignored. Callers should prefetch ``documents__type``.
         """
         from hope.models import Document
 
-        selected_duplicates = set(self.selected_individuals.all())
-        unresolved = [
-            individual
-            for individual in [self.golden_records_individual, *self.possible_duplicates.all()]
-            if individual not in selected_duplicates
-        ]
-        if len(unresolved) < 2:
+        parties = [self.golden_records_individual, *self.possible_duplicates.all()]
+        if len(parties) < 2:
             return True
         seen_signatures: set[str] = set()
-        for individual in unresolved:
+        for individual in parties:
             signatures = {
                 document.dedup_signature
                 for document in individual.documents.all()

--- a/src/hope/apps/grievance/services/needs_adjudication_ticket_services.py
+++ b/src/hope/apps/grievance/services/needs_adjudication_ticket_services.py
@@ -125,6 +125,26 @@ def _has_other_open_needs_adjudication_ticket(ticket_details: TicketNeedsAdjudic
     )
 
 
+def find_open_unique_identifiers_ticket_for_individual(
+    individual: Individual,
+) -> TicketNeedsAdjudicationDetails | None:
+    """Find the open Unique Identifiers Similarity ticket (if any) this individual is a party to.
+
+    Used to link a Data Change ticket that just corrected an individual's document to the
+    Needs Adjudication ticket it may resolve, so the operator can be offered a close-as-unique
+    prompt right after closing the Data Change ticket.
+    """
+    return (
+        TicketNeedsAdjudicationDetails.objects.filter(
+            Q(golden_records_individual=individual) | Q(possible_duplicates=individual),
+            ticket__issue_type=GrievanceTicket.ISSUE_TYPE_UNIQUE_IDENTIFIERS_SIMILARITY,
+        )
+        .exclude(ticket__status=GrievanceTicket.STATUS_CLOSED)
+        .order_by("created_at")
+        .first()
+    )
+
+
 def can_close_as_unique(ticket_details: TicketNeedsAdjudicationDetails) -> bool:
     """Whether the operator may resolve this ticket by marking everyone distinct and closing.
 

--- a/src/hope/apps/grievance/services/needs_adjudication_ticket_services.py
+++ b/src/hope/apps/grievance/services/needs_adjudication_ticket_services.py
@@ -2,7 +2,8 @@ import logging
 from typing import TYPE_CHECKING, Any, Sequence, cast
 
 from django.contrib.auth.models import AbstractUser
-from django.db.models import QuerySet
+from django.db.models import Q, QuerySet
+from rest_framework.exceptions import ValidationError
 
 from hope.apps.grievance.models import GrievanceTicket, TicketNeedsAdjudicationDetails
 from hope.apps.grievance.notifications import GrievanceNotification
@@ -112,6 +113,58 @@ def close_needs_adjudication_ticket_service(grievance_ticket: GrievanceTicket, u
     selected_duplicates = ticket_details.selected_individuals.all()
     traverse_sibling_tickets(grievance_ticket, selected_duplicates)
     close_needs_adjudication_new_ticket(ticket_details, user)
+
+
+def _has_other_open_needs_adjudication_ticket(ticket_details: TicketNeedsAdjudicationDetails) -> bool:
+    individuals = [ticket_details.golden_records_individual, *ticket_details.possible_duplicates.all()]
+    return (
+        TicketNeedsAdjudicationDetails.objects.exclude(ticket__status=GrievanceTicket.STATUS_CLOSED)
+        .exclude(id=ticket_details.id)
+        .filter(Q(golden_records_individual__in=individuals) | Q(possible_duplicates__in=individuals))
+        .exists()
+    )
+
+
+def can_close_as_unique(ticket_details: TicketNeedsAdjudicationDetails) -> bool:
+    """Whether the operator may resolve this ticket by marking everyone distinct and closing.
+
+    True only for an open Unique Identifiers Similarity ticket whose document conflict is
+    gone and that has no sibling open Needs Adjudication ticket for the same individuals.
+    """
+    ticket = ticket_details.ticket
+    return (
+        ticket.issue_type == GrievanceTicket.ISSUE_TYPE_UNIQUE_IDENTIFIERS_SIMILARITY
+        and ticket.status != GrievanceTicket.STATUS_CLOSED
+        and ticket_details.documents_no_longer_conflict()
+        and not _has_other_open_needs_adjudication_ticket(ticket_details)
+    )
+
+
+def mark_unique_and_close(ticket_details: TicketNeedsAdjudicationDetails, user: AbstractUser) -> None:
+    """Mark every individual on the ticket as distinct (unique) and close it directly.
+
+    Used when a separate Data Change ticket has already corrected the shared identifier,
+    so the ticket's sole premise (the duplicated document) no longer holds. Bypasses the
+    FOR_APPROVAL step by design.
+    """
+    ticket = ticket_details.ticket
+    if ticket.issue_type != GrievanceTicket.ISSUE_TYPE_UNIQUE_IDENTIFIERS_SIMILARITY:
+        raise ValidationError("Ticket can only be closed as unique for the Unique Identifiers Similarity issue type.")
+    if ticket.status == GrievanceTicket.STATUS_CLOSED:
+        raise ValidationError("Ticket is already closed.")
+    if not ticket_details.documents_no_longer_conflict():
+        raise ValidationError("Individuals still share a duplicated document; cannot close as unique.")
+    if _has_other_open_needs_adjudication_ticket(ticket_details):
+        raise ValidationError("Another open Needs Adjudication ticket exists for these individuals.")
+
+    all_individuals = [ticket_details.golden_records_individual, *ticket_details.possible_duplicates.all()]
+    ticket_details.selected_individuals.clear()
+    ticket_details.selected_distinct.set(all_individuals)
+
+    close_needs_adjudication_new_ticket(ticket_details, user)
+
+    ticket.status = GrievanceTicket.STATUS_CLOSED
+    ticket.save()
 
 
 def _get_min_max_score(golden_records: list[dict]) -> tuple[float, float]:

--- a/src/hope/apps/registration_data/tasks/deduplicate.py
+++ b/src/hope/apps/registration_data/tasks/deduplicate.py
@@ -1027,9 +1027,7 @@ class HardDocumentDeduplication:
         return program_ids
 
     def _generate_signature(self, document: Document) -> str:
-        if document.type.valid_for_deduplication:
-            return f"{document.type_id}--{document.document_number}--{document.country_id}"
-        return f"{document.document_number}--{document.country_id}"
+        return document.dedup_signature
 
     def _prepare_grievance_ticket_documents_deduplication(
         self,

--- a/src/hope/models/document.py
+++ b/src/hope/models/document.py
@@ -107,6 +107,12 @@ class Document(AbstractSyncable, SoftDeletableMergeStatusModel, TimeStampedUUIDM
     def __str__(self) -> str:
         return f"{self.type} - {self.document_number}"
 
+    @property
+    def dedup_signature(self) -> str:
+        if self.type.valid_for_deduplication:
+            return f"{self.type_id}--{self.document_number}--{self.country_id}"
+        return f"{self.document_number}--{self.country_id}"
+
     def mark_as_need_investigation(self) -> None:
         self.status = self.STATUS_NEED_INVESTIGATION
 

--- a/tests/unit/apps/grievance/test_close_needs_adjudication_as_unique.py
+++ b/tests/unit/apps/grievance/test_close_needs_adjudication_as_unique.py
@@ -1,0 +1,547 @@
+"""Tests for closing a Unique Identifiers Similarity needs-adjudication ticket as unique.
+
+Covers Document.dedup_signature, TicketNeedsAdjudicationDetails.documents_no_longer_conflict,
+the can_close_as_unique / mark_unique_and_close services and the close-as-unique API action.
+"""
+
+from typing import Any, Callable
+
+import pytest
+from rest_framework import status
+from rest_framework.exceptions import ValidationError as DRFValidationError
+from rest_framework.reverse import reverse
+
+from extras.test_utils.factories import (
+    AdminAreaLimitedToFactory,
+    AreaFactory,
+    AreaTypeFactory,
+    BusinessAreaFactory,
+    CountryFactory,
+    DocumentFactory,
+    DocumentTypeFactory,
+    GrievanceTicketFactory,
+    HouseholdFactory,
+    PartnerFactory,
+    ProgramFactory,
+    TicketNeedsAdjudicationDetailsFactory,
+    UserFactory,
+)
+from hope.apps.account.permissions import Permissions
+from hope.apps.grievance.models import GrievanceTicket, TicketNeedsAdjudicationDetails
+from hope.apps.grievance.services.needs_adjudication_ticket_services import (
+    can_close_as_unique,
+    mark_unique_and_close,
+)
+from hope.apps.household.const import NEEDS_ADJUDICATION, UNIQUE
+from hope.models import Document
+
+pytestmark = [
+    pytest.mark.usefixtures("mock_elasticsearch"),
+    pytest.mark.django_db,
+]
+
+
+@pytest.fixture
+def business_area() -> Any:
+    return BusinessAreaFactory(slug="afghanistan")
+
+
+@pytest.fixture
+def program(business_area: Any) -> Any:
+    return ProgramFactory(business_area=business_area, name="program afghanistan 1")
+
+
+@pytest.fixture
+def partner() -> Any:
+    return PartnerFactory(name="TestPartner")
+
+
+@pytest.fixture
+def user(partner: Any) -> Any:
+    return UserFactory(partner=partner)
+
+
+@pytest.fixture
+def country() -> Any:
+    return CountryFactory(name="Poland", short_name="Poland", iso_code2="PL", iso_code3="POL", iso_num="0616")
+
+
+@pytest.fixture
+def national_id_type() -> Any:
+    return DocumentTypeFactory(key="national_id", valid_for_deduplication=True)
+
+
+@pytest.fixture
+def receipt_type() -> Any:
+    return DocumentTypeFactory(key="receipt", valid_for_deduplication=False)
+
+
+def _build_individual(program: Any, business_area: Any) -> Any:
+    household = HouseholdFactory(program=program, business_area=business_area, create_role=False)
+    return household.head_of_household
+
+
+def _add_national_id(
+    individual: Any,
+    national_id_type: Any,
+    country: Any,
+    program: Any,
+    number: str,
+    doc_status: str = Document.STATUS_VALID,
+) -> Document:
+    return DocumentFactory(
+        type=national_id_type,
+        document_number=number,
+        individual=individual,
+        country=country,
+        program=program,
+        status=doc_status,
+    )
+
+
+def _build_ticket(
+    business_area: Any,
+    program: Any,
+    golden: Any,
+    duplicates: list,
+    issue_type: int = GrievanceTicket.ISSUE_TYPE_UNIQUE_IDENTIFIERS_SIMILARITY,
+    ticket_status: int = GrievanceTicket.STATUS_FOR_APPROVAL,
+) -> TicketNeedsAdjudicationDetails:
+    grievance = GrievanceTicketFactory(
+        category=GrievanceTicket.CATEGORY_NEEDS_ADJUDICATION,
+        issue_type=issue_type,
+        business_area=business_area,
+        status=ticket_status,
+    )
+    grievance.programs.set([program])
+    ticket_details = TicketNeedsAdjudicationDetailsFactory(
+        ticket=grievance,
+        golden_records_individual=golden,
+        is_multiple_duplicates_version=True,
+        selected_individual=None,
+    )
+    ticket_details.possible_duplicates.add(*duplicates)
+    return ticket_details
+
+
+# --------------------------------------------------------------------------- #
+# Document.dedup_signature
+# --------------------------------------------------------------------------- #
+def test_dedup_signature_includes_type_and_country_when_valid_for_deduplication(
+    business_area: Any, program: Any, national_id_type: Any, country: Any
+) -> None:
+    individual = _build_individual(program, business_area)
+    document = _add_national_id(individual, national_id_type, country, program, "ID-1")
+
+    assert document.dedup_signature == f"{document.type_id}--ID-1--{country.id}"
+
+
+def test_dedup_signature_excludes_type_when_not_valid_for_deduplication(
+    business_area: Any, program: Any, receipt_type: Any, country: Any
+) -> None:
+    individual = _build_individual(program, business_area)
+    document = DocumentFactory(
+        type=receipt_type,
+        document_number="R-1",
+        individual=individual,
+        country=country,
+        program=program,
+        status=Document.STATUS_VALID,
+    )
+
+    assert document.dedup_signature == f"R-1--{country.id}"
+
+
+# --------------------------------------------------------------------------- #
+# TicketNeedsAdjudicationDetails.documents_no_longer_conflict
+# --------------------------------------------------------------------------- #
+def test_documents_no_longer_conflict_true_when_numbers_differ(
+    business_area: Any, program: Any, national_id_type: Any, country: Any
+) -> None:
+    golden = _build_individual(program, business_area)
+    duplicate = _build_individual(program, business_area)
+    _add_national_id(golden, national_id_type, country, program, "ID-AAA")
+    _add_national_id(duplicate, national_id_type, country, program, "ID-BBB")
+    ticket_details = _build_ticket(business_area, program, golden, [duplicate])
+
+    assert ticket_details.documents_no_longer_conflict() is True
+
+
+def test_documents_no_longer_conflict_false_when_numbers_match(
+    business_area: Any, program: Any, national_id_type: Any, country: Any
+) -> None:
+    golden = _build_individual(program, business_area)
+    duplicate = _build_individual(program, business_area)
+    _add_national_id(golden, national_id_type, country, program, "ID-SAME")
+    _add_national_id(
+        duplicate, national_id_type, country, program, "ID-SAME", doc_status=Document.STATUS_NEED_INVESTIGATION
+    )
+    ticket_details = _build_ticket(business_area, program, golden, [duplicate])
+
+    assert ticket_details.documents_no_longer_conflict() is False
+
+
+def test_documents_no_longer_conflict_true_for_single_individual(
+    business_area: Any, program: Any, national_id_type: Any, country: Any
+) -> None:
+    golden = _build_individual(program, business_area)
+    _add_national_id(golden, national_id_type, country, program, "ID-ONLY")
+    ticket_details = _build_ticket(business_area, program, golden, [])
+
+    assert ticket_details.documents_no_longer_conflict() is True
+
+
+def test_documents_no_longer_conflict_false_on_partial_resolution(
+    business_area: Any, program: Any, national_id_type: Any, country: Any
+) -> None:
+    golden = _build_individual(program, business_area)
+    fixed = _build_individual(program, business_area)
+    still_sharing = _build_individual(program, business_area)
+    _add_national_id(golden, national_id_type, country, program, "ID-SHARED")
+    _add_national_id(fixed, national_id_type, country, program, "ID-FIXED")
+    _add_national_id(
+        still_sharing, national_id_type, country, program, "ID-SHARED", doc_status=Document.STATUS_NEED_INVESTIGATION
+    )
+    ticket_details = _build_ticket(business_area, program, golden, [fixed, still_sharing])
+
+    assert ticket_details.documents_no_longer_conflict() is False
+
+
+def test_documents_no_longer_conflict_ignores_selected_duplicates(
+    business_area: Any, program: Any, national_id_type: Any, country: Any
+) -> None:
+    golden = _build_individual(program, business_area)
+    removed_duplicate = _build_individual(program, business_area)
+    _add_national_id(golden, national_id_type, country, program, "ID-SHARED")
+    _add_national_id(
+        removed_duplicate,
+        national_id_type,
+        country,
+        program,
+        "ID-SHARED",
+        doc_status=Document.STATUS_NEED_INVESTIGATION,
+    )
+    ticket_details = _build_ticket(business_area, program, golden, [removed_duplicate])
+    ticket_details.selected_individuals.add(removed_duplicate)
+
+    assert ticket_details.documents_no_longer_conflict() is True
+
+
+def test_documents_no_longer_conflict_ignores_invalid_documents(
+    business_area: Any, program: Any, national_id_type: Any, country: Any
+) -> None:
+    golden = _build_individual(program, business_area)
+    duplicate = _build_individual(program, business_area)
+    _add_national_id(golden, national_id_type, country, program, "ID-SHARED")
+    _add_national_id(duplicate, national_id_type, country, program, "ID-SHARED", doc_status=Document.STATUS_INVALID)
+    ticket_details = _build_ticket(business_area, program, golden, [duplicate])
+
+    assert ticket_details.documents_no_longer_conflict() is True
+
+
+# --------------------------------------------------------------------------- #
+# can_close_as_unique
+# --------------------------------------------------------------------------- #
+def test_can_close_as_unique_true_when_resolved(
+    business_area: Any, program: Any, national_id_type: Any, country: Any
+) -> None:
+    golden = _build_individual(program, business_area)
+    duplicate = _build_individual(program, business_area)
+    _add_national_id(golden, national_id_type, country, program, "ID-1")
+    _add_national_id(duplicate, national_id_type, country, program, "ID-2")
+    ticket_details = _build_ticket(business_area, program, golden, [duplicate])
+
+    assert can_close_as_unique(ticket_details) is True
+
+
+def test_can_close_as_unique_false_for_biographical_issue_type(
+    business_area: Any, program: Any, national_id_type: Any, country: Any
+) -> None:
+    golden = _build_individual(program, business_area)
+    duplicate = _build_individual(program, business_area)
+    _add_national_id(golden, national_id_type, country, program, "ID-1")
+    _add_national_id(duplicate, national_id_type, country, program, "ID-2")
+    ticket_details = _build_ticket(
+        business_area,
+        program,
+        golden,
+        [duplicate],
+        issue_type=GrievanceTicket.ISSUE_TYPE_BIOGRAPHICAL_DATA_SIMILARITY,
+    )
+
+    assert can_close_as_unique(ticket_details) is False
+
+
+def test_can_close_as_unique_false_when_conflict_remains(
+    business_area: Any, program: Any, national_id_type: Any, country: Any
+) -> None:
+    golden = _build_individual(program, business_area)
+    duplicate = _build_individual(program, business_area)
+    _add_national_id(golden, national_id_type, country, program, "ID-SAME")
+    _add_national_id(
+        duplicate, national_id_type, country, program, "ID-SAME", doc_status=Document.STATUS_NEED_INVESTIGATION
+    )
+    ticket_details = _build_ticket(business_area, program, golden, [duplicate])
+
+    assert can_close_as_unique(ticket_details) is False
+
+
+def test_can_close_as_unique_false_when_other_open_ticket(
+    business_area: Any, program: Any, national_id_type: Any, country: Any
+) -> None:
+    golden = _build_individual(program, business_area)
+    duplicate = _build_individual(program, business_area)
+    _add_national_id(golden, national_id_type, country, program, "ID-1")
+    _add_national_id(duplicate, national_id_type, country, program, "ID-2")
+    ticket_details = _build_ticket(business_area, program, golden, [duplicate])
+    _build_ticket(business_area, program, golden, [duplicate])  # second open ticket for the same individuals
+
+    assert can_close_as_unique(ticket_details) is False
+
+
+# --------------------------------------------------------------------------- #
+# mark_unique_and_close
+# --------------------------------------------------------------------------- #
+def test_mark_unique_and_close_marks_all_distinct_and_closes(
+    user: Any, business_area: Any, program: Any, national_id_type: Any, country: Any
+) -> None:
+    golden = _build_individual(program, business_area)
+    duplicate = _build_individual(program, business_area)
+    golden.deduplication_golden_record_status = NEEDS_ADJUDICATION
+    golden.save()
+    duplicate.deduplication_golden_record_status = NEEDS_ADJUDICATION
+    duplicate.save()
+    doc_golden = _add_national_id(golden, national_id_type, country, program, "ID-1")
+    doc_duplicate = _add_national_id(duplicate, national_id_type, country, program, "ID-2")
+    ticket_details = _build_ticket(business_area, program, golden, [duplicate])
+
+    mark_unique_and_close(ticket_details, user)
+
+    ticket_details.ticket.refresh_from_db()
+    golden.refresh_from_db()
+    duplicate.refresh_from_db()
+    doc_golden.refresh_from_db()
+    doc_duplicate.refresh_from_db()
+    assert ticket_details.ticket.status == GrievanceTicket.STATUS_CLOSED
+    assert golden.duplicate is False
+    assert duplicate.duplicate is False
+    assert golden.deduplication_golden_record_status == UNIQUE
+    assert duplicate.deduplication_golden_record_status == UNIQUE
+    assert doc_golden.status == Document.STATUS_VALID
+    assert doc_duplicate.status == Document.STATUS_VALID
+    assert set(ticket_details.selected_distinct.all()) == {golden, duplicate}
+
+
+@pytest.mark.parametrize(
+    "issue_type",
+    [
+        GrievanceTicket.ISSUE_TYPE_BIOGRAPHICAL_DATA_SIMILARITY,
+        GrievanceTicket.ISSUE_TYPE_BIOMETRICS_SIMILARITY,
+    ],
+)
+def test_mark_unique_and_close_raises_for_non_unique_identifiers_issue_type(
+    user: Any, business_area: Any, program: Any, national_id_type: Any, country: Any, issue_type: int
+) -> None:
+    golden = _build_individual(program, business_area)
+    duplicate = _build_individual(program, business_area)
+    _add_national_id(golden, national_id_type, country, program, "ID-1")
+    _add_national_id(duplicate, national_id_type, country, program, "ID-2")
+    ticket_details = _build_ticket(business_area, program, golden, [duplicate], issue_type=issue_type)
+
+    with pytest.raises(DRFValidationError):
+        mark_unique_and_close(ticket_details, user)
+
+
+def test_mark_unique_and_close_raises_when_already_closed(
+    user: Any, business_area: Any, program: Any, national_id_type: Any, country: Any
+) -> None:
+    golden = _build_individual(program, business_area)
+    duplicate = _build_individual(program, business_area)
+    _add_national_id(golden, national_id_type, country, program, "ID-1")
+    _add_national_id(duplicate, national_id_type, country, program, "ID-2")
+    ticket_details = _build_ticket(
+        business_area, program, golden, [duplicate], ticket_status=GrievanceTicket.STATUS_CLOSED
+    )
+
+    with pytest.raises(DRFValidationError):
+        mark_unique_and_close(ticket_details, user)
+
+
+def test_mark_unique_and_close_raises_when_documents_still_conflict(
+    user: Any, business_area: Any, program: Any, national_id_type: Any, country: Any
+) -> None:
+    golden = _build_individual(program, business_area)
+    duplicate = _build_individual(program, business_area)
+    _add_national_id(golden, national_id_type, country, program, "ID-SAME")
+    _add_national_id(
+        duplicate, national_id_type, country, program, "ID-SAME", doc_status=Document.STATUS_NEED_INVESTIGATION
+    )
+    ticket_details = _build_ticket(business_area, program, golden, [duplicate])
+
+    with pytest.raises(DRFValidationError):
+        mark_unique_and_close(ticket_details, user)
+
+
+def test_mark_unique_and_close_raises_when_other_open_ticket(
+    user: Any, business_area: Any, program: Any, national_id_type: Any, country: Any
+) -> None:
+    golden = _build_individual(program, business_area)
+    duplicate = _build_individual(program, business_area)
+    _add_national_id(golden, national_id_type, country, program, "ID-1")
+    _add_national_id(duplicate, national_id_type, country, program, "ID-2")
+    ticket_details = _build_ticket(business_area, program, golden, [duplicate])
+    _build_ticket(business_area, program, golden, [duplicate])
+
+    with pytest.raises(DRFValidationError):
+        mark_unique_and_close(ticket_details, user)
+
+
+# --------------------------------------------------------------------------- #
+# close-as-unique API action
+# --------------------------------------------------------------------------- #
+def _close_as_unique_url(business_area: Any, ticket_details: TicketNeedsAdjudicationDetails) -> str:
+    return reverse(
+        "api:grievance-tickets:grievance-tickets-global-close-as-unique",
+        kwargs={
+            "business_area_slug": business_area.slug,
+            "pk": str(ticket_details.ticket.pk),
+        },
+    )
+
+
+def test_close_as_unique_endpoint_success(
+    api_client: Any,
+    user: Any,
+    business_area: Any,
+    program: Any,
+    national_id_type: Any,
+    country: Any,
+    create_user_role_with_permissions: Callable,
+) -> None:
+    golden = _build_individual(program, business_area)
+    duplicate = _build_individual(program, business_area)
+    _add_national_id(golden, national_id_type, country, program, "ID-1")
+    _add_national_id(duplicate, national_id_type, country, program, "ID-2")
+    ticket_details = _build_ticket(business_area, program, golden, [duplicate])
+    create_user_role_with_permissions(
+        user, [Permissions.GRIEVANCES_CLOSE_TICKET_EXCLUDING_FEEDBACK], business_area, program
+    )
+
+    client = api_client(user)
+    response = client.post(_close_as_unique_url(business_area, ticket_details), {}, format="json")
+
+    assert response.status_code == status.HTTP_202_ACCEPTED
+    ticket_details.ticket.refresh_from_db()
+    golden.refresh_from_db()
+    assert ticket_details.ticket.status == GrievanceTicket.STATUS_CLOSED
+    assert golden.duplicate is False
+
+
+def test_close_as_unique_endpoint_rejects_when_conflict_remains(
+    api_client: Any,
+    user: Any,
+    business_area: Any,
+    program: Any,
+    national_id_type: Any,
+    country: Any,
+    create_user_role_with_permissions: Callable,
+) -> None:
+    golden = _build_individual(program, business_area)
+    duplicate = _build_individual(program, business_area)
+    _add_national_id(golden, national_id_type, country, program, "ID-SAME")
+    _add_national_id(
+        duplicate, national_id_type, country, program, "ID-SAME", doc_status=Document.STATUS_NEED_INVESTIGATION
+    )
+    ticket_details = _build_ticket(business_area, program, golden, [duplicate])
+    create_user_role_with_permissions(
+        user, [Permissions.GRIEVANCES_CLOSE_TICKET_EXCLUDING_FEEDBACK], business_area, program
+    )
+
+    client = api_client(user)
+    response = client.post(_close_as_unique_url(business_area, ticket_details), {}, format="json")
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    ticket_details.ticket.refresh_from_db()
+    assert ticket_details.ticket.status == GrievanceTicket.STATUS_FOR_APPROVAL
+
+
+def test_close_as_unique_endpoint_forbidden_without_permission(
+    api_client: Any,
+    user: Any,
+    business_area: Any,
+    program: Any,
+    national_id_type: Any,
+    country: Any,
+    create_user_role_with_permissions: Callable,
+) -> None:
+    golden = _build_individual(program, business_area)
+    duplicate = _build_individual(program, business_area)
+    _add_national_id(golden, national_id_type, country, program, "ID-1")
+    _add_national_id(duplicate, national_id_type, country, program, "ID-2")
+    ticket_details = _build_ticket(business_area, program, golden, [duplicate])
+    create_user_role_with_permissions(user, [Permissions.GRIEVANCES_UPDATE], business_area, program)
+
+    client = api_client(user)
+    response = client.post(_close_as_unique_url(business_area, ticket_details), {}, format="json")
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_close_as_unique_endpoint_forbidden_without_area_access(
+    api_client: Any,
+    user: Any,
+    partner: Any,
+    business_area: Any,
+    program: Any,
+    national_id_type: Any,
+    country: Any,
+    create_user_role_with_permissions: Callable,
+) -> None:
+    area_type = AreaTypeFactory(name="District", country=country, area_level=2)
+    ticket_area = AreaFactory(name="Ticket Area", area_type=area_type, p_code="ticket-area")
+    other_area = AreaFactory(name="Other Area", area_type=area_type, p_code="other-area")
+    golden_household = HouseholdFactory(
+        program=program, business_area=business_area, create_role=False, admin2=ticket_area
+    )
+    golden = golden_household.head_of_household
+    duplicate = _build_individual(program, business_area)
+    _add_national_id(golden, national_id_type, country, program, "ID-1")
+    _add_national_id(duplicate, national_id_type, country, program, "ID-2")
+    ticket_details = _build_ticket(business_area, program, golden, [duplicate])
+    create_user_role_with_permissions(
+        user, [Permissions.GRIEVANCES_CLOSE_TICKET_EXCLUDING_FEEDBACK], business_area, program
+    )
+    AdminAreaLimitedToFactory(partner=partner, program=program, areas=[other_area])
+
+    client = api_client(user)
+    response = client.post(_close_as_unique_url(business_area, ticket_details), {}, format="json")
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_close_as_unique_endpoint_rejects_non_needs_adjudication_ticket(
+    api_client: Any,
+    user: Any,
+    business_area: Any,
+    program: Any,
+    create_user_role_with_permissions: Callable,
+) -> None:
+    grievance = GrievanceTicketFactory(
+        category=GrievanceTicket.CATEGORY_REFERRAL,
+        issue_type=None,
+        business_area=business_area,
+        status=GrievanceTicket.STATUS_FOR_APPROVAL,
+    )
+    grievance.programs.set([program])
+    create_user_role_with_permissions(
+        user, [Permissions.GRIEVANCES_CLOSE_TICKET_EXCLUDING_FEEDBACK], business_area, program
+    )
+
+    url = reverse(
+        "api:grievance-tickets:grievance-tickets-global-close-as-unique",
+        kwargs={"business_area_slug": business_area.slug, "pk": str(grievance.pk)},
+    )
+    client = api_client(user)
+    response = client.post(url, {}, format="json")
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/tests/unit/apps/grievance/test_close_needs_adjudication_as_unique.py
+++ b/tests/unit/apps/grievance/test_close_needs_adjudication_as_unique.py
@@ -1,7 +1,9 @@
 """Tests for closing a Unique Identifiers Similarity needs-adjudication ticket as unique.
 
 Covers Document.dedup_signature, TicketNeedsAdjudicationDetails.documents_no_longer_conflict,
-the can_close_as_unique / mark_unique_and_close services and the close-as-unique API action.
+the can_close_as_unique / mark_unique_and_close / find_open_unique_identifiers_ticket_for_individual
+services, the close-as-unique API action, and the Data Change ticket's link to its Needs
+Adjudication counterpart (IndividualDataUpdateTicketDetailsSerializer.linked_needs_adjudication_ticket_id).
 """
 
 from typing import Any, Callable
@@ -23,6 +25,7 @@ from extras.test_utils.factories import (
     HouseholdFactory,
     PartnerFactory,
     ProgramFactory,
+    TicketIndividualDataUpdateDetailsFactory,
     TicketNeedsAdjudicationDetailsFactory,
     UserFactory,
 )
@@ -30,6 +33,7 @@ from hope.apps.account.permissions import Permissions
 from hope.apps.grievance.models import GrievanceTicket, TicketNeedsAdjudicationDetails
 from hope.apps.grievance.services.needs_adjudication_ticket_services import (
     can_close_as_unique,
+    find_open_unique_identifiers_ticket_for_individual,
     mark_unique_and_close,
 )
 from hope.apps.household.const import NEEDS_ADJUDICATION, UNIQUE
@@ -545,3 +549,149 @@ def test_close_as_unique_endpoint_rejects_non_needs_adjudication_ticket(
     response = client.post(url, {}, format="json")
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+# --------------------------------------------------------------------------- #
+# find_open_unique_identifiers_ticket_for_individual
+# --------------------------------------------------------------------------- #
+def test_find_open_unique_identifiers_ticket_for_individual_finds_golden(
+    business_area: Any, program: Any, national_id_type: Any, country: Any
+) -> None:
+    golden = _build_individual(program, business_area)
+    duplicate = _build_individual(program, business_area)
+    _add_national_id(golden, national_id_type, country, program, "ID-1")
+    _add_national_id(duplicate, national_id_type, country, program, "ID-2")
+    ticket_details = _build_ticket(business_area, program, golden, [duplicate])
+
+    assert find_open_unique_identifiers_ticket_for_individual(golden) == ticket_details
+
+
+def test_find_open_unique_identifiers_ticket_for_individual_finds_possible_duplicate(
+    business_area: Any, program: Any, national_id_type: Any, country: Any
+) -> None:
+    golden = _build_individual(program, business_area)
+    duplicate = _build_individual(program, business_area)
+    _add_national_id(golden, national_id_type, country, program, "ID-1")
+    _add_national_id(duplicate, national_id_type, country, program, "ID-2")
+    ticket_details = _build_ticket(business_area, program, golden, [duplicate])
+
+    assert find_open_unique_identifiers_ticket_for_individual(duplicate) == ticket_details
+
+
+def test_find_open_unique_identifiers_ticket_for_individual_none_when_ticket_closed(
+    business_area: Any, program: Any, national_id_type: Any, country: Any
+) -> None:
+    golden = _build_individual(program, business_area)
+    duplicate = _build_individual(program, business_area)
+    _add_national_id(golden, national_id_type, country, program, "ID-1")
+    _add_national_id(duplicate, national_id_type, country, program, "ID-2")
+    _build_ticket(business_area, program, golden, [duplicate], ticket_status=GrievanceTicket.STATUS_CLOSED)
+
+    assert find_open_unique_identifiers_ticket_for_individual(golden) is None
+
+
+def test_find_open_unique_identifiers_ticket_for_individual_none_for_other_issue_type(
+    business_area: Any, program: Any, national_id_type: Any, country: Any
+) -> None:
+    golden = _build_individual(program, business_area)
+    duplicate = _build_individual(program, business_area)
+    _add_national_id(golden, national_id_type, country, program, "ID-1")
+    _add_national_id(duplicate, national_id_type, country, program, "ID-2")
+    _build_ticket(
+        business_area,
+        program,
+        golden,
+        [duplicate],
+        issue_type=GrievanceTicket.ISSUE_TYPE_BIOGRAPHICAL_DATA_SIMILARITY,
+    )
+
+    assert find_open_unique_identifiers_ticket_for_individual(golden) is None
+
+
+def test_find_open_unique_identifiers_ticket_for_individual_none_when_no_ticket(
+    business_area: Any, program: Any
+) -> None:
+    unrelated = _build_individual(program, business_area)
+
+    assert find_open_unique_identifiers_ticket_for_individual(unrelated) is None
+
+
+def test_find_open_unique_identifiers_ticket_for_individual_single_query(
+    business_area: Any, program: Any, national_id_type: Any, country: Any, django_assert_num_queries: Callable
+) -> None:
+    golden = _build_individual(program, business_area)
+    duplicate = _build_individual(program, business_area)
+    _add_national_id(golden, national_id_type, country, program, "ID-1")
+    _add_national_id(duplicate, national_id_type, country, program, "ID-2")
+    _build_ticket(business_area, program, golden, [duplicate])
+
+    with django_assert_num_queries(1):
+        find_open_unique_identifiers_ticket_for_individual(golden)
+
+
+# --------------------------------------------------------------------------- #
+# Data Change ticket detail exposes linked_needs_adjudication_ticket_id
+# --------------------------------------------------------------------------- #
+def _data_change_ticket_detail_url(business_area: Any, grievance_ticket: GrievanceTicket) -> str:
+    return reverse(
+        "api:grievance-tickets:grievance-tickets-global-detail",
+        kwargs={"business_area_slug": business_area.slug, "pk": str(grievance_ticket.id)},
+    )
+
+
+def test_data_change_ticket_exposes_linked_ticket_id_when_present(
+    api_client: Any,
+    user: Any,
+    business_area: Any,
+    program: Any,
+    national_id_type: Any,
+    country: Any,
+    create_user_role_with_permissions: Callable,
+) -> None:
+    golden = _build_individual(program, business_area)
+    duplicate = _build_individual(program, business_area)
+    _add_national_id(golden, national_id_type, country, program, "ID-1")
+    _add_national_id(duplicate, national_id_type, country, program, "ID-2")
+    na_ticket_details = _build_ticket(business_area, program, golden, [duplicate])
+    data_change_ticket = GrievanceTicketFactory(
+        category=GrievanceTicket.CATEGORY_DATA_CHANGE,
+        issue_type=GrievanceTicket.ISSUE_TYPE_INDIVIDUAL_DATA_CHANGE_DATA_UPDATE,
+        business_area=business_area,
+    )
+    data_change_ticket.programs.set([program])
+    data_update_details = TicketIndividualDataUpdateDetailsFactory(ticket=data_change_ticket, individual=golden)
+    create_user_role_with_permissions(
+        user, [Permissions.GRIEVANCES_VIEW_DETAILS_EXCLUDING_SENSITIVE], business_area, program
+    )
+
+    client = api_client(user)
+    response = client.get(_data_change_ticket_detail_url(business_area, data_update_details.ticket))
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data["ticket_details"]["linked_needs_adjudication_ticket_id"] == str(na_ticket_details.ticket_id)
+
+
+def test_data_change_ticket_linked_ticket_id_none_when_absent(
+    api_client: Any,
+    user: Any,
+    business_area: Any,
+    program: Any,
+    create_user_role_with_permissions: Callable,
+) -> None:
+    unrelated = _build_individual(program, business_area)
+    data_change_ticket = GrievanceTicketFactory(
+        category=GrievanceTicket.CATEGORY_DATA_CHANGE,
+        issue_type=GrievanceTicket.ISSUE_TYPE_INDIVIDUAL_DATA_CHANGE_DATA_UPDATE,
+        business_area=business_area,
+    )
+    data_change_ticket.programs.set([program])
+    data_update_details = TicketIndividualDataUpdateDetailsFactory(ticket=data_change_ticket, individual=unrelated)
+    create_user_role_with_permissions(
+        user, [Permissions.GRIEVANCES_VIEW_DETAILS_EXCLUDING_SENSITIVE], business_area, program
+    )
+
+    client = api_client(user)
+    response = client.get(_data_change_ticket_detail_url(business_area, data_update_details.ticket))
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data["ticket_details"]["linked_needs_adjudication_ticket_id"] is None

--- a/tests/unit/apps/grievance/test_close_needs_adjudication_as_unique.py
+++ b/tests/unit/apps/grievance/test_close_needs_adjudication_as_unique.py
@@ -211,24 +211,24 @@ def test_documents_no_longer_conflict_false_on_partial_resolution(
     assert ticket_details.documents_no_longer_conflict() is False
 
 
-def test_documents_no_longer_conflict_ignores_selected_duplicates(
+def test_documents_no_longer_conflict_false_for_selected_duplicate_still_sharing(
     business_area: Any, program: Any, national_id_type: Any, country: Any
 ) -> None:
     golden = _build_individual(program, business_area)
-    removed_duplicate = _build_individual(program, business_area)
+    selected_duplicate = _build_individual(program, business_area)
     _add_national_id(golden, national_id_type, country, program, "ID-SHARED")
     _add_national_id(
-        removed_duplicate,
+        selected_duplicate,
         national_id_type,
         country,
         program,
         "ID-SHARED",
         doc_status=Document.STATUS_NEED_INVESTIGATION,
     )
-    ticket_details = _build_ticket(business_area, program, golden, [removed_duplicate])
-    ticket_details.selected_individuals.add(removed_duplicate)
+    ticket_details = _build_ticket(business_area, program, golden, [selected_duplicate])
+    ticket_details.selected_individuals.add(selected_duplicate)
 
-    assert ticket_details.documents_no_longer_conflict() is True
+    assert ticket_details.documents_no_longer_conflict() is False
 
 
 def test_documents_no_longer_conflict_ignores_invalid_documents(
@@ -489,6 +489,60 @@ def test_close_as_unique_endpoint_forbidden_without_permission(
     response = client.post(_close_as_unique_url(business_area, ticket_details), {}, format="json")
 
     assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_close_as_unique_endpoint_forbidden_with_creator_scoped_permission_when_not_creator(
+    api_client: Any,
+    user: Any,
+    business_area: Any,
+    program: Any,
+    national_id_type: Any,
+    country: Any,
+    create_user_role_with_permissions: Callable,
+) -> None:
+    golden = _build_individual(program, business_area)
+    duplicate = _build_individual(program, business_area)
+    _add_national_id(golden, national_id_type, country, program, "ID-1")
+    _add_national_id(duplicate, national_id_type, country, program, "ID-2")
+    ticket_details = _build_ticket(business_area, program, golden, [duplicate])
+    create_user_role_with_permissions(
+        user, [Permissions.GRIEVANCES_CLOSE_TICKET_EXCLUDING_FEEDBACK_AS_CREATOR], business_area, program
+    )
+
+    client = api_client(user)
+    response = client.post(_close_as_unique_url(business_area, ticket_details), {}, format="json")
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    ticket_details.ticket.refresh_from_db()
+    assert ticket_details.ticket.status == GrievanceTicket.STATUS_FOR_APPROVAL
+
+
+def test_close_as_unique_endpoint_success_with_creator_scoped_permission_when_creator(
+    api_client: Any,
+    user: Any,
+    business_area: Any,
+    program: Any,
+    national_id_type: Any,
+    country: Any,
+    create_user_role_with_permissions: Callable,
+) -> None:
+    golden = _build_individual(program, business_area)
+    duplicate = _build_individual(program, business_area)
+    _add_national_id(golden, national_id_type, country, program, "ID-1")
+    _add_national_id(duplicate, national_id_type, country, program, "ID-2")
+    ticket_details = _build_ticket(business_area, program, golden, [duplicate])
+    ticket_details.ticket.created_by = user
+    ticket_details.ticket.save()
+    create_user_role_with_permissions(
+        user, [Permissions.GRIEVANCES_CLOSE_TICKET_EXCLUDING_FEEDBACK_AS_CREATOR], business_area, program
+    )
+
+    client = api_client(user)
+    response = client.post(_close_as_unique_url(business_area, ticket_details), {}, format="json")
+
+    assert response.status_code == status.HTTP_202_ACCEPTED
+    ticket_details.ticket.refresh_from_db()
+    assert ticket_details.ticket.status == GrievanceTicket.STATUS_CLOSED
 
 
 def test_close_as_unique_endpoint_forbidden_without_area_access(

--- a/tests/unit/apps/grievance/test_grievance_detail.py
+++ b/tests/unit/apps/grievance/test_grievance_detail.py
@@ -988,6 +988,7 @@ def test_grievance_detail_individual_data_update(
         "id": str(ticket_details.id),
         "individual_data": ticket_details.individual_data,
         "role_reassign_data": ticket_details.role_reassign_data,
+        "linked_needs_adjudication_ticket_id": None,
     }
 
 

--- a/tests/unit/apps/registration_data/test_deduplicate_helpers.py
+++ b/tests/unit/apps/registration_data/test_deduplicate_helpers.py
@@ -159,16 +159,14 @@ def test_build_document_signatures_single_doc():
     dedup = HardDocumentDeduplication()
     individual_id = uuid.uuid4()
 
+    expected_sig = "passport--DOC-001--AFG"
     doc = MagicMock()
     doc.document_number = "DOC-001"
     doc.individual_id = individual_id
-    doc.type.valid_for_deduplication = True
-    doc.type_id = "passport"
-    doc.country_id = "AFG"
+    doc.dedup_signature = expected_sig
 
     documents_numbers, new_sigs, per_individual_dict, duplicated = dedup._build_document_signatures([doc])
 
-    expected_sig = "passport--DOC-001--AFG"
     assert documents_numbers == ["DOC-001"]
     assert new_sigs == [expected_sig]
     assert per_individual_dict[str(individual_id)] == [expected_sig]
@@ -180,23 +178,19 @@ def test_build_document_signatures_duplicates():
     individual_id_1 = uuid.uuid4()
     individual_id_2 = uuid.uuid4()
 
+    expected_sig = "passport--DOC-001--AFG"
     doc1 = MagicMock()
     doc1.document_number = "DOC-001"
     doc1.individual_id = individual_id_1
-    doc1.type.valid_for_deduplication = True
-    doc1.type_id = "passport"
-    doc1.country_id = "AFG"
+    doc1.dedup_signature = expected_sig
 
     doc2 = MagicMock()
     doc2.document_number = "DOC-001"
     doc2.individual_id = individual_id_2
-    doc2.type.valid_for_deduplication = True
-    doc2.type_id = "passport"
-    doc2.country_id = "AFG"
+    doc2.dedup_signature = expected_sig
 
     documents_numbers, new_sigs, per_individual_dict, duplicated = dedup._build_document_signatures([doc1, doc2])
 
-    expected_sig = "passport--DOC-001--AFG"
     assert documents_numbers == ["DOC-001", "DOC-001"]
     assert new_sigs == [expected_sig, expected_sig]
     assert per_individual_dict[str(individual_id_1)] == [expected_sig]


### PR DESCRIPTION
## Problem

[AB#320839](https://unicef.visualstudio.com/4e044e8d-bc28-4768-8074-f80ff6e4a0e5/_workitems/edit/320839)

When two distinct individuals are registered with the **same national ID**, the system raises a **Needs Adjudication** ticket of type *Unique Identifiers Similarity* (`issue_type = 23`). An operator can correct one individual's ID via a separate **Data Change** ticket — but after that ticket closes and the IDs differ, the original Needs Adjudication ticket **stays open forever**. Nothing re-evaluates or closes it, and the two tickets are not linked.

Reported example (Myanmar, "Multi-Purpose Cash Assistance - KOBO"): NA ticket `GRV-3495774`, linked Data Change ticket `GRV-3495814`.

## Solution

When an operator closes the **Data Change** ticket that corrected an individual's document, and that individual is party to an open Unique Identifiers Similarity ticket whose conflict is now gone, offer a one-click **"mark unique and close"** for the linked ticket right there. The decision is made **after the Data Change ticket's close actually applies the document edit**, by comparing documents live (no re-deduplication), gated by strict guards.

### Guards (all must hold)
1. `issue_type == ISSUE_TYPE_UNIQUE_IDENTIFIERS_SIMILARITY` (24/25 are name/biometric based — not resolved by an ID fix)
2. No shared document signature remains among unresolved individuals (handles partial resolution with >2 individuals)
3. No other open Needs Adjudication ticket involves these individuals (dedup status is cleared globally on the individual)
4. Ticket is open and passes the existing close validation

The action marks every individual on the linked ticket as **distinct** and closes it **directly, bypassing `FOR_APPROVAL`** (intentional — the ticket's sole premise is gone).

## Backend
- **`Document.dedup_signature`** — single source of truth for the dedup signature (`type_id--number--country_id`, honouring `valid_for_deduplication`); `HardDocumentDeduplication._generate_signature` now delegates to it.
- **`TicketNeedsAdjudicationDetails.documents_no_longer_conflict()`** — pairwise, signature-accurate conflict check that ignores invalidated documents. `has_duplicated_document` is left untouched (it only feeds an existing FE display field).
- **`find_open_unique_identifiers_ticket_for_individual()`** — finds the open Unique Identifiers Similarity ticket (if any) an individual is a party to; exposed as `linked_needs_adjudication_ticket_id` on `IndividualDataUpdateTicketDetailsSerializer` so the frontend knows which ticket to offer once the Data Change ticket closes.
- **`mark_unique_and_close()` / `can_close_as_unique()`** services + **`can_close_as_unique`** flag on the Needs Adjudication ticket detail serializer.
- **`POST .../close-as-unique`** action on `GrievanceTicketViewSet` with close permissions, per-individual area-access checks, concurrency check, activity log and cache clear.

## Frontend
- `GrievanceDetailsToolbar`: closing a **Data Change** ticket now checks `ticketDetails.linkedNeedsAdjudicationTicketId`; if present, it re-fetches that ticket, and if `canCloseAsUnique` is now true, asks the operator to mark its individuals as unique and calls `restBusinessAreasGrievanceTicketsCloseAsUniqueCreate` for it. The linked ticket's number in the dialog is a clickable link (opens in a new tab) to its detail page. The Needs Adjudication ticket's own Close button is unchanged from `develop` — closing it directly still goes through the normal status-change flow only.
- The generated REST client (`src/restgenerated`, git-ignored) is regenerated from the backend OpenAPI in CI.

## Tests
`tests/unit/apps/grievance/test_close_needs_adjudication_as_unique.py`: signature branches, conflict detection incl. partial resolution and invalid-document handling, all service guards, the `close-as-unique` API action, `find_open_unique_identifiers_ticket_for_individual` (incl. a query-count assertion), and the Data Change ticket detail exposing `linked_needs_adjudication_ticket_id`.

- ✅ 100% patch coverage on changed backend lines
- ✅ `tox -e mypy`, `tox -e lint` clean; FE `eslint` clean

## Manual testing

Verified end-to-end locally (Afghanistan business area), one Program per scenario, root superuser, clicking through the real UI:

| Scenario | Setup | Result |
|---|---|---|
| Conflict resolved | Data Change ticket edits the shared national ID to a new, unique number | Closing the Data Change ticket shows the "Close linked ticket as unique" dialog; confirming closes the linked Needs Adjudication ticket and marks both individuals distinct |
| Unrelated edit | Data Change ticket edits an unrelated field (`given_name`), document untouched | Dialog does **not** appear (document conflict still holds) |
| Partial multi-duplicate resolution | 3 individuals share the ID; Data Change ticket fixes only one duplicate | Dialog does **not** appear (the other duplicate still conflicts) |
| Sibling open ticket | Conflict resolved, but a second open Needs Adjudication ticket also involves the same individual | Dialog does **not** appear (guard blocks: another open ticket exists) |
| Wrong issue type | Needs Adjudication ticket is `ISSUE_TYPE_BIOGRAPHICAL_DATA_SIMILARITY` (24), not Unique Identifiers Similarity | No link is found at all, no dialog offered |

Also confirmed: closing a Needs Adjudication ticket directly (not via a Data Change ticket) still goes through the plain status-change close flow, unchanged from `develop`.

