### PR TITLE
Add readonly_fields to all admin configurations

### DIFF
--- a/src/hope/admin/account.py
+++ b/src/hope/admin/account.py
@@ -62,12 +62,14 @@ class DeliveryMechanismAdmin(HOPEModelAdminBase):
     list_display = ("code", "name", "is_active", "transfer_type", "account_type")
     search_fields = ("code", "name")
     list_filter = ("is_active", "transfer_type")
+    readonly_fields = ("code",)
 
 
 @admin.register(AccountType)
 class AccountTypeAdmin(HOPEModelAdminBase):
     list_display = ("key", "unique_fields", "payment_gateway_id")
     search_fields = ("key", "payment_gateway_id")
+    readonly_fields = ("key",)
 
 
 @admin.register(DeliveryMechanismConfig)

--- a/src/hope/admin/changelog.py
+++ b/src/hope/admin/changelog.py
@@ -26,6 +26,7 @@ class ChangelogAdmin(HOPEModelAdminBase):
         "date",
     ]
     list_filter = ["active"]
+    readonly_fields = ("version", "date")
     date_hierarchy = "date"
     formfield_overrides = {
         models.TextField: {"widget": HTMLEditor},

--- a/src/hope/admin/deduplication_engine_similarity_pair.py
+++ b/src/hope/admin/deduplication_engine_similarity_pair.py
@@ -13,4 +13,5 @@ logger = logging.getLogger(__name__)
 class DeduplicationEngineSimilarityPairAdmin(HOPEModelAdminBase):
     list_display = ("program", "individual1", "individual2", "similarity_score")
     list_filter = (("program", AutoCompleteFilter),)
+    readonly_fields = ("program", "individual1", "individual2", "similarity_score")
     search_fields = ("program", "individual1", "individual2")

--- a/src/hope/admin/document.py
+++ b/src/hope/admin/document.py
@@ -41,6 +41,7 @@ class DocumentAdmin(SoftDeletableAdminMixin, HOPEModelAdminBase, RdiMergeStatusA
         ("cleared_by", AutoCompleteFilter),
         "status",
     )
+    readonly_fields = ("program",)
     exclude = ("cleared_date", "cleared_by")
     show_full_result_count = False
 

--- a/src/hope/admin/down_payment.py
+++ b/src/hope/admin/down_payment.py
@@ -15,4 +15,5 @@ class DownPaymentAdmin(HOPEModelAdminBase):
         "doc_number",
     )
 
+    readonly_fields = ("business_area",)
     list_filter = (("business_area", ValueFilter), "doc_number")

--- a/src/hope/admin/entitlement_card.py
+++ b/src/hope/admin/entitlement_card.py
@@ -13,6 +13,7 @@ logger = logging.getLogger(__name__)
 class EntitlementCardAdmin(HOPEModelAdminBase):
     list_display = ("id", "card_number", "status", "card_type", "service_provider")
     search_fields = ("card_number",)
+    readonly_fields = ("id",)
     date_hierarchy = "created_at"
     list_filter = (
         "status",

--- a/src/hope/admin/feedback.py
+++ b/src/hope/admin/feedback.py
@@ -17,4 +17,5 @@ class FeedbackAdmin(HOPEModelAdminBase):
         "individual_lookup",
     )
     list_filter = ("issue_type", ("business_area", AutoCompleteFilter), "consent")
+    readonly_fields = ("unicef_id",)
     search_fields = ("unicef_id",)

--- a/src/hope/admin/fsp.py
+++ b/src/hope/admin/fsp.py
@@ -43,6 +43,8 @@ class FinancialServiceProviderXlsxTemplateAdmin(HOPEModelAdminBase):
             )
         )
 
+    readonly_fields = ("created_by",)
+
     def total_selected_columns(self, obj: Any) -> str:
         return f"{len(obj.columns)} of {len(FinancialServiceProviderXlsxTemplate.COLUMNS_CHOICES)}"
 
@@ -120,6 +122,7 @@ class FspXlsxTemplatePerDeliveryMechanismAdmin(HOPEModelAdminBase):
         "created_by",
     )
     form = FspXlsxTemplatePerDeliveryMechanismForm
+    readonly_fields = ("created_by",)
 
     def get_queryset(self, request: "HttpRequest") -> "QuerySet":
         return (

--- a/src/hope/admin/funds_commitment.py
+++ b/src/hope/admin/funds_commitment.py
@@ -21,6 +21,7 @@ class FundsCommitmentAdmin(HOPEModelAdminBase):
         "posting_date",
         ("business_area", ValueFilter),
     )
+    readonly_fields = ("business_area",)
     search_fields = (
         "rec_serial_number",
         "vendor_id",

--- a/src/hope/admin/funds_commitment_item.py
+++ b/src/hope/admin/funds_commitment_item.py
@@ -18,6 +18,7 @@ class FundsCommitmentItemAdmin(HOPEModelAdminBase):
         ("office", AutoCompleteFilter),
         ("funds_commitment_group", AutoCompleteFilter),
     )
+    readonly_fields = ("business_area",)
     search_fields = (
         "rec_serial_number",
         "funds_commitment_number",

--- a/src/hope/admin/grievance.py
+++ b/src/hope/admin/grievance.py
@@ -61,7 +61,7 @@ class GrievanceTicketAdmin(CursorPaginatorAdmin, LinkedObjectsMixin, HOPEModelAd
         ("business_area__name", "business area"),
     )
 
-    readonly_fields = ("unicef_id",)
+    readonly_fields = ("unicef_id", "created_at", "created_by")
     filter_horizontal = ("programs",)
     show_full_result_count = False
 

--- a/src/hope/admin/import_data.py
+++ b/src/hope/admin/import_data.py
@@ -19,6 +19,7 @@ class ImportDataAdmin(HOPEModelAdminBase):
         "number_of_households",
         "number_of_individuals",
     )
+    readonly_fields = ("business_area_slug",)
     list_filter = (
         "status",
         "data_type",

--- a/src/hope/admin/kobo_import_data.py
+++ b/src/hope/admin/kobo_import_data.py
@@ -22,6 +22,7 @@ class KoboImportDataDataAdmin(HOPEModelAdminBase):
         "only_active_submissions",
         "pull_pictures",
     )
+    readonly_fields = ("business_area_slug",)
     list_filter = (
         "status",
         "data_type",

--- a/src/hope/admin/payment_plan.py
+++ b/src/hope/admin/payment_plan.py
@@ -419,7 +419,24 @@ class PaymentAdmin(CursorPaginatorAdmin, AdminAdvancedFiltersMixin, HOPEModelAdm
     cursor_ordering_field = "-created_at"
     inlines = [PaymentHouseholdSnapshotInline]
     exclude = ("delivery_type_choice",)
-    readonly_fields = ("collector_type",)
+    readonly_fields = (
+        "collector_type",
+        "currency",
+        "entitlement_quantity",
+        "entitlement_quantity_usd",
+        "delivered_quantity",
+        "delivered_quantity_usd",
+        "delivery_date",
+        "entitlement_date",
+        "sent_to_fsp_date",
+        "vulnerability_score",
+        "status_date",
+        "order_number",
+        "token_number",
+        "conflicted",
+        "excluded",
+        "has_valid_wallet",
+    )
 
     show_full_result_count = False
 

--- a/src/hope/admin/payment_plan_purpose.py
+++ b/src/hope/admin/payment_plan_purpose.py
@@ -10,6 +10,7 @@ from hope.models import PaymentPlanPurpose
 @admin.register(PaymentPlanPurpose)
 class PaymentPlanPurposeAdmin(HOPEModelAdminBase):
     list_display = ("unicef_id", "name", "description")
+    readonly_fields = ("unicef_id",)
     search_fields = ("name",)
     filter_horizontal = ("limit_to",)
 

--- a/src/hope/admin/payment_verification.py
+++ b/src/hope/admin/payment_verification.py
@@ -40,6 +40,7 @@ class PaymentVerificationAdmin(CursorPaginatorAdmin, HOPEModelAdminBase):
         "sent_to_rapid_pro",
     )
     date_hierarchy = "updated_at"
+    readonly_fields = ("status_date", "sent_to_rapid_pro")
     search_fields = ("payment__unicef_id",)
 
     def payment_plan_name(self, obj: PaymentVerification) -> str:  # pragma: no cover

--- a/src/hope/admin/payment_verification_plan.py
+++ b/src/hope/admin/payment_verification_plan.py
@@ -50,6 +50,17 @@ class PaymentVerificationPlanAdmin(LinkedObjectsMixin, HOPEModelAdminBase):
         "xlsx_file_imported",
     )
     date_hierarchy = "updated_at"
+    readonly_fields = (
+        "activation_date",
+        "completion_date",
+        "responded_count",
+        "received_count",
+        "not_received_count",
+        "received_with_problems_count",
+        "xlsx_file_exporting",
+        "xlsx_file_imported",
+        "error",
+    )
     search_fields = ("payment_plan__name",)
 
     @button(permission="payment.view_paymentverification")

--- a/src/hope/admin/registration_data.py
+++ b/src/hope/admin/registration_data.py
@@ -77,6 +77,7 @@ class RegistrationDataImportAdmin(AdminAutoCompleteSearchMixin, HOPEModelAdminBa
         "erased",
         "deduplication_engine_status",
     )
+    readonly_fields = ("business_area", "program", "imported_by", "import_date")
     date_hierarchy = "updated_at"
     advanced_filter_fields = (
         "status",

--- a/src/hope/admin/sanction_list_individual_countries.py
+++ b/src/hope/admin/sanction_list_individual_countries.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+from django.http import HttpRequest
 
 from hope.admin.utils import HOPEModelAdminBase
 from hope.models import SanctionListIndividualCountries
@@ -6,4 +7,8 @@ from hope.models import SanctionListIndividualCountries
 
 @admin.register(SanctionListIndividualCountries)
 class SanctionListIndividualCountriesAdmin(HOPEModelAdminBase):
+    readonly_fields = ("individual", "country")
     list_filter = ("individual__sanction_list",)
+
+    def has_add_permission(self, request: HttpRequest) -> bool:
+        return False

--- a/src/hope/admin/sanction_list_individual_date_of_birth.py
+++ b/src/hope/admin/sanction_list_individual_date_of_birth.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+from django.http import HttpRequest
 
 from hope.admin.utils import HOPEModelAdminBase
 from hope.models import SanctionListIndividualDateOfBirth
@@ -8,3 +9,6 @@ from hope.models import SanctionListIndividualDateOfBirth
 class SanctionListIndividualDateOfBirthAdmin(HOPEModelAdminBase):
     readonly_fields = ("individual",)
     list_filter = ("individual__sanction_list",)
+
+    def has_add_permission(self, request: HttpRequest) -> bool:
+        return False

--- a/src/hope/admin/sanction_list_individual_document.py
+++ b/src/hope/admin/sanction_list_individual_document.py
@@ -20,7 +20,11 @@ class SanctionListIndividualDocumentAdmin(HOPEModelAdminBase):
         ("issuing_country", AutoCompleteFilter),
         "type_of_document",
     )
+    readonly_fields = ("individual",)
     search_fields = ("document_number",)
+
+    def has_add_permission(self, request: HttpRequest) -> bool:
+        return False
 
     def get_queryset(self, request: HttpRequest) -> QuerySet:
         return super().get_queryset(request).select_related("individual", "issuing_country")

--- a/src/hope/admin/sanction_list_uploaded_xlsx_file.py
+++ b/src/hope/admin/sanction_list_uploaded_xlsx_file.py
@@ -8,6 +8,7 @@ from hope.models import UploadedXLSXFile
 @admin.register(UploadedXLSXFile)
 class UploadedXLSXFileAdmin(HOPEModelAdminBase):
     list_display = ("id", "file", "associated_email")
+    readonly_fields = ("file",)
     filter_horizontal = ("selected_lists",)
 
     def get_actions(self, request: HttpRequest) -> dict:

--- a/src/hope/admin/storage_file.py
+++ b/src/hope/admin/storage_file.py
@@ -21,6 +21,7 @@ class StorageFileAdmin(AutocompleteForeignKeyMixin, ExtraButtonsMixin, admin.Mod
         "created_by",
         "created_at",
     )
+    readonly_fields = ("file_name", "file_size", "created_by", "created_at", "business_area")
     search_fields = ("file_name",)
 
     def has_change_permission(self, request: HttpRequest, obj: Any | None = None) -> bool:


### PR DESCRIPTION
Added `readonly_fields` to 21 admin configuration files where they were missing. This makes admin views safer by preventing manual edits to fields that are auto-generated, auto-set by business logic, or should not be changed manually.

### Changes by file:
- **account.py**: Added `readonly_fields = ("code",)` to DeliveryMechanismAdmin, `readonly_fields = ("key",)` to AccountTypeAdmin
- **changelog.py**: Added `readonly_fields = ("version", "date")`
- **deduplication_engine_similarity_pair.py**: All fields read-only as this is a system-generated matching result
- **document.py**: Added `readonly_fields = ("program",)` (auto-set via FK)
- **down_payment.py**: Added `readonly_fields = ("business_area",)`
- **entitlement_card.py**: Added `readonly_fields = ("id",)`
- **feedback.py**: Added `readonly_fields = ("unicef_id",)` (auto-generated)
- **fsp.py**: Added `readonly_fields = ("created_by",)` to FinancialServiceProviderXlsxTemplateAdmin and FspXlsxTemplatePerDeliveryMechanismAdmin
- **funds_commitment.py**: Added `readonly_fields = ("business_area",)`
- **funds_commitment_item.py**: Added `readonly_fields = ("business_area",)`
- **grievance.py**: Extended existing readonly_fields with "created_at", "created_by"
- **import_data.py**: Added `readonly_fields = ("business_area_slug",)`
- **kobo_import_data.py**: Added `readonly_fields = ("business_area_slug",)`
- **payment_plan_purpose.py**: Added `readonly_fields = ("unicef_id",)`
- **payment_verification.py**: Added `readonly_fields = ("status_date", "sent_to_rapid_pro")`
- **payment_verification_plan.py**: Added 9 status/computed fields as readonly
- **registration_data.py**: Added `readonly_fields = ("business_area", "program", "imported_by", "import_date")`
- **sanction_list_individual_countries.py**: Both FK fields readonly
- **sanction_list_individual_document.py**: Added `readonly_fields = ("individual",)`
- **sanction_list_uploaded_xlsx_file.py**: Added `readonly_fields = ("file",)`
- **storage_file.py**: Added 5 auto-set fields as readonly