### PR TITLE
[326607] Grievance: apply approved household Flex Field changes on ticket close

### DIFF
--- a/src/frontend/src/components/grievances/RequestedHouseholdDataChange.tsx
+++ b/src/frontend/src/components/grievances/RequestedHouseholdDataChange.tsx
@@ -233,12 +233,6 @@ export function RequestedHouseholdDataChange({
               values.selectedFlexFields.includes(key);
           }
         });
-        // Only add flex_fields to householdApproveData if not empty
-        if (Object.keys(flexFieldsApproveData).length > 0) {
-          householdApproveData.flex_fields = flexFieldsApproveData;
-        } else if ('flex_fields' in householdApproveData) {
-          delete householdApproveData.flex_fields;
-        }
         // Roles: add each as roles__<individual_id>: boolean
         householdApproveData.roles = values.selectedRoles.map(
           (individualId) => ({
@@ -250,8 +244,10 @@ export function RequestedHouseholdDataChange({
         // Build mutation payload
         const mutationPayload: {
           householdApproveData: any;
+          flexFieldsApproveData: { [key: string]: boolean };
         } = {
           householdApproveData,
+          flexFieldsApproveData,
         };
 
         try {

--- a/src/hope/apps/grievance/services/data_change/household_data_update_service.py
+++ b/src/hope/apps/grievance/services/data_change/household_data_update_service.py
@@ -168,7 +168,7 @@ class HouseholdDataUpdateService(DataChangeService):
         flex_fields = {
             field: data.get("value")
             for field, data in flex_fields_with_additional_data.items()
-            if isinstance(data, dict) and data.get("approve_status") is True
+            if isinstance(data, dict) and is_approved(data)
         }
         if country_origin.get("value") is not None:
             household_data["country_origin"]["value"] = geo_models.Country.objects.filter(  # type: ignore[index]

--- a/tests/unit/apps/grievance/services/data_change/test_household_data_update_service.py
+++ b/tests/unit/apps/grievance/services/data_change/test_household_data_update_service.py
@@ -480,6 +480,66 @@ def test_update_currency_change_records_previous_value_as_code(all_currencies: N
     }
 
 
+def test_close_applies_approved_flex_field_to_household() -> None:
+    household = HouseholdFactory(create_role=False, flex_fields={"existing_flex": "keep"})
+    ticket_details = TicketHouseholdDataUpdateDetailsFactory(
+        household=household,
+        household_data={
+            "flex_fields": {
+                "test_h_f": {"value": "new value", "approve_status": True, "previous_value": None},
+            },
+        },
+    )
+    ticket = ticket_details.ticket
+    ticket.save()
+
+    service = HouseholdDataUpdateService(ticket, {})
+    service.close(UserFactory())
+    household.refresh_from_db()
+
+    assert household.flex_fields == {"existing_flex": "keep", "test_h_f": "new value"}
+
+
+def test_close_applies_flex_field_approved_with_string_status() -> None:
+    household = HouseholdFactory(create_role=False, flex_fields={})
+    ticket_details = TicketHouseholdDataUpdateDetailsFactory(
+        household=household,
+        household_data={
+            "flex_fields": {
+                "test_h_f": {"value": "new value", "approve_status": "true", "previous_value": None},
+            },
+        },
+    )
+    ticket = ticket_details.ticket
+    ticket.save()
+
+    service = HouseholdDataUpdateService(ticket, {})
+    service.close(UserFactory())
+    household.refresh_from_db()
+
+    assert household.flex_fields == {"test_h_f": "new value"}
+
+
+def test_close_skips_unapproved_flex_field() -> None:
+    household = HouseholdFactory(create_role=False, flex_fields={})
+    ticket_details = TicketHouseholdDataUpdateDetailsFactory(
+        household=household,
+        household_data={
+            "flex_fields": {
+                "test_h_f": {"value": "new value", "approve_status": False, "previous_value": None},
+            },
+        },
+    )
+    ticket = ticket_details.ticket
+    ticket.save()
+
+    service = HouseholdDataUpdateService(ticket, {})
+    service.close(UserFactory())
+    household.refresh_from_db()
+
+    assert household.flex_fields == {}
+
+
 def test_close_resolves_currency_from_code(all_currencies) -> None:
     household = HouseholdFactory(create_role=False, currency=None)
     ticket_details = TicketHouseholdDataUpdateDetailsFactory(


### PR DESCRIPTION
[AB#326607](https://unicef.visualstudio.com/4e044e8d-bc28-4768-8074-f80ff6e4a0e5/_workitems/edit/326607) 
 
  ## Problem                                                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                             
  Approving a Flex Field change on a Household Data Update grievance had no effect —                                                                                                                                                                                                                                         
  the change could be approved and the ticket closed, but the value was never written                                                                                                                                                                                                                                        
  to the household. Regression from the GraphQL → REST migration.                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                             
  ## Fix                                                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                             
The frontend nested flex-field approvals under `householdApproveData.flex_fields`,                                                                                                                                                                                                                                         
  but the endpoint reads them from a separate top-level `flex_fields_approve_data`                                                                                                                                                                                                                                           
  param, so approvals never reached the backend. Fixed in                                                                                                                                                                                                                                                                    
  `RequestedHouseholdDataChange.tsx` by sending `flexFieldsApproveData` as a top-level                                                                                                                                                                                                                                       
  field of the approve payload (matching the individual-data-change flow), and dropping                                                                                                                                                                                                                                      
  the now-unnecessary "only if not empty" guard.                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                             
  Also aligned the flex-field approval check in `household_data_update_service.py` with                                                                                                                                                                                                                                      
  the rest of `close()` for consistency — not a bug fix.  