### PR TITLE
[324346] Aurora: USDC (crypto wallet) RDI import for Ukraine

### DIFF
--- a/src/hope/apps/core/management/commands/demo_data/payment.py
+++ b/src/hope/apps/core/management/commands/demo_data/payment.py
@@ -206,6 +206,7 @@ def generate_delivery_mechanisms() -> None:
         ("IBAN Provider Bank", FinancialInstitution.FinancialInstitutionType.BANK),
         ("Generic Bank", FinancialInstitution.FinancialInstitutionType.BANK),
         ("Generic Telco Company", FinancialInstitution.FinancialInstitutionType.TELCO),
+        ("Generic Crypto", FinancialInstitution.FinancialInstitutionType.OTHER),
     ]
 
     for fi_name, fi_type in generic_fis:

--- a/src/hope/contrib/aurora/apps.py
+++ b/src/hope/contrib/aurora/apps.py
@@ -25,6 +25,7 @@ class Config(AppConfig):
             Registration2024,
             UkraineBaseRegistrationService,
             UkraineRegistrationService,
+            UkraineUSDCRegistrationService,
         )
         import hope.contrib.aurora.signals  # noqa: F401
 
@@ -35,4 +36,5 @@ class Config(AppConfig):
         registry.register(UkraineRegistrationService)
         registry.register(CzechRepublicFlexRegistration)
         registry.register(Registration2024)
+        registry.register(UkraineUSDCRegistrationService)
         registry.register(NigeriaPeopleRegistrationService)

--- a/src/hope/contrib/aurora/services/ukraine_flex_registration_service.py
+++ b/src/hope/contrib/aurora/services/ukraine_flex_registration_service.py
@@ -1,3 +1,4 @@
+from functools import cached_property
 from typing import Any
 import uuid
 
@@ -26,6 +27,9 @@ from hope.apps.household.const import (
 from hope.apps.household.forms import DocumentForm, IndividualForm
 from hope.contrib.aurora.services.base_flex_registration_service import (
     BaseRegistrationService,
+)
+from hope.contrib.aurora.services.generic_registration_service import (
+    GenericRegistrationService,
 )
 from hope.models import (
     Area,
@@ -361,7 +365,7 @@ class UkraineUSDCRegistrationService(UkraineBaseRegistrationService):
         household_data = super()._prepare_household_data(household_dict, record, registration_data_import)
         consent = household_dict.get("consent_h_c")
         if consent is not None:
-            household_data["consent"] = consent in ("y", "yes", "1", 1, "true", "True", True)
+            household_data["consent"] = GenericRegistrationService.get_boolean(consent)
         return household_data
 
     def _prepare_individual_data(
@@ -384,25 +388,21 @@ class UkraineUSDCRegistrationService(UkraineBaseRegistrationService):
         individuals = PendingIndividual.objects.filter(
             registration_data_import=registration_data_import,
             detail_id=record.source_id,
-        ).exclude(wallet_address="", wallet_name="")
-        if not individuals:
-            return
-
-        account_type = self._get_wallet_account_type()
-        financial_institution = FinancialInstitution.get_generic_one(account_type.key, is_valid_iban=False)
+        ).exclude(wallet_address="")
         accounts = [
             PendingAccount(
                 individual=individual,
-                account_type=account_type,
-                number=individual.wallet_address or None,
-                financial_institution=financial_institution,
+                account_type=self._wallet_account_type,
+                number=individual.wallet_address,
+                financial_institution=self._wallet_financial_institution,
                 data={"wallet_address": individual.wallet_address, "wallet_name": individual.wallet_name},
             )
             for individual in individuals
         ]
         PendingAccount.objects.bulk_create(accounts)
 
-    def _get_wallet_account_type(self) -> Any:
+    @cached_property
+    def _wallet_account_type(self) -> Any:
         delivery_mechanism = DeliveryMechanism.objects.filter(code=self.DIGITAL_WALLET_DELIVERY_MECHANISM_CODE).first()
         if not delivery_mechanism or not delivery_mechanism.account_type:
             raise ValidationError(
@@ -410,3 +410,7 @@ class UkraineUSDCRegistrationService(UkraineBaseRegistrationService):
                 "configured; sync it from the Payment Gateway before importing USDC wallets."
             )
         return delivery_mechanism.account_type
+
+    @cached_property
+    def _wallet_financial_institution(self) -> Any:
+        return FinancialInstitution.get_generic_one(self._wallet_account_type.key, is_valid_iban=False)

--- a/src/hope/contrib/aurora/services/ukraine_flex_registration_service.py
+++ b/src/hope/contrib/aurora/services/ukraine_flex_registration_service.py
@@ -30,7 +30,10 @@ from hope.contrib.aurora.services.base_flex_registration_service import (
 from hope.models import (
     Area,
     Country,
+    DeliveryMechanism,
     DocumentType,
+    FinancialInstitution,
+    PendingAccount,
     PendingDocument,
     PendingHousehold,
     PendingIndividual,
@@ -244,7 +247,7 @@ class UkraineBaseRegistrationService(BaseRegistrationService):
         for document_key_string, (
             document_number_field_name,
             picture_field_name,
-        ) in UkraineRegistrationService.DOCUMENT_MAPPING_KEY_DICT.items():
+        ) in self.DOCUMENT_MAPPING_KEY_DICT.items():
             document_number = individual_dict.get(document_number_field_name)
             certificate_picture = individual_dict.get(picture_field_name, "")
 
@@ -314,3 +317,98 @@ class Registration2024(UkraineBaseRegistrationService):
             individual_dict, self.INDIVIDUAL_FLEX_FIELDS
         )
         return individual_data
+
+
+class UkraineUSDCRegistrationService(UkraineBaseRegistrationService):
+    """USDC registration for Ukraine — regular (household-based) programme.
+
+    Maps the finalized USDC form to Households + Individuals, storing the crypto wallet
+    both on the Individual (`wallet_address`/`wallet_name`, for display/grievance) and on a
+    ``PendingAccount``. The account type is taken from the ``transfer_to_digital_wallet`` delivery mechanism
+    so it always matches payout, and its financial institution is the generic one for that account type.
+    """
+
+    DIGITAL_WALLET_DELIVERY_MECHANISM_CODE = "transfer_to_digital_wallet"
+
+    INDIVIDUAL_MAPPING_DICT = {
+        "given_name": "given_name_i_c",
+        "middle_name": "middle_name_i_c",
+        "family_name": "family_name_i_c",
+        "birth_date": "birth_date",
+        "sex": "gender_i_c",
+        "phone_no": "phone_no_i_c",
+        "relationship": "relationship_i_c",
+        "role": "role_i_c",
+        "wallet_name": "wallet_name_i_c",
+        "wallet_address": "wallet_address_i_c",
+    }
+
+    DOCUMENT_MAPPING_KEY_DICT = {
+        IDENTIFICATION_TYPE_TO_KEY_MAPPING[IDENTIFICATION_TYPE_TAX_ID]: (
+            "tax_id_no_i_c",
+            "tax_id_picture",
+        ),
+    }
+
+    INDIVIDUAL_FLEX_FIELDS: list[str] = ["wallet_num_image_i_f", "id_wallet_image_i_f"]
+
+    def _prepare_household_data(
+        self,
+        household_dict: dict,
+        record: Any,
+        registration_data_import: RegistrationDataImport,
+    ) -> dict:
+        household_data = super()._prepare_household_data(household_dict, record, registration_data_import)
+        consent = household_dict.get("consent_h_c")
+        if consent is not None:
+            household_data["consent"] = consent in ("y", "yes", "1", 1, "true", "True", True)
+        return household_data
+
+    def _prepare_individual_data(
+        self,
+        individual_dict: dict,
+        household: PendingHousehold,
+        registration_data_import: RegistrationDataImport,
+    ) -> dict:
+        individual_data = super()._prepare_individual_data(individual_dict, household, registration_data_import)
+        individual_data["estimated_birth_date"] = False
+        if flex_fields := build_flex_arg_dict_from_list_if_exists(individual_dict, self.INDIVIDUAL_FLEX_FIELDS):
+            individual_data["flex_fields"] = flex_fields
+        return individual_data
+
+    def create_household_for_rdi_household(self, record: Any, registration_data_import: RegistrationDataImport) -> None:
+        super().create_household_for_rdi_household(record, registration_data_import)
+        self._create_wallet_accounts(record, registration_data_import)
+
+    def _create_wallet_accounts(self, record: Any, registration_data_import: RegistrationDataImport) -> None:
+        individuals = PendingIndividual.objects.filter(
+            registration_data_import=registration_data_import,
+            detail_id=record.source_id,
+        ).exclude(wallet_address="", wallet_name="")
+        if not individuals:
+            return
+
+        account_type = self._get_wallet_account_type()
+        financial_institution = FinancialInstitution.get_generic_one(account_type.key, is_valid_iban=False)
+        accounts = [
+            PendingAccount(
+                individual=individual,
+                account_type=account_type,
+                number=individual.wallet_address or None,
+                financial_institution=financial_institution,
+                data={"wallet_address": individual.wallet_address, "wallet_name": individual.wallet_name},
+            )
+            for individual in individuals
+        ]
+        PendingAccount.objects.bulk_create(accounts)
+
+    def _get_wallet_account_type(self) -> Any:
+        delivery_mechanism = DeliveryMechanism.objects.filter(
+            code=self.DIGITAL_WALLET_DELIVERY_MECHANISM_CODE
+        ).first()
+        if not delivery_mechanism or not delivery_mechanism.account_type:
+            raise ValidationError(
+                f"Delivery mechanism '{self.DIGITAL_WALLET_DELIVERY_MECHANISM_CODE}' has no account type "
+                "configured; sync it from the Payment Gateway before importing USDC wallets."
+            )
+        return delivery_mechanism.account_type

--- a/src/hope/contrib/aurora/services/ukraine_flex_registration_service.py
+++ b/src/hope/contrib/aurora/services/ukraine_flex_registration_service.py
@@ -403,9 +403,7 @@ class UkraineUSDCRegistrationService(UkraineBaseRegistrationService):
         PendingAccount.objects.bulk_create(accounts)
 
     def _get_wallet_account_type(self) -> Any:
-        delivery_mechanism = DeliveryMechanism.objects.filter(
-            code=self.DIGITAL_WALLET_DELIVERY_MECHANISM_CODE
-        ).first()
+        delivery_mechanism = DeliveryMechanism.objects.filter(code=self.DIGITAL_WALLET_DELIVERY_MECHANISM_CODE).first()
         if not delivery_mechanism or not delivery_mechanism.account_type:
             raise ValidationError(
                 f"Delivery mechanism '{self.DIGITAL_WALLET_DELIVERY_MECHANISM_CODE}' has no account type "

--- a/src/hope/contrib/aurora/services/ukraine_flex_registration_service.py
+++ b/src/hope/contrib/aurora/services/ukraine_flex_registration_service.py
@@ -32,6 +32,7 @@ from hope.contrib.aurora.services.generic_registration_service import (
     GenericRegistrationService,
 )
 from hope.models import (
+    AccountType,
     Area,
     Country,
     DeliveryMechanism,
@@ -98,6 +99,7 @@ class UkraineBaseRegistrationService(BaseRegistrationService):
     def create_household_for_rdi_household(self, record: Any, registration_data_import: RegistrationDataImport) -> None:
         individuals: list[PendingIndividual] = []
         documents: list[PendingDocument] = []
+        accounts: list[PendingAccount] = []
         record_data_dict = record.get_data()
         household_dict = record_data_dict.get("household", [])[0]
         individuals_array = record_data_dict.get("individuals", [])
@@ -140,10 +142,15 @@ class UkraineBaseRegistrationService(BaseRegistrationService):
                     household.head_of_household = individual
                     household.save(update_fields=("head_of_household",))
                 documents.extend(self._prepare_documents(individual_dict, individual))
+                accounts.extend(self._prepare_accounts(individual_dict, individual))
             except ValidationError as e:
                 raise ValidationError({f"individual nr {index + 1}": [str(e)]}) from e
 
         PendingDocument.objects.bulk_create(documents)
+        PendingAccount.objects.bulk_create(accounts)
+
+    def _prepare_accounts(self, individual_dict: dict, individual: PendingIndividual) -> list[PendingAccount]:
+        return []
 
     def _set_default_head_of_household(self, individuals_array: list[dict[str, Any]]) -> None:
         for individual_data in individuals_array:
@@ -326,10 +333,9 @@ class Registration2024(UkraineBaseRegistrationService):
 class UkraineUSDCRegistrationService(UkraineBaseRegistrationService):
     """USDC registration for Ukraine — regular (household-based) programme.
 
-    Maps the finalized USDC form to Households + Individuals, storing the crypto wallet
-    both on the Individual (`wallet_address`/`wallet_name`, for display/grievance) and on a
-    ``PendingAccount``. The account type is taken from the ``transfer_to_digital_wallet`` delivery mechanism
-    so it always matches payout, and its financial institution is the generic one for that account type.
+    Maps the finalized USDC form to Households + Individuals. The crypto wallet is stored on a ``PendingAccount``.
+    The account type is taken from the ``transfer_to_digital_wallet`` delivery mechanism so it always matches payout,
+    and its financial institution is the generic one for that account type.
     """
 
     DIGITAL_WALLET_DELIVERY_MECHANISM_CODE = "transfer_to_digital_wallet"
@@ -343,8 +349,6 @@ class UkraineUSDCRegistrationService(UkraineBaseRegistrationService):
         "phone_no": "phone_no_i_c",
         "relationship": "relationship_i_c",
         "role": "role_i_c",
-        "wallet_name": "wallet_name_i_c",
-        "wallet_address": "wallet_address_i_c",
     }
 
     DOCUMENT_MAPPING_KEY_DICT = {
@@ -380,29 +384,23 @@ class UkraineUSDCRegistrationService(UkraineBaseRegistrationService):
             individual_data["flex_fields"] = flex_fields
         return individual_data
 
-    def create_household_for_rdi_household(self, record: Any, registration_data_import: RegistrationDataImport) -> None:
-        super().create_household_for_rdi_household(record, registration_data_import)
-        self._create_wallet_accounts(record, registration_data_import)
-
-    def _create_wallet_accounts(self, record: Any, registration_data_import: RegistrationDataImport) -> None:
-        individuals = PendingIndividual.objects.filter(
-            registration_data_import=registration_data_import,
-            detail_id=record.source_id,
-        ).exclude(wallet_address="")
-        accounts = [
+    def _prepare_accounts(self, individual_dict: dict, individual: PendingIndividual) -> list[PendingAccount]:
+        wallet_address = (individual_dict.get("wallet_address_i_c") or "").strip()
+        if not wallet_address:
+            return []
+        wallet_name = (individual_dict.get("wallet_name_i_c") or "").strip()
+        return [
             PendingAccount(
                 individual=individual,
-                account_type=self._wallet_account_type,
-                number=individual.wallet_address,
-                financial_institution=self._wallet_financial_institution,
-                data={"wallet_address": individual.wallet_address, "wallet_name": individual.wallet_name},
+                account_type=self._digital_wallet_account_type,
+                number=wallet_address,
+                financial_institution=self._digital_wallet_financial_institution,
+                data={"wallet_address": wallet_address, "wallet_name": wallet_name},
             )
-            for individual in individuals
         ]
-        PendingAccount.objects.bulk_create(accounts)
 
     @cached_property
-    def _wallet_account_type(self) -> Any:
+    def _digital_wallet_account_type(self) -> AccountType:
         delivery_mechanism = DeliveryMechanism.objects.filter(code=self.DIGITAL_WALLET_DELIVERY_MECHANISM_CODE).first()
         if not delivery_mechanism or not delivery_mechanism.account_type:
             raise ValidationError(
@@ -412,5 +410,5 @@ class UkraineUSDCRegistrationService(UkraineBaseRegistrationService):
         return delivery_mechanism.account_type
 
     @cached_property
-    def _wallet_financial_institution(self) -> Any:
-        return FinancialInstitution.get_generic_one(self._wallet_account_type.key, is_valid_iban=False)
+    def _digital_wallet_financial_institution(self) -> FinancialInstitution:
+        return FinancialInstitution.get_generic_one(self._digital_wallet_account_type.key, is_valid_iban=False)

--- a/src/hope/models/financial_institution.py
+++ b/src/hope/models/financial_institution.py
@@ -51,6 +51,9 @@ class FinancialInstitution(TimeStampedModel):
         if account_type == "card":
             return cls.objects.get(name="Generic Bank")
 
+        if account_type == "crypto":
+            return cls.objects.get(name="Generic Crypto")
+
         logger.error(f"Unknown account type for generic Financial Institution: {account_type}")
         return cls.objects.get(name="Generic Bank")
 

--- a/tests/unit/apps/aurora/test_ukraine_usdc_registration_service.py
+++ b/tests/unit/apps/aurora/test_ukraine_usdc_registration_service.py
@@ -205,6 +205,42 @@ def test_consent_read_from_form_when_declined(
     assert household.consent is False
 
 
+def test_consent_defaults_to_true_when_not_in_form(
+    registration: Any,
+    user: Any,
+    ukraine_country: Any,
+    tax_id_document_type: Any,
+    submission_timestamp: datetime.datetime,
+) -> None:
+    record = RecordFactory(
+        registration=registration.source_id,
+        timestamp=submission_timestamp,
+        source_id=7,
+        fields={
+            "household": [{}],
+            "individuals": [
+                {
+                    "given_name_i_c": "Ivan",
+                    "family_name_i_c": "Kovalenko",
+                    "birth_date": "1970-07-07",
+                    "gender_i_c": "male",
+                    "relationship_i_c": "head",
+                    "role_i_c": "y",
+                    "tax_id_no_i_c": "5555555555",
+                }
+            ],
+        },
+        files=json.dumps({}).encode(),
+    )
+    service = UkraineUSDCRegistrationService(registration)
+    rdi = service.create_rdi(user, "usdc rdi")
+
+    service.process_records(rdi.id, [record.id])
+
+    household = PendingHousehold.objects.get(registration_data_import=rdi)
+    assert household.consent is True
+
+
 def test_individual_full_name_concatenated_and_birth_date_not_estimated(
     registration: Any,
     user: Any,
@@ -369,18 +405,19 @@ def test_import_errors_when_delivery_mechanism_not_configured(
     assert not PendingHousehold.objects.filter(registration_data_import=rdi).exists()
 
 
-def test_no_wallet_account_when_no_wallet_data(
+def test_no_wallet_account_when_address_missing(
     registration: Any,
     user: Any,
     ukraine_country: Any,
     tax_id_document_type: Any,
     digital_wallet_delivery_mechanism: DeliveryMechanism,
+    generic_crypto_fi: FinancialInstitution,
     submission_timestamp: datetime.datetime,
 ) -> None:
     record = RecordFactory(
         registration=registration.source_id,
         timestamp=submission_timestamp,
-        source_id=3,
+        source_id=6,
         fields={
             "household": [{"consent_h_c": True}],
             "individuals": [
@@ -391,7 +428,7 @@ def test_no_wallet_account_when_no_wallet_data(
                     "gender_i_c": "male",
                     "relationship_i_c": "head",
                     "role_i_c": "y",
-                    "tax_id_no_i_c": "5555555555",
+                    "wallet_name_i_c": "Trust",
                 }
             ],
         },
@@ -403,6 +440,7 @@ def test_no_wallet_account_when_no_wallet_data(
     service.process_records(rdi.id, [record.id])
 
     individual = PendingIndividual.objects.get(registration_data_import=rdi)
+    assert individual.wallet_name == "Trust"
     assert not PendingAccount.objects.filter(individual=individual).exists()
 
 

--- a/tests/unit/apps/aurora/test_ukraine_usdc_registration_service.py
+++ b/tests/unit/apps/aurora/test_ukraine_usdc_registration_service.py
@@ -1,0 +1,427 @@
+import datetime
+import json
+from typing import Any
+
+from django.utils import timezone
+import pytest
+
+from extras.test_utils.factories.account import UserFactory
+from extras.test_utils.factories.aurora import OrganizationFactory, ProjectFactory, RecordFactory, RegistrationFactory
+from extras.test_utils.factories.core import BusinessAreaFactory, DataCollectingTypeFactory
+from extras.test_utils.factories.geo import CountryFactory
+from extras.test_utils.factories.household import DocumentTypeFactory
+from extras.test_utils.factories.payment import (
+    AccountTypeFactory,
+    DeliveryMechanismFactory,
+    FinancialInstitutionFactory,
+)
+from extras.test_utils.factories.program import ProgramFactory
+from hope.apps.core.utils import IDENTIFICATION_TYPE_TO_KEY_MAPPING
+from hope.apps.household.const import IDENTIFICATION_TYPE_TAX_ID, ROLE_PRIMARY
+from hope.contrib.aurora.models import Record
+from hope.contrib.aurora.services.ukraine_flex_registration_service import UkraineUSDCRegistrationService
+from hope.models import (
+    DataCollectingType,
+    DeliveryMechanism,
+    FinancialInstitution,
+    PendingAccount,
+    PendingDocument,
+    PendingHousehold,
+    PendingIndividual,
+    PendingIndividualRoleInHousehold,
+    Program,
+)
+
+pytestmark = [pytest.mark.django_db, pytest.mark.usefixtures("mock_elasticsearch")]
+
+
+@pytest.fixture
+def business_area() -> Any:
+    return BusinessAreaFactory(slug="some-ukraine-slug")
+
+
+@pytest.fixture
+def data_collecting_type(business_area: Any) -> DataCollectingType:
+    data_collecting_type = DataCollectingTypeFactory(label="SomeFull", code="some_full")
+    data_collecting_type.limit_to.add(business_area)
+    return data_collecting_type
+
+
+@pytest.fixture
+def program(business_area: Any, data_collecting_type: DataCollectingType) -> Program:
+    return ProgramFactory(
+        status=Program.ACTIVE,
+        business_area=business_area,
+        data_collecting_type=data_collecting_type,
+    )
+
+
+@pytest.fixture
+def organization(business_area: Any) -> Any:
+    return OrganizationFactory(business_area=business_area, slug=business_area.slug)
+
+
+@pytest.fixture
+def project(organization: Any, program: Program) -> Any:
+    return ProjectFactory(name="usdc_project", organization=organization, programme=program)
+
+
+@pytest.fixture
+def registration(project: Any) -> Any:
+    return RegistrationFactory(name="usdc_registration", project=project)
+
+
+@pytest.fixture
+def user() -> Any:
+    return UserFactory()
+
+
+@pytest.fixture
+def ukraine_country() -> Any:
+    return CountryFactory(name="Ukraine", short_name="Ukraine", iso_code2="UA", iso_code3="UKR", iso_num="0804")
+
+
+@pytest.fixture
+def tax_id_document_type() -> Any:
+    return DocumentTypeFactory(
+        key=IDENTIFICATION_TYPE_TO_KEY_MAPPING[IDENTIFICATION_TYPE_TAX_ID],
+        label=IDENTIFICATION_TYPE_TAX_ID,
+    )
+
+
+@pytest.fixture
+def generic_crypto_fi() -> FinancialInstitution:
+    return FinancialInstitutionFactory(
+        name="Generic Crypto",
+        type=FinancialInstitution.FinancialInstitutionType.OTHER,
+        country=None,
+    )
+
+
+@pytest.fixture
+def digital_wallet_delivery_mechanism(generic_crypto_fi: FinancialInstitution) -> DeliveryMechanism:
+    return DeliveryMechanismFactory(
+        code="transfer_to_digital_wallet",
+        name="Transfer to Digital Wallet",
+        transfer_type=DeliveryMechanism.TransferType.DIGITAL,
+        account_type=AccountTypeFactory(key="crypto", label="Crypto"),
+    )
+
+
+@pytest.fixture
+def submission_timestamp() -> datetime.datetime:
+    return timezone.make_aware(datetime.datetime(2026, 6, 15))
+
+
+@pytest.fixture
+def usdc_record(registration: Any, submission_timestamp: datetime.datetime) -> Record:
+    return RecordFactory(
+        registration=registration.source_id,
+        timestamp=submission_timestamp,
+        source_id=1,
+        fields={
+            "household": [{"consent_h_c": True}],
+            "individuals": [
+                {
+                    "given_name_i_c": "Olena",
+                    "middle_name_i_c": "Ivanivna",
+                    "family_name_i_c": "Shevchenko",
+                    "birth_date": "1990-05-12",
+                    "gender_i_c": "female",
+                    "phone_no_i_c": "0501112233",
+                    "relationship_i_c": "head",
+                    "role_i_c": "y",
+                    "tax_id_no_i_c": "1234567890",
+                    "wallet_address_i_c": "0xABCDEF0123456789",
+                    "wallet_name_i_c": "MetaMask",
+                    "wallet_num_image_i_f": "d2FsbGV0X251bV9pbWFnZQ==",
+                    "id_wallet_image_i_f": "aWRfd2FsbGV0X2ltYWdl",
+                }
+            ],
+        },
+        files=json.dumps({}).encode(),
+    )
+
+
+def test_creates_household_in_ukraine_for_regular_programme(
+    registration: Any,
+    user: Any,
+    program: Program,
+    ukraine_country: Any,
+    tax_id_document_type: Any,
+    digital_wallet_delivery_mechanism: DeliveryMechanism,
+    usdc_record: Record,
+    submission_timestamp: datetime.datetime,
+) -> None:
+    service = UkraineUSDCRegistrationService(registration)
+    rdi = service.create_rdi(user, "usdc rdi")
+
+    service.process_records(rdi.id, [usdc_record.id])
+
+    household = PendingHousehold.objects.get(registration_data_import=rdi)
+    assert household.program == program
+    assert household.country.iso_code2 == "UA"
+    assert household.country_origin.iso_code2 == "UA"
+    assert household.consent is True
+    assert household.first_registration_date == submission_timestamp
+
+
+def test_consent_read_from_form_when_declined(
+    registration: Any,
+    user: Any,
+    ukraine_country: Any,
+    tax_id_document_type: Any,
+    digital_wallet_delivery_mechanism: DeliveryMechanism,
+    submission_timestamp: datetime.datetime,
+) -> None:
+    record = RecordFactory(
+        registration=registration.source_id,
+        timestamp=submission_timestamp,
+        source_id=2,
+        fields={
+            "household": [{"consent_h_c": "n"}],
+            "individuals": [
+                {
+                    "given_name_i_c": "Petro",
+                    "family_name_i_c": "Bondarenko",
+                    "birth_date": "1985-03-01",
+                    "gender_i_c": "male",
+                    "relationship_i_c": "head",
+                    "role_i_c": "y",
+                    "tax_id_no_i_c": "9876543210",
+                    "wallet_address_i_c": "0x0011223344556677",
+                    "wallet_name_i_c": "Trust",
+                }
+            ],
+        },
+        files=json.dumps({}).encode(),
+    )
+    service = UkraineUSDCRegistrationService(registration)
+    rdi = service.create_rdi(user, "usdc rdi")
+
+    service.process_records(rdi.id, [record.id])
+
+    household = PendingHousehold.objects.get(registration_data_import=rdi)
+    assert household.consent is False
+
+
+def test_individual_full_name_concatenated_and_birth_date_not_estimated(
+    registration: Any,
+    user: Any,
+    ukraine_country: Any,
+    tax_id_document_type: Any,
+    digital_wallet_delivery_mechanism: DeliveryMechanism,
+    usdc_record: Record,
+) -> None:
+    service = UkraineUSDCRegistrationService(registration)
+    rdi = service.create_rdi(user, "usdc rdi")
+
+    service.process_records(rdi.id, [usdc_record.id])
+
+    individual = PendingIndividual.objects.get(registration_data_import=rdi)
+    assert individual.full_name == "Olena Ivanivna Shevchenko"
+    assert str(individual.birth_date) == "1990-05-12"
+    assert individual.estimated_birth_date is False
+
+
+def test_individual_wallet_fields_populated(
+    registration: Any,
+    user: Any,
+    ukraine_country: Any,
+    tax_id_document_type: Any,
+    digital_wallet_delivery_mechanism: DeliveryMechanism,
+    usdc_record: Record,
+) -> None:
+    service = UkraineUSDCRegistrationService(registration)
+    rdi = service.create_rdi(user, "usdc rdi")
+
+    service.process_records(rdi.id, [usdc_record.id])
+
+    individual = PendingIndividual.objects.get(registration_data_import=rdi)
+    assert individual.wallet_address == "0xABCDEF0123456789"
+    assert individual.wallet_name == "MetaMask"
+
+
+def test_wallet_images_stored_as_flex_fields(
+    registration: Any,
+    user: Any,
+    ukraine_country: Any,
+    tax_id_document_type: Any,
+    digital_wallet_delivery_mechanism: DeliveryMechanism,
+    usdc_record: Record,
+) -> None:
+    service = UkraineUSDCRegistrationService(registration)
+    rdi = service.create_rdi(user, "usdc rdi")
+
+    service.process_records(rdi.id, [usdc_record.id])
+
+    individual = PendingIndividual.objects.get(registration_data_import=rdi)
+    assert individual.flex_fields["wallet_num_image_i_f"] == "d2FsbGV0X251bV9pbWFnZQ=="
+    assert individual.flex_fields["id_wallet_image_i_f"] == "aWRfd2FsbGV0X2ltYWdl"
+
+
+def test_creates_only_tax_id_document(
+    registration: Any,
+    user: Any,
+    ukraine_country: Any,
+    tax_id_document_type: Any,
+    digital_wallet_delivery_mechanism: DeliveryMechanism,
+    usdc_record: Record,
+) -> None:
+    service = UkraineUSDCRegistrationService(registration)
+    rdi = service.create_rdi(user, "usdc rdi")
+
+    service.process_records(rdi.id, [usdc_record.id])
+
+    individual = PendingIndividual.objects.get(registration_data_import=rdi)
+    documents = PendingDocument.objects.filter(individual=individual)
+    assert documents.count() == 1
+    assert documents.first().document_number == "1234567890"
+    assert documents.first().type.key == IDENTIFICATION_TYPE_TO_KEY_MAPPING[IDENTIFICATION_TYPE_TAX_ID]
+
+
+def test_wallet_account_created_for_collector(
+    registration: Any,
+    user: Any,
+    ukraine_country: Any,
+    tax_id_document_type: Any,
+    digital_wallet_delivery_mechanism: DeliveryMechanism,
+    generic_crypto_fi: FinancialInstitution,
+    usdc_record: Record,
+) -> None:
+    service = UkraineUSDCRegistrationService(registration)
+    rdi = service.create_rdi(user, "usdc rdi")
+
+    service.process_records(rdi.id, [usdc_record.id])
+
+    individual = PendingIndividual.objects.get(registration_data_import=rdi)
+    account = PendingAccount.objects.get(individual=individual)
+    assert account.account_type == digital_wallet_delivery_mechanism.account_type
+    assert account.number == "0xABCDEF0123456789"
+    assert account.financial_institution == generic_crypto_fi
+    assert account.data == {"wallet_address": "0xABCDEF0123456789", "wallet_name": "MetaMask"}
+
+
+def test_wallet_accounts_created_for_each_individual_with_wallet(
+    registration: Any,
+    user: Any,
+    ukraine_country: Any,
+    tax_id_document_type: Any,
+    digital_wallet_delivery_mechanism: DeliveryMechanism,
+    generic_crypto_fi: FinancialInstitution,
+    submission_timestamp: datetime.datetime,
+) -> None:
+    record = RecordFactory(
+        registration=registration.source_id,
+        timestamp=submission_timestamp,
+        source_id=4,
+        fields={
+            "household": [{"consent_h_c": True}],
+            "individuals": [
+                {
+                    "given_name_i_c": "Olena",
+                    "family_name_i_c": "Shevchenko",
+                    "birth_date": "1990-05-12",
+                    "gender_i_c": "female",
+                    "relationship_i_c": "head",
+                    "role_i_c": "y",
+                    "wallet_address_i_c": "0xAAA1",
+                    "wallet_name_i_c": "MetaMask",
+                },
+                {
+                    "given_name_i_c": "Mykola",
+                    "family_name_i_c": "Shevchenko",
+                    "birth_date": "2010-08-08",
+                    "gender_i_c": "male",
+                    "relationship_i_c": "son_daughter",
+                    "role_i_c": "n",
+                    "wallet_address_i_c": "0xBBB2",
+                    "wallet_name_i_c": "Trust",
+                },
+            ],
+        },
+        files=json.dumps({}).encode(),
+    )
+    service = UkraineUSDCRegistrationService(registration)
+    rdi = service.create_rdi(user, "usdc rdi")
+
+    service.process_records(rdi.id, [record.id])
+
+    accounts = PendingAccount.objects.filter(individual__registration_data_import=rdi)
+    assert accounts.count() == 2
+    assert set(accounts.values_list("number", flat=True)) == {"0xAAA1", "0xBBB2"}
+
+
+def test_import_errors_when_delivery_mechanism_not_configured(
+    registration: Any,
+    user: Any,
+    ukraine_country: Any,
+    tax_id_document_type: Any,
+    usdc_record: Record,
+) -> None:
+    service = UkraineUSDCRegistrationService(registration)
+    rdi = service.create_rdi(user, "usdc rdi")
+
+    service.process_records(rdi.id, [usdc_record.id])
+
+    usdc_record.refresh_from_db()
+    assert usdc_record.status == Record.STATUS_ERROR
+    assert not PendingHousehold.objects.filter(registration_data_import=rdi).exists()
+
+
+def test_no_wallet_account_when_no_wallet_data(
+    registration: Any,
+    user: Any,
+    ukraine_country: Any,
+    tax_id_document_type: Any,
+    digital_wallet_delivery_mechanism: DeliveryMechanism,
+    submission_timestamp: datetime.datetime,
+) -> None:
+    record = RecordFactory(
+        registration=registration.source_id,
+        timestamp=submission_timestamp,
+        source_id=3,
+        fields={
+            "household": [{"consent_h_c": True}],
+            "individuals": [
+                {
+                    "given_name_i_c": "Ivan",
+                    "family_name_i_c": "Kovalenko",
+                    "birth_date": "1970-07-07",
+                    "gender_i_c": "male",
+                    "relationship_i_c": "head",
+                    "role_i_c": "y",
+                    "tax_id_no_i_c": "5555555555",
+                }
+            ],
+        },
+        files=json.dumps({}).encode(),
+    )
+    service = UkraineUSDCRegistrationService(registration)
+    rdi = service.create_rdi(user, "usdc rdi")
+
+    service.process_records(rdi.id, [record.id])
+
+    individual = PendingIndividual.objects.get(registration_data_import=rdi)
+    assert not PendingAccount.objects.filter(individual=individual).exists()
+
+
+def test_role_creates_primary_collector(
+    registration: Any,
+    user: Any,
+    ukraine_country: Any,
+    tax_id_document_type: Any,
+    digital_wallet_delivery_mechanism: DeliveryMechanism,
+    usdc_record: Record,
+) -> None:
+    service = UkraineUSDCRegistrationService(registration)
+    rdi = service.create_rdi(user, "usdc rdi")
+
+    service.process_records(rdi.id, [usdc_record.id])
+
+    household = PendingHousehold.objects.get(registration_data_import=rdi)
+    individual = PendingIndividual.objects.get(registration_data_import=rdi)
+    assert household.head_of_household == individual
+    assert PendingIndividualRoleInHousehold.objects.filter(
+        household=household, individual=individual, role=ROLE_PRIMARY
+    ).exists()

--- a/tests/unit/apps/aurora/test_ukraine_usdc_registration_service.py
+++ b/tests/unit/apps/aurora/test_ukraine_usdc_registration_service.py
@@ -260,7 +260,7 @@ def test_individual_full_name_concatenated_and_birth_date_not_estimated(
     assert individual.estimated_birth_date is False
 
 
-def test_individual_wallet_fields_populated(
+def test_wallet_stored_on_account_not_on_individual(
     registration: Any,
     user: Any,
     ukraine_country: Any,
@@ -274,8 +274,10 @@ def test_individual_wallet_fields_populated(
     service.process_records(rdi.id, [usdc_record.id])
 
     individual = PendingIndividual.objects.get(registration_data_import=rdi)
-    assert individual.wallet_address == "0xABCDEF0123456789"
-    assert individual.wallet_name == "MetaMask"
+    assert individual.wallet_address == ""
+    assert individual.wallet_name == ""
+    account = PendingAccount.objects.get(individual=individual)
+    assert account.data == {"wallet_address": "0xABCDEF0123456789", "wallet_name": "MetaMask"}
 
 
 def test_wallet_images_stored_as_flex_fields(
@@ -440,7 +442,6 @@ def test_no_wallet_account_when_address_missing(
     service.process_records(rdi.id, [record.id])
 
     individual = PendingIndividual.objects.get(registration_data_import=rdi)
-    assert individual.wallet_name == "Trust"
     assert not PendingAccount.objects.filter(individual=individual).exists()
 
 

--- a/tests/unit/apps/payment/test_model_financial_institution.py
+++ b/tests/unit/apps/payment/test_model_financial_institution.py
@@ -20,6 +20,10 @@ def generic_financial_institutions():
             name="IBAN Provider Bank",
             type=FinancialInstitution.FinancialInstitutionType.BANK,
         ),
+        FinancialInstitution.objects.create(
+            name="Generic Crypto",
+            type=FinancialInstitution.FinancialInstitutionType.OTHER,
+        ),
     ]
 
 
@@ -30,6 +34,7 @@ def test_get_generic_one(generic_financial_institutions):
         ("xxx", True, "Generic Bank"),
         ("bank", True, "IBAN Provider Bank"),
         ("bank", False, "Generic Bank"),
+        ("crypto", False, "Generic Crypto"),
     ]
     for account_type, is_valid_iban, expected_fi_name in cases:
         assert FinancialInstitution.get_generic_one(account_type, is_valid_iban).name == expected_fi_name


### PR DESCRIPTION
 [AB#324346](https://unicef.visualstudio.com/4e044e8d-bc28-4768-8074-f80ff6e4a0e5/_workitems/edit/324346)
 Adds UkraineUSDCRegistrationService, the Aurora flex-registration parser for the finalized USDC Ukraine pilot form. It imports a regular (household-based) programme, creating Households + Individuals and, for each individual with a wallet, a PendingAccount so the wallet is payable via the Transfer to Digital Wallet mechanism.
  
  Mapping
- Individual: names + full_name (concatenated), birth_date, estimated_birth_date=False, gender, phone (UA +380), relationship, collector role, wallet_address/wallet_name.
- Household: consent from form, country = UA, first_registration_date = submission date.
- Document: tax id only. Flex fields: wallet_num_image_i_f, id_wallet_image_i_f.

Wallet → payment

Payout reads the collector's Account (by delivery_mechanism.account_type), not the Individual fields — so the wallet is stored in both: the Individual fields (display/grievance) and a PendingAccount. The account type is derived from the transfer_to_digital_wallet delivery mechanism (always matches payout); number = wallet_address, data = {wallet_address, wallet_name}, FI = the generic one for that type.

Supporting changes

- get_generic_one: crypto branch → "Generic Crypto"
- _prepare_documents now reads self.DOCUMENT_MAPPING_KEY_DICT
- Registered the service in aurora/apps.py.
  
  
**Deploy prerequisites:**

1. PG: 

- create the crypto account type → sync_account_types; 
- repoint transfer_to_digital_wallet.account_type → crypto → sync_delivery_mechanisms;
- set the USDC FSP required_fields + FspNameMapping (source=Account, keys wallet_address/wallet_name) → sync_fsps;

2. HOPE: create the "Generic Crypto" FinancialInstitution in the envs

3. Aurora: point the registration's rdi_parser at UkraineUSDCRegistrationService.