### PR TITLE
hotfix(aurora): repair admin Create-RDI button broken by bound task method

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [ "setuptools", "wheel" ]
 
 [project]
 name = "hope"
-version = "4.15.6"
+version = "4.15.7"
 description = "HCT MIS is UNICEF's humanitarian cash transfer platform."
 readme = "README.md"
 license = { text = "None" }

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "4.15.6",
+  "version": "4.15.7",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/hope/contrib/aurora/services/base_flex_registration_service.py
+++ b/src/hope/contrib/aurora/services/base_flex_registration_service.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 
 
 class BaseRegistrationService(AuroraProcessor, abc.ABC):
-    process_flex_records_task = process_flex_records_async_task
+    process_flex_records_task = staticmethod(process_flex_records_async_task)
 
     def __init__(self, registration: Registration) -> None:
         self.registration = registration

--- a/tests/unit/apps/aurora/test_celery_tasks.py
+++ b/tests/unit/apps/aurora/test_celery_tasks.py
@@ -17,6 +17,7 @@ from extras.test_utils.factories import (
     OrganizationFactory,
     ProgramFactory,
     ProjectFactory,
+    RegistrationDataImportFactory,
     RegistrationFactory,
 )
 from hope.apps.core.celery_tasks import NonRetriableTaskError, async_retry_job_task
@@ -686,6 +687,20 @@ def test_create_task_for_processing_records_calls_celery_task_with_nullable_rdi(
     create_task_for_processing_records(service, registration, None, [1, 2, 3])
 
     celery_task.assert_called_once_with(registration, None, [1, 2, 3])
+
+
+def test_create_task_for_processing_records_does_not_bind_self_on_real_service(
+    ukraine_context: dict[str, object],
+) -> None:
+    registration = ukraine_context["registration"]
+    service = registration.rdi_parser
+    rdi = RegistrationDataImportFactory(program=ukraine_context["program"])
+
+    with patch("hope.contrib.aurora.celery_tasks.AsyncRetryJob.queue_task") as queue_task:
+        create_task_for_processing_records(service, registration, rdi, [1, 2, 3])
+
+    queue_task.assert_called_once()
+    assert queue_task.call_args.kwargs["config"]["records_ids"] == [1, 2, 3]
 
 
 def test_process_flex_records_task_action_raises_not_implemented_without_service(

--- a/uv.lock
+++ b/uv.lock
@@ -1981,7 +1981,7 @@ wheels = [
 
 [[package]]
 name = "hope"
-version = "4.15.6"
+version = "4.15.7"
 source = { editable = "." }
 dependencies = [
     { name = "black" },


### PR DESCRIPTION
## What was broken

Clicking **Create RDI** (and **Add to existing RDI**) in Aurora admin failed with:

```
TypeError: process_flex_records_async_task() takes 3 positional arguments but 4 were given
```

So nobody could start an RDI import from the admin.

## Why

In `base_flex_registration_service.py` the Celery task was attached to the class as a plain function:

```python
process_flex_records_task = process_flex_records_async_task
```

`registration.rdi_parser` returns a service **instance**. Reading a function off an instance turns it into a *bound method*, so Python passes `self` as the first argument automatically. The task expects 3 args (`registration, rdi, records_ids`); the hidden `self` made it 4 → crash.

The Celery auto-import path (`automate_rdi_creation`) was unaffected because it calls `service.process_records()` directly, which is why only the admin button broke.

## The fix

Wrap it in `staticmethod` so `self` is never bound:

```python
process_flex_records_task = staticmethod(process_flex_records_async_task)
```

Admin works again; the Celery path keeps working unchanged.

## When it broke

Regressed in #5902 (aurora async tasks refactor), where the attribute was renamed to `process_flex_records_task`. The existing test missed it because it replaced the attribute with a `Mock` — a Mock isn't a descriptor, so it never bound `self` and hid the bug. The added regression test uses a **real** service instance and reproduces the exact production error without the fix.

## Notes

- Patch version bumped 4.15.6 → 4.15.7 (backend + frontend), `uv.lock` regenerated. `bun.lock` does not embed the frontend version, so it is unchanged.
