### PR TITLE
feat(household): es shadow-cluster delta sync + change-stream tools (master)

### DIFF
--- a/src/hope/apps/household/management/commands/README.md
+++ b/src/hope/apps/household/management/commands/README.md
@@ -1,0 +1,89 @@
+# ES 8 → ES 9 shadow-cluster migration runbook
+
+Zero-ish-downtime cutover from the ES 8 (Bitnami) cluster to a fresh ES 9 cluster.
+
+The trick: bulk-copy ES 8 → ES 9 up front, then keep catching ES 9 up to Postgres with an
+**incremental, DB-based delta** while the app still serves from ES 8. When ES 9 is within seconds
+of the DB, flip the backend to ES 9 and run one final delta to close the last gap.
+
+
+**Two pods, two ES targets** (from `reindex-delta.yml` / `mutate-data.yml`):
+
+- `adhoc-reindex-delta` overrides `ELASTICSEARCH_HOST` → ES 9 (`hope-es-search-master:9200`), so its
+  `default` connection writes to ES 9. **The delta runs here.** No alias to pass — just `--since ...`;
+  the command prints host + ES version on startup so you can confirm ES 9 before anything writes.
+- `adhoc-mutate-data` does **not** override it → its `default` is ES 8 (the app cluster). **The
+  generator runs here**, so its `post_save` signal writes land in ES 8, not ES 9 — ES 9 is touched
+  only by the delta. That isolation is the whole point: it proves the delta, not the signals.
+
+## Steps
+
+| # | Step | Owner | Env | What |
+|---|------|-------|-----|------|
+| 1 | Initial state | Valeriya | rehearsal only | ES 8 populated from the DB (ES is empty after a dump restore), backend/Celery point at ES 8, empty ES 9 ready. On the real cutover ES 8 is already populated — no dump-restore step there. |
+| 2 | Bulk copy ES 8 → ES 9 | Valeriya | both | `copy-job.yaml` runs `es_migrate.py`. Note its **start time `T0`** — the first `--since` for the delta. |
+| 3 | Generate a change stream | Jan | rehearsal only | On `adhoc-mutate-data`, run `es_mutate_stream`. Realistic logged stream to prove the delta shrinks each pass. On the real cutover, live traffic is the stream — skip. |
+| 4 | Delta catch-up  | Jan | both | On `adhoc-reindex-delta` (`default` = ES 9), run `es_populate_delta --since <T>` |
+| 5 | Scale Celery to 0 | Valeriya | both | Blocks dedup, no code change. Web still writes to ES via HOPE's `post_save` signals — harmless: before switch → ES 8, after → ES 9. Search slightly stale for minutes, acceptable. |
+| 6 | Switch backend/Celery to ES 9 | Valeriya | both | Flip the app's ES connection to ES 9. |
+| 7 | Final delta | Jan | both | Immediately re-run `es_populate_delta --since <start of the last pass from step 4>`. Catches everything written to ES 8 in the gap between the last delta and the switch. |
+| 8 | Scale Celery back up | Valeriya | both | Restore workers. |
+
+## Tooling (this directory)
+
+| File | Owner | What |
+|------|-------|------|
+| `es8_to_es9_migration/es_migrate.py` + `copy-job.yaml` | Valeriya | Bulk ES 8 → ES 9 copy (raw-HTTP, idempotent by `_id`). |
+| `es_populate_delta.py` | Jan | Incremental DB → ES 9 catch-up. Loops in-scope programs, upserts only changed docs, deletes soft-removed docs by `_id`, full-populates only programs whose index does not exist. Never deletes an index. |
+| `es_mutate_stream.py` | Jan | **Ephemeral rehearsal only.** Mutates households/individuals in a loop (`given_name`, household `residence_status`, soft-deletes) and logs every change to JSONL so ES output can be asserted against it. |
+| `reindex-delta.yml` | Jan | Pod `adhoc-reindex-delta`, `ELASTICSEARCH_HOST` → ES 9. |
+| `mutate-data.yml` | Jan | Pod `adhoc-mutate-data`, `default` = ES 8 (rehearsal only). |
+
+## Commands
+
+### Deploy the command files (generator → mutate pod, delta → delta pod)
+
+Management commands are picked up from any installed app's `management/commands/`, so drop Jan's
+files under `core` in each pod. Run from the repo root:
+
+```bash
+kubectl cp src/hope/apps/household/management/commands/es_mutate_stream.py \
+  adhoc-mutate-data:/app/.venv/lib/python3.14/site-packages/hope/apps/core/management/commands/es_mutate_stream.py
+
+kubectl cp src/hope/apps/household/management/commands/es_populate_delta.py \
+  adhoc-reindex-delta:/app/.venv/lib/python3.14/site-packages/hope/apps/core/management/commands/es_populate_delta.py
+```
+
+### Step 3 — generate changes (rehearsal only, on `adhoc-mutate-data` → ES 8)
+
+```bash
+# continuous stream (Ctrl+C to stop); log is flushed per record
+kubectl exec -it adhoc-mutate-data -- \
+  django-admin es_mutate_stream --passes 1 --batch 500 --delete-every 0 --sleep 0 --log /tmp/mutate_log.jsonl
+```
+
+### Step 4 & 7 — delta catch-up (on `adhoc-reindex-delta` → ES 9)
+
+`--since` is a plain ISO-8601 UTC timestamp — pass it literally. The first pass uses `T0`, the
+bulk-copy start time (example below: `2026-07-08T12:00:50Z`).
+
+```bash
+# dry-run first: per-program delta, no writes
+kubectl exec -it adhoc-reindex-delta -- \
+  django-admin es_populate_delta --since 2026-07-08T12:00:50Z --dry-run
+
+# real pass
+kubectl exec -it adhoc-reindex-delta -- \
+  django-admin es_populate_delta --since 2026-07-08T12:00:50Z --parallel --threads 8
+```
+
+
+For step 7, `--since` = the time you noted for the **last** step-4 pass. Each run prints the target
+cluster + ES version up front (confirm ES 9), then per program:
+`[n/total] <code> id=...: <status> -- ind +N/-M hh +N/-M`.
+
+### Read-only drift check (any time)
+
+```bash
+kubectl exec -it adhoc-reindex-delta -- django-admin es_populate_delta --reconcile
+```

--- a/src/hope/apps/household/management/commands/README.md
+++ b/src/hope/apps/household/management/commands/README.md
@@ -23,11 +23,14 @@ of the DB, flip the backend to ES 9 and run one final delta to close the last ga
 | 1 | Initial state | Valeriya | rehearsal only | ES 8 populated from the DB (ES is empty after a dump restore), backend/Celery point at ES 8, empty ES 9 ready. On the real cutover ES 8 is already populated — no dump-restore step there. |
 | 2 | Bulk copy ES 8 → ES 9 | Valeriya | both | `copy-job.yaml` runs `es_migrate.py`. Note its **start time `T0`** — the first `--since` for the delta. |
 | 3 | Generate a change stream | Jan | rehearsal only | On `adhoc-mutate-data`, run `es_mutate_stream`. Realistic logged stream to prove the delta shrinks each pass. On the real cutover, live traffic is the stream — skip. |
-| 4 | Delta catch-up  | Jan | both | On `adhoc-reindex-delta` (`default` = ES 9), run `es_populate_delta --since <T>` |
-| 5 | Scale Celery to 0 | Valeriya | both | Blocks dedup, no code change. Web still writes to ES via HOPE's `post_save` signals — harmless: before switch → ES 8, after → ES 9. Search slightly stale for minutes, acceptable. |
-| 6 | Switch backend/Celery to ES 9 | Valeriya | both | Flip the app's ES connection to ES 9. |
-| 7 | Final delta | Jan | both | Immediately re-run `es_populate_delta --since <start of the last pass from step 4>`. Catches everything written to ES 8 in the gap between the last delta and the switch. |
-| 8 | Scale Celery back up | Valeriya | both | Restore workers. |
+| 4 | Delta catch-up | Jan | both | On `adhoc-reindex-delta` (`default` = ES 9), run `es_populate_delta --since <T>`. Repeat with the previous pass's start time until the reported delta is small. |
+| 5 | Pause deployment | Jan | both | Freeze auto-deploy so nothing ships into the cutover window. |
+| 6 | Merge [#6174](https://github.com/unicef/hope/pull/6174) | Jan | both | ES 9 client code (master backport) onto the target so backend/Celery can talk to ES 9. |
+| 7 | Scale Celery to 0 | Valeriya | both | Blocks dedup, no code change. Web still writes to ES via HOPE's `post_save` signals — harmless: before switch → ES 8, after → ES 9. Search slightly stale for minutes, acceptable. |
+| 8 | Switch backend/Celery to ES 9 | Valeriya | both | Flip the app's ES connection to ES 9. |
+| 9 | Final delta | Jan | both | Immediately re-run `es_populate_delta --since <start of the last step-4 pass>`. Catches everything written to ES 8 in the gap between the last delta and the switch. |
+| 10 | Scale Celery back up | Valeriya | both | Restore workers. |
+| 11 | Resume deployment | Jan | both | Unfreeze auto-deploy once the cutover is verified. |
 
 ## Tooling (this directory)
 
@@ -62,7 +65,7 @@ kubectl exec -it adhoc-mutate-data -- \
   django-admin es_mutate_stream --passes 1 --batch 500 --delete-every 0 --sleep 0 --log /tmp/mutate_log.jsonl
 ```
 
-### Step 4 & 7 — delta catch-up (on `adhoc-reindex-delta` → ES 9)
+### Step 4 & 9 — delta catch-up (on `adhoc-reindex-delta` → ES 9)
 
 `--since` is a plain ISO-8601 UTC timestamp — pass it literally. The first pass uses `T0`, the
 bulk-copy start time (example below: `2026-07-08T12:00:50Z`).
@@ -78,7 +81,7 @@ kubectl exec -it adhoc-reindex-delta -- \
 ```
 
 
-For step 7, `--since` = the time you noted for the **last** step-4 pass. Each run prints the target
+For step 9, `--since` = the time you noted for the **last** step-4 pass. Each run prints the target
 cluster + ES version up front (confirm ES 9), then per program:
 `[n/total] <code> id=...: <status> -- ind +N/-M hh +N/-M`.
 

--- a/src/hope/apps/household/management/commands/README.md
+++ b/src/hope/apps/household/management/commands/README.md
@@ -18,20 +18,20 @@ of the DB, flip the backend to ES 9 and run one final delta to close the last ga
 
 ## Steps
 
-| # | Step | Owner | Env | What |
-|---|------|-------|-----|------|
+| # | Step | Owner | Env | What                                                                                                                                                                                       |
+|---|------|-------|-----|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | 1 | Initial state | Valeriya | rehearsal only | ES 8 populated from the DB (ES is empty after a dump restore), backend/Celery point at ES 8, empty ES 9 ready. On the real cutover ES 8 is already populated — no dump-restore step there. |
-| 2 | Bulk copy ES 8 → ES 9 | Valeriya | both | `copy-job.yaml` runs `es_migrate.py`. Note its **start time `T0`** — the first `--since` for the delta. |
-| 3 | Generate a change stream | Jan | rehearsal only | On `adhoc-mutate-data`, run `es_mutate_stream`. Realistic logged stream to prove the delta shrinks each pass. On the real cutover, live traffic is the stream — skip. |
-| 4 | Delta catch-up | Jan | both | On `adhoc-reindex-delta` (`default` = ES 9), run `es_populate_delta --since <T>`. |
-| 5 | Pause deployment | Jan | both | Freeze auto-deploy so nothing ships into the cutover window. |
-| 6 | Merge [#6174](https://github.com/unicef/hope/pull/6174) | Jan | both | ES 9 client code (master backport) onto the target so backend/Celery can talk to ES 9. |
-| 7 | Scale Celery to 0 | Valeriya | both | Blocks dedup, no code change. Web still writes to ES via HOPE's `post_save` signals — harmless: before switch → ES 8, after → ES 9. Search slightly stale for minutes, acceptable. |
-| 8 | Delta catch-up | Jan | both | On `adhoc-reindex-delta` (`default` = ES 9), run `es_populate_delta --since <start of last pass from step 4>`. |
-| 9 | Resume deployment | Jan | both | Unfreeze auto-deploy. |
-| 10 | Switch backend/Celery to ES 9 | Valeriya | both | Flip the app's ES connection to ES 9. |
-| 11 | Final delta | Jan | both | Immediately re-run `es_populate_delta --since <start of the last pass from step 4>`. Catches everything written to ES 8 in the gap between the last delta and the switch. |
-| 12 | Scale Celery back up | Valeriya | both | Restore workers. |
+| 2 | Bulk copy ES 8 → ES 9 | Valeriya | both | `copy-job.yaml` runs `es_migrate.py`. Note its **start time `T0`** — the first `--since` for the delta.                                                                                    |
+| 3 | Generate a change stream | Jan | rehearsal only | On `adhoc-mutate-data`, run `es_mutate_stream`. Realistic logged stream to prove the delta shrinks each pass. On the real cutover, live traffic is the stream — skip.                      |
+| 4 | Delta catch-up | Jan | both | On `adhoc-reindex-delta` (`default` = ES 9), run `es_populate_delta --since <T>`.                                                                                                          |
+| 5 | Pause deployment | Jan | both | Freeze auto-deploy so nothing ships into the cutover window.                                                                                                                               |
+| 6 | Merge [#6174](https://github.com/unicef/hope/pull/6174) | Jan | both | ES 9 client code (master backport) onto the target so backend/Celery can talk to ES 9. Wait for CI to pass                                                                                 |
+| 7 | Scale Celery to 0 | Valeriya | both | Blocks dedup, no code change. Web still writes to ES via HOPE's `post_save` signals — harmless: before switch → ES 8, after → ES 9. Search slightly stale for minutes, acceptable.         |
+| 8 | Delta catch-up | Jan | both | On `adhoc-reindex-delta` (`default` = ES 9), run `es_populate_delta --since <start of last pass from step 4>`.                                                                             |
+| 9 | Resume deployment | Jan | both | Unfreeze auto-deploy.                                                                                                                                                                      |
+| 10 | Switch backend/Celery to ES 9 | Valeriya | both | Flip the app's ES connection to ES 9.                                                                                                                                                      |
+| 11 | Final delta | Jan | both | Immediately re-run `es_populate_delta --since <start of the last pass from step 4>`. Catches everything written to ES 8 in the gap between the last delta and the switch.                  |
+| 12 | Scale Celery back up | Valeriya | both | Restore workers.                                                                                                                                                                           |
 
 ## Tooling (this directory)
 

--- a/src/hope/apps/household/management/commands/README.md
+++ b/src/hope/apps/household/management/commands/README.md
@@ -23,14 +23,15 @@ of the DB, flip the backend to ES 9 and run one final delta to close the last ga
 | 1 | Initial state | Valeriya | rehearsal only | ES 8 populated from the DB (ES is empty after a dump restore), backend/Celery point at ES 8, empty ES 9 ready. On the real cutover ES 8 is already populated — no dump-restore step there. |
 | 2 | Bulk copy ES 8 → ES 9 | Valeriya | both | `copy-job.yaml` runs `es_migrate.py`. Note its **start time `T0`** — the first `--since` for the delta. |
 | 3 | Generate a change stream | Jan | rehearsal only | On `adhoc-mutate-data`, run `es_mutate_stream`. Realistic logged stream to prove the delta shrinks each pass. On the real cutover, live traffic is the stream — skip. |
-| 4 | Delta catch-up | Jan | both | On `adhoc-reindex-delta` (`default` = ES 9), run `es_populate_delta --since <T>`. Repeat with the previous pass's start time until the reported delta is small. |
+| 4 | Delta catch-up | Jan | both | On `adhoc-reindex-delta` (`default` = ES 9), run `es_populate_delta --since <T>`. |
 | 5 | Pause deployment | Jan | both | Freeze auto-deploy so nothing ships into the cutover window. |
 | 6 | Merge [#6174](https://github.com/unicef/hope/pull/6174) | Jan | both | ES 9 client code (master backport) onto the target so backend/Celery can talk to ES 9. |
 | 7 | Scale Celery to 0 | Valeriya | both | Blocks dedup, no code change. Web still writes to ES via HOPE's `post_save` signals — harmless: before switch → ES 8, after → ES 9. Search slightly stale for minutes, acceptable. |
-| 8 | Switch backend/Celery to ES 9 | Valeriya | both | Flip the app's ES connection to ES 9. |
-| 9 | Final delta | Jan | both | Immediately re-run `es_populate_delta --since <start of the last step-4 pass>`. Catches everything written to ES 8 in the gap between the last delta and the switch. |
-| 10 | Scale Celery back up | Valeriya | both | Restore workers. |
-| 11 | Resume deployment | Jan | both | Unfreeze auto-deploy once the cutover is verified. |
+| 8 | Delta catch-up | Jan | both | On `adhoc-reindex-delta` (`default` = ES 9), run `es_populate_delta --since <start of last pass from step 4>`. |
+| 9 | Resume deployment | Jan | both | Unfreeze auto-deploy. |
+| 10 | Switch backend/Celery to ES 9 | Valeriya | both | Flip the app's ES connection to ES 9. |
+| 11 | Final delta | Jan | both | Immediately re-run `es_populate_delta --since <start of the last pass from step 4>`. Catches everything written to ES 8 in the gap between the last delta and the switch. |
+| 12 | Scale Celery back up | Valeriya | both | Restore workers. |
 
 ## Tooling (this directory)
 
@@ -65,7 +66,7 @@ kubectl exec -it adhoc-mutate-data -- \
   django-admin es_mutate_stream --passes 1 --batch 500 --delete-every 0 --sleep 0 --log /tmp/mutate_log.jsonl
 ```
 
-### Step 4 & 9 — delta catch-up (on `adhoc-reindex-delta` → ES 9)
+### Steps 4 & 8 — delta catch-up (on `adhoc-reindex-delta` → ES 9)
 
 `--since` is a plain ISO-8601 UTC timestamp — pass it literally. The first pass uses `T0`, the
 bulk-copy start time (example below: `2026-07-08T12:00:50Z`).
@@ -81,7 +82,7 @@ kubectl exec -it adhoc-reindex-delta -- \
 ```
 
 
-For step 9, `--since` = the time you noted for the **last** step-4 pass. Each run prints the target
+For step 11 (final delta), `--since` = the time you noted for the **last** catch-up pass. Each run prints the target
 cluster + ES version up front (confirm ES 9), then per program:
 `[n/total] <code> id=...: <status> -- ind +N/-M hh +N/-M`.
 

--- a/src/hope/apps/household/management/commands/_es_shadow.py
+++ b/src/hope/apps/household/management/commands/_es_shadow.py
@@ -1,0 +1,22 @@
+"""Register the `v9` ES9 shadow-cluster connection from ELASTICSEARCH_HOST_V9.
+
+Keeps the shadow wiring next to the migration commands instead of in core
+settings (config/fragments/es.py); no-op if the env var is unset. On master the
+delta runs on the `default` connection (ELASTICSEARCH_HOST), so this helper is
+not wired into es_populate_delta -- kept only for a multi-alias shadow setup.
+"""
+
+import os
+
+from django.conf import settings
+from elasticsearch_dsl import connections
+
+
+def register_shadow_connection(alias: str = "v9", env_var: str = "ELASTICSEARCH_HOST_V9") -> bool:
+    """Add `alias` to ELASTICSEARCH_DSL + the connections registry at runtime. True if registered."""
+    host = os.environ.get(env_var, "").strip()
+    if not host:
+        return False
+    settings.ELASTICSEARCH_DSL.setdefault(alias, {"hosts": host, "request_timeout": 30})
+    connections.configure(**settings.ELASTICSEARCH_DSL)
+    return True

--- a/src/hope/apps/household/management/commands/es8_to_es9_migration/copy-job.yaml
+++ b/src/hope/apps/household/management/commands/es8_to_es9_migration/copy-job.yaml
@@ -1,0 +1,32 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: es-copy-job
+  namespace: ictd-hope-eph-1
+  labels: {rehearsal: copy}
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels: {rehearsal: copy}
+    spec:
+      restartPolicy: Never
+      serviceAccountName: core
+      containers:
+        - name: copy
+          image: unicef/hope-support-images:core-62c6b84092b74eec335918fb5f80586c31c0180a
+          command: ["bash", "-c", "cd /scripts && python3 es_migrate.py"]
+          env:
+            - {name: SRC, value: "http://hope-elasticsearch:9200"}
+            - {name: DST, value: "http://hope-es-search-master:9200"}
+            - {name: CONC, value: "6"}
+            - {name: SCROLL_SIZE, value: "2000"}
+            - {name: INDEX_GLOB, value: "households_*,individuals_*"}
+          volumeMounts:
+            - {name: scripts, mountPath: /scripts}
+          resources:
+            requests: {cpu: 100m, memory: 512Mi}
+            limits: {cpu: "2", memory: 1536Mi}
+      volumes:
+        - name: scripts
+          configMap: {name: mig-scripts}

--- a/src/hope/apps/household/management/commands/es8_to_es9_migration/es_migrate.py
+++ b/src/hope/apps/household/management/commands/es8_to_es9_migration/es_migrate.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Migrate HOPE indices from cluster A (ES8) -> cluster B (ES9).
+
+Raw HTTP (stdlib only) so it talks to ES8 (read) and ES9 (write) with plain
+JSON — no client version / compat-header issues. Idempotent: bulk index by _id,
+so re-running only overwrites/adds (delta pass).
+
+Env:
+  SRC          source base url   (default cluster A: http://hope-elasticsearch:9200)
+  DST          dest base url     (default cluster B: http://hope-es-search:9200)
+  CONC         parallel indices  (default 6)
+  SCROLL_SIZE  docs per scroll   (default 2000)
+  INDEX_GLOB   comma globs        (default households_*,individuals_*)
+"""
+
+from concurrent.futures import ThreadPoolExecutor, as_completed
+import contextlib
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+
+SRC = os.environ.get("SRC", "http://hope-elasticsearch:9200").rstrip("/")
+DST = os.environ.get("DST", "http://hope-es-search:9200").rstrip("/")
+CONC = int(os.environ.get("CONC", "6"))
+SCROLL_SIZE = int(os.environ.get("SCROLL_SIZE", "2000"))
+INDEX_GLOB = os.environ.get("INDEX_GLOB", "households_*,individuals_*")
+
+
+def req(method, url, data=None, ndjson=False):
+    headers = {"Content-Type": "application/x-ndjson" if ndjson else "application/json"}
+    body = None
+    if data is not None:
+        body = data.encode() if isinstance(data, str) else json.dumps(data).encode()
+    r = urllib.request.Request(url, data=body, method=method, headers=headers)
+    with urllib.request.urlopen(r, timeout=180) as resp:
+        raw = resp.read()
+        return json.loads(raw) if raw else {}
+
+
+def strip_boost(obj):
+    """ES9 removed the `boost` mapping param — remove it recursively."""
+    if isinstance(obj, dict):
+        obj.pop("boost", None)
+        for v in obj.values():
+            strip_boost(v)
+    elif isinstance(obj, list):
+        for v in obj:
+            strip_boost(v)
+    return obj
+
+
+def list_indices(base, globs):
+    out = []
+    for g in globs.split(","):
+        g = g.strip()
+        try:
+            data = req("GET", f"{base}/_cat/indices/{g}?h=index&format=json")
+            out += [d["index"] for d in data]
+        except urllib.error.HTTPError as e:
+            if e.code != 404:
+                raise
+    return sorted({i for i in out if not i.startswith(".")})
+
+
+def create_dest_index(index):
+    meta = req("GET", f"{SRC}/{index}")[index]
+    mappings = strip_boost(meta.get("mappings", {}) or {})
+    src_idx = (meta.get("settings", {}) or {}).get("index", {}) or {}
+    settings = {"number_of_shards": src_idx.get("number_of_shards", "1"), "number_of_replicas": "0"}
+    if "analysis" in src_idx:  # carry over custom/phonetic analyzers
+        settings["analysis"] = src_idx["analysis"]
+    body = {"settings": {"index": settings}, "mappings": mappings}
+    try:
+        req("PUT", f"{DST}/{index}", body)
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode(errors="replace")
+        if e.code == 400 and "resource_already_exists" in detail:
+            return
+        raise RuntimeError(f"create {index} failed: {e.code} {detail[:200]}")
+
+
+def migrate_index(index):
+    t0 = time.time()
+    create_dest_index(index)
+    total = 0
+    r = req(
+        "POST", f"{SRC}/{index}/_search?scroll=5m", {"size": SCROLL_SIZE, "query": {"match_all": {}}, "sort": ["_doc"]}
+    )
+    sid = r.get("_scroll_id")
+    hits = r["hits"]["hits"]
+    while hits:
+        lines = []
+        for h in hits:
+            lines.append(json.dumps({"index": {"_index": index, "_id": h["_id"]}}))
+            lines.append(json.dumps(h["_source"]))
+        resp = req("POST", f"{DST}/_bulk", "\n".join(lines) + "\n", ndjson=True)
+        if resp.get("errors"):
+            for it in resp["items"]:
+                err = it.get("index", {}).get("error")
+                if err:
+                    return index, total, time.time() - t0, "BULK_ERR:" + json.dumps(err)[:160]
+        total += len(hits)
+        r = req("POST", f"{SRC}/_search/scroll", {"scroll": "5m", "scroll_id": sid})
+        sid = r.get("_scroll_id")
+        hits = r["hits"]["hits"]
+    with contextlib.suppress(Exception):
+        req("DELETE", f"{SRC}/_search/scroll", {"scroll_id": [sid]})
+    return index, total, time.time() - t0, "OK"
+
+
+def main():
+    indices = list_indices(SRC, INDEX_GLOB)
+    time.time()
+    grand = done = fails = 0
+    with ThreadPoolExecutor(max_workers=CONC) as ex:
+        futs = {ex.submit(migrate_index, i): i for i in indices}
+        for f in as_completed(futs):
+            idx = futs[f]
+            try:
+                idx, total, el, status = f.result()
+            except Exception:
+                done += 1
+                fails += 1
+                continue
+            grand += total
+            done += 1
+            if status != "OK":
+                fails += 1
+
+
+if __name__ == "__main__":
+    main()

--- a/src/hope/apps/household/management/commands/es_mutate_stream.py
+++ b/src/hope/apps/household/management/commands/es_mutate_stream.py
@@ -1,0 +1,152 @@
+"""Continuously mutate households/individuals to produce a realistic change stream.
+
+A dev/test companion to ``es_populate_delta``: run it while the delta command catches up a shadow
+cluster and each pass bumps ``updated_at`` on a random sample, so re-running ``--since <start>``
+should report a shrinking number of programs as the delta converges.
+
+Every mutation is appended to a JSONL log (one JSON object per line) with the exact ids and the
+before/after value, so ES output can be asserted against it afterwards::
+
+    {"ts": "...", "action": "update", "model": "Individual", "object_id": "<uuid>",
+     "individual_id": "<uuid>", "household_id": "<uuid|null>",
+     "individual_unicef_id": "IND-...", "household_unicef_id": "HH-...|null",
+     "field": "given_name", "old": "Anna", "new": "Anna#4821"}
+
+For Household mutations the individual side is left null (a household change has no single
+individual). Read the log back with::
+
+    [json.loads(line) for line in open("mutate_log.jsonl")]
+
+Examples
+--------
+    python manage.py es_mutate_stream                          # forever, 3s between passes
+    python manage.py es_mutate_stream --sleep 5 --batch 3 --passes 20
+    python manage.py es_mutate_stream --delete-every 0         # no soft-deletes
+    python manage.py es_mutate_stream --log /tmp/run1.jsonl
+
+"""
+
+import json
+import random
+import time
+from typing import IO, Any
+import uuid
+
+from django.core.management.base import BaseCommand
+from django.db.models import QuerySet
+from django.utils import timezone
+
+from hope.models import Household, Individual
+
+
+class Command(BaseCommand):
+    help = "Continuously mutate households/individuals to feed es_populate_delta (dev/test tool)."
+
+    # residence_status is embedded in HouseholdDocument, so its change is verifiable in ES (unlike size).
+    RESIDENCE_STATUSES = ("IDP", "IDP_RETURNEE", "REFUGEE", "OTHERS_OF_CONCERN", "HOST", "NON_HOST", "RETURNEE")
+
+    def add_arguments(self, parser: Any) -> None:
+        parser.add_argument("--sleep", type=float, default=3.0, help="Seconds between passes.")
+        parser.add_argument("--batch", type=int, default=5, help="Records touched per model per pass.")
+        parser.add_argument("--passes", type=int, default=0, help="Number of passes (0 = forever).")
+        parser.add_argument(
+            "--delete-every", type=int, default=10, help="Soft-delete 1 individual every N passes (0 = off)."
+        )
+        parser.add_argument("--log", default="mutate_log.jsonl", help="JSONL log path (appended, never clobbered).")
+
+    def handle(self, *args: Any, **opts: Any) -> None:
+        ind_total = Individual.all_merge_status_objects.count()
+        hh_total = Household.objects.count()
+        self.stdout.write(f"start: individuals={ind_total} households={hh_total} -> log={opts['log']} (Ctrl+C stops)")
+        if ind_total == 0 and hh_total == 0:
+            self.stdout.write(self.style.WARNING("nothing to mutate (empty DB) -- seed some data first."))
+            return
+
+        fh = open(opts["log"], "a", encoding="utf-8")  # noqa: SIM115  # kept open across the loop
+        i = 0
+        try:
+            while opts["passes"] == 0 or i < opts["passes"]:
+                i += 1
+                try:
+                    ni = self._touch_individuals(opts["batch"], fh)
+                    nh = self._touch_households(opts["batch"], fh)
+                    extra = ""
+                    if opts["delete_every"] and i % opts["delete_every"] == 0:
+                        uid = self._soft_delete_one(fh)
+                        extra = f", soft-deleted {uid}" if uid else ""
+                    stamp = timezone.now().isoformat(timespec="seconds")
+                    self.stdout.write(f"[{stamp}] pass {i}: touched {ni} ind / {nh} hh{extra}")
+                except Exception as e:  # noqa: BLE001  # pragma: no cover  # keep loop alive on transient error
+                    self.stdout.write(self.style.ERROR(f"pass {i}: error, continuing -- {e}"))
+                time.sleep(opts["sleep"])
+        except KeyboardInterrupt:  # pragma: no cover
+            self.stdout.write(f"\nstopped at pass {i}. log: {opts['log']}")
+        finally:
+            fh.close()
+
+    @staticmethod
+    def _random_window(qs: QuerySet, n: int) -> list:
+        # order_by("?") is ORDER BY RANDOM() -> full-table sort (deadly on 12M rows).
+        # UUID pk is indexed: seek from a random uuid, wrap around if it lands near the end.
+        pivot = uuid.uuid4()
+        rows = list(qs.filter(pk__gte=pivot).order_by("pk")[:n])
+        if len(rows) < n:
+            rows += list(qs.filter(pk__lt=pivot).order_by("pk")[: n - len(rows)])
+        return rows
+
+    @staticmethod
+    def _write(fh: IO[str], record: dict) -> None:
+        fh.write(json.dumps(record, ensure_ascii=False, default=str) + "\n")
+        fh.flush()  # crash-safe: every mutation is on disk before the next one
+
+    @staticmethod
+    def _record(  # noqa: PLR0913
+        action: str, model: str, ind: Individual | None, hh: Household | None, field: str, old: Any, new: Any
+    ) -> dict:
+        return {
+            "ts": timezone.now().isoformat(timespec="seconds"),
+            "action": action,
+            "model": model,
+            "object_id": str(ind.id if model == "Individual" else hh.id),
+            "individual_id": str(ind.id) if ind else None,
+            "household_id": str(hh.id) if hh else None,
+            "individual_unicef_id": ind.unicef_id if ind else None,
+            "household_unicef_id": hh.unicef_id if hh else None,
+            "field": field,
+            "old": old,
+            "new": new,
+        }
+
+    @classmethod
+    def _touch_individuals(cls, n: int, fh: IO[str]) -> int:
+        inds = cls._random_window(Individual.all_merge_status_objects.select_related("household"), n)
+        for ind in inds:
+            old = ind.given_name
+            ind.given_name = f"{(old or 'Name').split('#')[0]}#{random.randint(1000, 9999)}"  # noqa: S311
+            # updated_at must be listed: Django does NOT auto-add auto_now fields to
+            # update_fields, and es_populate_delta --since keys off updated_at.
+            ind.save(update_fields=["given_name", "updated_at"])
+            cls._write(fh, cls._record("update", "Individual", ind, ind.household, "given_name", old, ind.given_name))
+        return len(inds)
+
+    @classmethod
+    def _touch_households(cls, n: int, fh: IO[str]) -> int:
+        hhs = cls._random_window(Household.objects.all(), n)
+        for hh in hhs:
+            old = hh.residence_status
+            new = random.choice([s for s in cls.RESIDENCE_STATUSES if s != old])  # noqa: S311  # embedded in ES doc
+            hh.residence_status = new
+            hh.save(update_fields=["residence_status", "updated_at"])  # list updated_at (see _touch_individuals)
+            cls._write(fh, cls._record("update", "Household", None, hh, "residence_status", old, new))  # ind side N/A
+        return len(hhs)
+
+    @classmethod
+    def _soft_delete_one(cls, fh: IO[str]) -> str | None:
+        rows = cls._random_window(Individual.all_merge_status_objects.select_related("household"), 1)
+        if not rows:  # pragma: no cover
+            return None
+        ind = rows[0]
+        hh = ind.household
+        ind.delete()  # SoftDeletableMergeStatusModel -> soft=True by default
+        cls._write(fh, cls._record("soft_delete", "Individual", ind, hh, "is_removed", False, True))
+        return ind.unicef_id

--- a/src/hope/apps/household/management/commands/es_populate_delta.py
+++ b/src/hope/apps/household/management/commands/es_populate_delta.py
@@ -1,0 +1,413 @@
+"""Catch up a shadow Elasticsearch cluster with Postgres after the bulk copy, incrementally.
+
+Records keep changing in Postgres while the ES bulk copy runs, so the shadow cluster drifts.
+This command closes that gap **without ever deleting an index**: it loops the in-scope programs
+and, for each one that has a delta since ``--since``, writes only the changed documents into the
+existing per-program index (upsert changed, delete the docs of soft-removed records). A program
+whose index does not exist yet (e.g. created during the window) is the only full-populate case:
+we create the index and populate the whole program.
+
+Postgres is the source of truth. The Individual/Household ES documents embed related objects, so a
+change is any of:
+
+* Individual (base)   -> ``updated_at``
+* Household (base)    -> ``updated_at``
+* Document            -> ``updated_at`` (embedded in individual.documents and
+                         household.head_of_household.documents)
+* IndividualIdentity  -> ``modified`` (model_utils TimeStampedModel; embedded in individual.identities)
+
+A soft-delete bumps ``updated_at`` and sets ``is_removed=True``; such records are removed from ES
+by ``_id`` (the document, never the index).
+
+Known gaps, out of scope for this incremental pass (need a separate full ``es_shadow_populate``):
+
+* Reference-data rename (Partner / Area / Country / DocumentType): touches documents across many
+  programs with no per-program key -- only reported here as a warning, not applied.
+* Hard-delete (row physically gone): ``--since`` cannot see it, so its ES document is left orphaned.
+  A future ``--reconcile`` id-diff pass would remove such orphans.
+
+The shadow cluster is selected by pointing the pod's ELASTICSEARCH_HOST env at it; the 'default'
+connection then writes there.
+
+Examples
+--------
+Catch up all active programs from the bulk-copy start time (minus a small buffer)::
+
+    python manage.py es_populate_delta --since 2026-07-01T08:55Z --parallel --threads 8
+
+Dry-run -- print each program's delta without writing::
+
+    python manage.py es_populate_delta --since 2026-07-01T08:55Z --dry-run
+
+Narrow to a single program or a whole business area::
+
+    python manage.py es_populate_delta --since 2026-07-01T08:55Z --program my-program-code
+    python manage.py es_populate_delta --since 2026-07-01T08:55Z --business-area afghanistan
+
+Report count drift (ES vs DB) without touching anything::
+
+    python manage.py es_populate_delta --reconcile
+
+"""
+
+from datetime import datetime
+from typing import Any
+import uuid
+
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+from django.utils import timezone
+
+from hope.apps.household.services.index_management import (
+    check_program_indexes,
+    create_program_indexes,
+    populate_program_indexes,
+)
+
+
+class Command(BaseCommand):
+    help = (
+        "Incrementally catch up per-program ES indexes on a shadow cluster against Postgres: "
+        "upsert only changed documents, never delete an index. "
+        "Shadow cluster is the one that waits to be plugged into prod and replace the current one."
+    )
+
+    def add_arguments(self, parser: Any) -> None:
+        parser.add_argument(
+            "--using",
+            default="default",
+            help=(
+                "Connection alias from settings.ELASTICSEARCH_DSL (default: 'default'). "
+                "Point the pod's ELASTICSEARCH_HOST at the shadow cluster and 'default' writes there."
+            ),
+        )
+        parser.add_argument(
+            "--since",
+            default=None,
+            help=(
+                "ISO-8601 timestamp. Sync programs with an Individual/Household/Document/Identity "
+                "changed at/after this time. Use the bulk-copy start time minus a small buffer."
+            ),
+        )
+        parser.add_argument(
+            "--reconcile",
+            action="store_true",
+            help="Report ES-vs-DB count drift per in-scope program (read-only, no writes).",
+        )
+        parser.add_argument(
+            "--include-non-active",
+            action="store_true",
+            help="Include closed/finished programs (default: ACTIVE only).",
+        )
+        parser.add_argument(
+            "--program",
+            default=None,
+            help="Limit scope to a single program (UUID or code). Handy to sync a small sample first.",
+        )
+        parser.add_argument(
+            "--business-area",
+            default=None,
+            help="Limit scope to a business area (slug). Combine with --program to narrow further.",
+        )
+        parser.add_argument(
+            "--parallel",
+            action="store_true",
+            default=getattr(settings, "ELASTICSEARCH_POPULATE_PARALLEL", False),
+            help="Use parallel_bulk for indexing.",
+        )
+        parser.add_argument(
+            "--threads",
+            type=int,
+            default=getattr(settings, "ELASTICSEARCH_POPULATE_THREAD_COUNT", 4),
+            help="Worker threads when --parallel is set.",
+        )
+        parser.add_argument(
+            "--chunk-size",
+            type=int,
+            default=getattr(settings, "ELASTICSEARCH_POPULATE_CHUNK_SIZE", 2000),
+            help="Bulk chunk size.",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Print each program's delta (and full-populate/no-delta status) without writing.",
+        )
+        parser.add_argument(
+            "--verify",
+            action="store_true",
+            help="After each program, run check_program_indexes() to confirm DB/ES counts match.",
+        )
+
+    def handle(self, *args: Any, **opts: Any) -> None:
+        using: str = opts["using"]
+        if using not in settings.ELASTICSEARCH_DSL:
+            raise CommandError(
+                f"Connection alias '{using}' is not registered in settings.ELASTICSEARCH_DSL "
+                f"(have: {list(settings.ELASTICSEARCH_DSL)}). "
+                f"Use --using default and point the pod's ELASTICSEARCH_HOST at the shadow cluster."
+            )
+        if not opts["since"] and not opts["reconcile"]:
+            raise CommandError("Provide --since <timestamp> and/or --reconcile.")
+
+        self._print_server_version(using)
+
+        from hope.models import Program
+
+        scope = Program.objects.all() if opts["include_non_active"] else Program.objects.filter(status=Program.ACTIVE)
+        scope = self._apply_scope_filters(scope, opts)
+        code_by_id = dict(scope.values_list("id", "code"))
+        if (opts["program"] or opts["business_area"]) and not code_by_id:
+            self.stdout.write(self.style.WARNING("No programs match --program / --business-area (nothing to do)."))
+            return
+
+        if opts["reconcile"]:
+            self._report_reconcile(code_by_id, using)
+
+        if not opts["since"]:
+            return
+
+        since = self._parse_since(opts["since"])
+        self._warn_reference_data(since)
+        self.stdout.write(f"Target cluster: '{using}' -> {settings.ELASTICSEARCH_DSL[using]['hosts']}")
+        self._sync_programs(code_by_id, since, using, opts)
+
+    def _sync_programs(self, code_by_id: dict, since: datetime, using: str, opts: dict) -> None:
+        # Loop every in-scope program and compute its delta *inside* the program (queries scoped to
+        # program_id=pid) -- deliberately no single cross-program scan over all Individuals/Households/
+        # Documents. A brand-new program (no index yet) lands in the missing-index full-populate branch.
+        total = len(code_by_id)
+        self.stdout.write(f"Scanning {total} in-scope program(s) for a delta since {since.isoformat()} ...")
+
+        failed: list = []
+        synced = 0
+        for n, (pid, code) in enumerate(sorted(code_by_id.items(), key=lambda kv: kv[1] or ""), start=1):
+            try:
+                status, msg = self._process_program(str(pid), since, using, opts)
+            except Exception as exc:  # noqa: BLE001  # one bad program must not abort the whole run
+                status, msg = "failed", str(exc)
+            style = self.style.ERROR if status == "failed" else self.style.SUCCESS
+            self.stdout.write(style(f"[{n}/{total}] {code} id={pid}: {status} -- {msg}"))
+            if status == "failed":
+                failed.append((code, pid, msg))
+                continue
+            if status != "no delta":
+                synced += 1
+            if opts["verify"] and not opts["dry_run"]:
+                vok, vmsg = check_program_indexes(str(pid))
+                self.stdout.write((self.style.SUCCESS if vok else self.style.WARNING)(f"    verify: {vmsg}"))
+
+        if failed:
+            self.stdout.write(self.style.ERROR(f"Failed programs ({len(failed)}):"))
+            for code, pid, msg in failed:
+                self.stdout.write(self.style.ERROR(f"  - {code}  id={pid}  {msg}"))
+            raise CommandError(f"Done with {len(failed)} failure(s) on cluster '{using}'.")
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Done. Cluster '{using}': {synced} of {total} program(s) had work, rest already in sync."
+            )
+        )
+
+    def _process_program(self, pid: str, since: datetime, using: str, opts: dict) -> tuple[str, str]:
+        """Sync one program: full-populate if the index is missing, else upsert/delete only the delta."""
+        from elasticsearch_dsl import connections
+
+        from hope.apps.household.documents import get_household_doc, get_individual_doc
+
+        ind_doc = get_individual_doc(pid)
+        hh_doc = get_household_doc(pid)
+        es = connections.get_connection(using)
+        ind_index = ind_doc._index._name
+        hh_index = hh_doc._index._name
+
+        # New program: no index yet -> create + full populate (this is the ONLY full-populate path).
+        if not es.indices.exists(index=ind_index) or not es.indices.exists(index=hh_index):
+            if opts["dry_run"]:
+                return "would-populate (no index)", f"index {ind_index} / {hh_index}"
+            ok, msg = create_program_indexes(pid)
+            if ok:
+                ok, msg = populate_program_indexes(pid, batch_size=opts["chunk_size"])
+            return ("populated (new index)", msg) if ok else ("failed", msg)
+
+        delta = self._program_delta(pid, since)
+        counts = (
+            f"ind +{len(delta['ind_present'])}/-{len(delta['ind_removed'])} "
+            f"hh +{len(delta['hh_present'])}/-{len(delta['hh_removed'])}"
+        )
+        if not any(delta.values()):
+            return "no delta", counts
+        if opts["dry_run"]:
+            return "would-sync delta", counts
+
+        self._apply_delta(pid, delta, ind_doc, hh_doc, opts)
+        return "delta synced", counts
+
+    @staticmethod
+    def _apply_delta(pid: str, delta: dict, ind_doc: type, hh_doc: type, opts: dict) -> None:
+        from hope.apps.utils.elasticsearch_utils import remove_elasticsearch_documents_by_matching_ids
+        from hope.models import Household, Individual
+
+        chunk = opts["chunk_size"]
+        parallel = opts["parallel"]
+        if delta["ind_present"]:
+            qs = Individual.all_merge_status_objects.filter(id__in=delta["ind_present"]).iterator(chunk_size=chunk)
+            ind_doc().update(qs, action="index", parallel=parallel)
+        if delta["hh_present"]:
+            qs = Household.objects.filter(id__in=delta["hh_present"]).iterator(chunk_size=chunk)
+            hh_doc().update(qs, action="index", parallel=parallel)
+        if delta["ind_removed"]:
+            remove_elasticsearch_documents_by_matching_ids([str(i) for i in delta["ind_removed"]], ind_doc)
+        if delta["hh_removed"]:
+            remove_elasticsearch_documents_by_matching_ids([str(i) for i in delta["hh_removed"]], hh_doc)
+
+    @staticmethod
+    def _program_delta(pid: str, since: datetime) -> dict:
+        """Ids of this program's records to upsert (present) or delete (soft-removed) in ES.
+
+        Mirrors ``get_instances_from_related`` in documents.py (which side-object change forces which
+        document to re-index):
+
+        * present individuals = changed directly, or owning a changed Document/Identity, or whose
+          household changed (individual doc embeds household.unicef_id / admin1 / admin2)
+        * present households = changed directly, or whose head_of_household changed, or whose
+          head_of_household owns a changed Document (household doc embeds the head's own fields + docs)
+        * removed = soft-deleted (updated_at bumped, is_removed=True); a record both changed and
+          removed goes to removed.
+
+        Per-program scoping keeps the unindexed IndividualIdentity.modified join cheap: it starts from
+        this program's individuals (indexed program_id) and joins identities by FK, not a full scan.
+        """
+        from hope.models import Household, Individual
+
+        ind_present = set(
+            Individual.all_merge_status_objects.filter(program_id=pid)
+            .filter(updated_at__gte=since)
+            .values_list("id", flat=True)
+        )
+        ind_present |= set(
+            Individual.all_merge_status_objects.filter(program_id=pid, documents__updated_at__gte=since)
+            .values_list("id", flat=True)
+            .distinct()
+        )
+        ind_present |= set(
+            Individual.all_merge_status_objects.filter(program_id=pid, identities__modified__gte=since)
+            .values_list("id", flat=True)
+            .distinct()
+        )
+        # Individual doc embeds household.unicef_id / admin1 / admin2 -> a household change
+        # re-indexes its members (mirrors get_instances_from_related: Household -> individuals.all()).
+        ind_present |= set(
+            Individual.all_merge_status_objects.filter(program_id=pid, household__updated_at__gte=since)
+            .values_list("id", flat=True)
+            .distinct()
+        )
+        ind_removed = set(
+            Individual.all_objects.filter(program_id=pid, is_removed=True, updated_at__gte=since).values_list(
+                "id", flat=True
+            )
+        )
+        ind_present -= ind_removed
+
+        hh_present = set(
+            Household.objects.filter(program_id=pid).filter(updated_at__gte=since).values_list("id", flat=True)
+        )
+        hh_present |= set(
+            Household.objects.filter(program_id=pid, head_of_household__documents__updated_at__gte=since)
+            .values_list("id", flat=True)
+            .distinct()
+        )
+        # Household doc embeds head_of_household's own fields (given_name, full_name, phone...) ->
+        # a change to the head individual re-indexes the household. This is what es_mutate_stream bumps.
+        hh_present |= set(
+            Household.objects.filter(program_id=pid, head_of_household__updated_at__gte=since)
+            .values_list("id", flat=True)
+            .distinct()
+        )
+        hh_removed = set(
+            Household.all_objects.filter(program_id=pid, is_removed=True, updated_at__gte=since).values_list(
+                "id", flat=True
+            )
+        )
+        hh_present -= hh_removed
+        return {
+            "ind_present": ind_present,
+            "ind_removed": ind_removed,
+            "hh_present": hh_present,
+            "hh_removed": hh_removed,
+        }
+
+    def _print_server_version(self, using: str) -> None:
+        # Confirm which ES server we are about to write to (host + version) before any work.
+        from elasticsearch_dsl import connections
+
+        host = settings.ELASTICSEARCH_DSL[using]["hosts"]
+        try:
+            info = connections.get_connection(using).info()
+            version = info["version"]["number"]
+            cluster = info.get("cluster_name", "?")
+            self.stdout.write(self.style.SUCCESS(f"ES '{using}' -> {host} | cluster={cluster} version={version}"))
+        except Exception as exc:  # noqa: BLE001  # surface a clear connection error instead of a later traceback
+            raise CommandError(f"Cannot reach ES '{using}' at {host}: {exc}") from exc
+
+    def _report_reconcile(self, code_by_id: dict, using: str) -> None:
+        # Read-only drift report. Rebuilding a mismatch would mean deleting the index -- not allowed
+        # here; orphan cleanup (hard-deletes) is a separate id-diff pass, not built yet.
+        mismatched = []
+        for pid, code in code_by_id.items():
+            ok, msg = check_program_indexes(str(pid))
+            if not ok:
+                mismatched.append((code, pid, msg))
+        self.stdout.write(f"Reconcile (read-only): {len(mismatched)} of {len(code_by_id)} program(s) drift.")
+        for code, pid, msg in mismatched:
+            self.stdout.write(self.style.WARNING(f"  - {code}  id={pid}  {msg}"))
+
+    def _warn_reference_data(self, since: datetime) -> None:
+        ref_changed = self._reference_data_changed(since)
+        if ref_changed:
+            self.stdout.write(
+                self.style.WARNING(
+                    f"Reference data changed since {since.isoformat()} ({', '.join(ref_changed)}); "
+                    f"this spans many programs with no per-program key and is NOT applied by the delta -- "
+                    f"run a full es_shadow_populate for those."
+                )
+            )
+
+    @staticmethod
+    def _apply_scope_filters(scope: Any, opts: dict) -> Any:
+        if opts["business_area"]:
+            scope = scope.filter(business_area__slug=opts["business_area"])
+        program = opts["program"]
+        if program:
+            try:
+                uuid.UUID(str(program))
+                scope = scope.filter(id=program)
+            except (ValueError, AttributeError):
+                scope = scope.filter(code=program)
+        return scope
+
+    @staticmethod
+    def _parse_since(raw: str) -> datetime:
+        try:
+            dt = datetime.fromisoformat(raw)
+        except ValueError as exc:
+            raise CommandError(f"--since '{raw}' is not a valid ISO-8601 timestamp.") from exc
+        if timezone.is_naive(dt):
+            dt = timezone.make_aware(dt, timezone.get_current_timezone())
+        return dt
+
+    @staticmethod
+    def _reference_data_changed(since: datetime) -> list[str]:
+        """Return names of embedded reference tables (no per-program key) changed at/after `since`.
+
+        A change to any of these can invalidate documents across every program, so it cannot be
+        narrowed to record ids. The check is cheap: an indexed ``updated_at`` existence probe.
+        Partner (identities.partner.name) has no timestamp field and is undetectable here.
+        """
+        from hope.models import Area, BusinessArea, Country, DocumentType
+
+        checks = {
+            "DocumentType": DocumentType,  # documents.key (type.key)
+            "Country": Country,  # documents.country (iso_code3)
+            "Area": Area,  # admin1 / admin2 (name)
+            "BusinessArea": BusinessArea,  # business_area (slug)
+        }
+        return [name for name, model in checks.items() if model.objects.filter(updated_at__gte=since).exists()]

--- a/src/hope/apps/household/management/commands/mutate-data.yml
+++ b/src/hope/apps/household/management/commands/mutate-data.yml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: adhoc-mutate-data
+spec:
+      containers:
+        - name: backend1
+          command: ["/bin/sh"]
+          args: ["-c", "sleep infinity"]
+          # args: ["-c", "django-admin runserver 0.0.0.0:8080"]
+          # args: ["-c", "django-admin shell -c 'from hct_mis_a"]
+          image: unicef/hope-support-images:core-7b7d83765c6b8a8b264ea6a1d273fdcb4538fd90
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 8080
+          envFrom:
+            - secretRef:
+                name: hope-core-backend
+            - configMapRef:
+                name: hope-core-backend
+            - secretRef:
+                name: keyvault-secret
+          env:
+            - name: DEBUG
+              value: "True"
+            - name: DJANGO_DEBUG
+              value: "True"
+      restartPolicy: Never

--- a/src/hope/apps/household/management/commands/reindex-delta.yml
+++ b/src/hope/apps/household/management/commands/reindex-delta.yml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: adhoc-reindex-delta
+spec:
+      containers:
+        - name: backend1
+          command: ["/bin/sh"]
+          args: ["-c", "sleep infinity"]
+          # args: ["-c", "django-admin runserver 0.0.0.0:8080"]
+          # args: ["-c", "django-admin shell -c 'from hct_mis_a"]
+          image: unicef/hope-support-images:core-7b7d83765c6b8a8b264ea6a1d273fdcb4538fd90
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 8080
+          envFrom:
+            - secretRef:
+                name: hope-core-backend
+            - configMapRef:
+                name: hope-core-backend
+            - secretRef:
+                name: keyvault-secret
+          env:
+            - name: DEBUG
+              value: "True"
+            - name: DJANGO_DEBUG
+              value: "True"
+            - name: ELASTICSEARCH_HOST
+              value: "http://hope-es-search-master:9200"
+      restartPolicy: Never

--- a/tests/unit/apps/household/test_es_mutate_stream.py
+++ b/tests/unit/apps/household/test_es_mutate_stream.py
@@ -1,0 +1,90 @@
+"""Tests for the es_mutate_stream dev/test command (change-stream generator + JSONL log)."""
+
+from io import StringIO
+import json
+from pathlib import Path
+
+from django.core.management import call_command
+import pytest
+
+from extras.test_utils.factories import HouseholdFactory, IndividualFactory
+from hope.models import Individual
+
+pytestmark = pytest.mark.django_db
+
+CMD = "es_mutate_stream"
+RECORD_KEYS = {
+    "ts",
+    "action",
+    "model",
+    "object_id",
+    "individual_id",
+    "household_id",
+    "individual_unicef_id",
+    "household_unicef_id",
+    "field",
+    "old",
+    "new",
+}
+
+
+def _run(tmp_path: Path, *extra: str) -> list[dict]:
+    log = tmp_path / "m.jsonl"
+    call_command(CMD, "--sleep", "0", "--log", str(log), *extra, stdout=StringIO())
+    return [json.loads(line) for line in log.read_text().splitlines()]
+
+
+def test_logs_parseable_records_with_all_keys(tmp_path: Path) -> None:
+    HouseholdFactory()
+    IndividualFactory()
+
+    rows = _run(tmp_path, "--passes", "1", "--batch", "5", "--delete-every", "0")
+
+    assert rows
+    assert all(set(r) >= RECORD_KEYS for r in rows)
+
+
+def test_individual_record_ids_and_field(tmp_path: Path) -> None:
+    IndividualFactory()
+
+    rows = _run(tmp_path, "--passes", "1", "--batch", "1", "--delete-every", "0")
+
+    ind_rec = next(r for r in rows if r["model"] == "Individual")
+    assert ind_rec["object_id"] == ind_rec["individual_id"]
+    assert ind_rec["field"] == "given_name"
+    assert ind_rec["old"] != ind_rec["new"]
+
+
+def test_household_record_has_null_individual_side(tmp_path: Path) -> None:
+    HouseholdFactory()
+
+    rows = _run(tmp_path, "--passes", "1", "--batch", "1", "--delete-every", "0")
+
+    hh_rec = next(r for r in rows if r["model"] == "Household")
+    assert hh_rec["individual_id"] is None
+    assert hh_rec["individual_unicef_id"] is None
+    assert hh_rec["household_id"] == hh_rec["object_id"]
+    assert hh_rec["field"] == "residence_status"  # embedded in ES doc -> verifiable, unlike size
+    assert hh_rec["old"] != hh_rec["new"]
+
+
+def test_soft_delete_is_logged(tmp_path: Path) -> None:
+    ind = IndividualFactory()
+
+    rows = _run(tmp_path, "--passes", "1", "--batch", "1", "--delete-every", "1")
+
+    sd = next(r for r in rows if r["action"] == "soft_delete")
+    assert sd["field"] == "is_removed"
+    assert sd["old"] is False
+    assert sd["new"] is True
+    assert Individual.all_objects.get(pk=ind.pk).is_removed is True
+
+
+def test_empty_db_warns_and_writes_no_log(tmp_path: Path) -> None:
+    out = StringIO()
+    log = tmp_path / "m.jsonl"
+
+    call_command(CMD, "--sleep", "0", "--passes", "1", "--log", str(log), stdout=out)
+
+    assert "nothing to mutate" in out.getvalue()
+    assert not log.exists()

--- a/tests/unit/apps/household/test_es_populate_delta.py
+++ b/tests/unit/apps/household/test_es_populate_delta.py
@@ -1,0 +1,400 @@
+"""Tests for the es_populate_delta management command (incremental, never deletes an index).
+
+ES-touching bits (server version probe, per-program doc classes, ES connection, create/populate,
+remove-by-id) are mocked, so these tests need no live Elasticsearch cluster. The DB-only per-program
+delta detection (`_program_delta`) is exercised directly against factories.
+"""
+
+import datetime
+from io import StringIO
+from unittest.mock import MagicMock, patch
+import uuid
+
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.utils import timezone
+import pytest
+
+from extras.test_utils.factories import (
+    BusinessAreaFactory,
+    DocumentFactory,
+    HouseholdFactory,
+    IndividualFactory,
+    IndividualIdentityFactory,
+    ProgramFactory,
+)
+from hope.apps.household.management.commands.es_populate_delta import Command
+from hope.models import Household, Individual, Program
+
+pytestmark = pytest.mark.django_db
+
+CMD = "es_populate_delta"
+_MOD = "hope.apps.household.management.commands.es_populate_delta"
+CHECK = f"{_MOD}.check_program_indexes"
+CREATE = f"{_MOD}.create_program_indexes"
+POPULATE = f"{_MOD}.populate_program_indexes"
+VERSION = f"{_MOD}.Command._print_server_version"
+PROCESS = f"{_MOD}.Command._process_program"
+DELTA = f"{_MOD}.Command._program_delta"
+APPLY = f"{_MOD}.Command._apply_delta"
+GET_IND_DOC = "hope.apps.household.documents.get_individual_doc"
+GET_HH_DOC = "hope.apps.household.documents.get_household_doc"
+GET_CONN = "elasticsearch_dsl.connections.get_connection"
+REMOVE = "hope.apps.utils.elasticsearch_utils.remove_elasticsearch_documents_by_matching_ids"
+
+OPTS = {"dry_run": False, "chunk_size": 2000, "parallel": False, "threads": 4, "verify": False}
+
+
+# ── _parse_since ─────────────────────────────────────────────────────────────
+
+
+def test_parse_since_naive_is_made_aware() -> None:
+    dt = Command._parse_since("2026-07-01T09:00:00")
+    assert timezone.is_aware(dt)
+
+
+def test_parse_since_accepts_z_suffix_as_utc() -> None:
+    dt = Command._parse_since("2026-07-01T09:00:00Z")
+    assert timezone.is_aware(dt)
+    assert dt.utcoffset() == datetime.timedelta(0)
+
+
+def test_parse_since_invalid_raises() -> None:
+    with pytest.raises(CommandError):
+        Command._parse_since("not-a-timestamp")
+
+
+# ── _program_delta (per-program record-level delta) ───────────────────────────
+
+
+def test_program_delta_direct_individual_change_is_present() -> None:
+    prog = ProgramFactory(status=Program.ACTIVE)
+    since = timezone.now() - datetime.timedelta(days=1)
+    ind = IndividualFactory(program=prog, business_area=prog.business_area)
+
+    delta = Command._program_delta(str(prog.id), since)
+
+    assert ind.id in delta["ind_present"]
+    assert ind.id not in delta["ind_removed"]
+
+
+def test_program_delta_changed_document_marks_owner_present() -> None:
+    prog = ProgramFactory(status=Program.ACTIVE)
+    since = timezone.now()
+    past = since - datetime.timedelta(hours=1)
+    ind = IndividualFactory(program=prog, business_area=prog.business_area)
+    Individual.all_merge_status_objects.filter(pk=ind.pk).update(updated_at=past)  # not via direct
+    DocumentFactory(individual=ind)  # fresh updated_at -> triggers via documents
+
+    delta = Command._program_delta(str(prog.id), since)
+
+    assert ind.id in delta["ind_present"]
+
+
+def test_program_delta_changed_identity_marks_owner_present() -> None:
+    prog = ProgramFactory(status=Program.ACTIVE)
+    since = timezone.now()
+    past = since - datetime.timedelta(hours=1)
+    ind = IndividualFactory(program=prog, business_area=prog.business_area)
+    Individual.all_merge_status_objects.filter(pk=ind.pk).update(updated_at=past)
+    IndividualIdentityFactory(individual=ind)  # fresh `modified` -> triggers via identities
+
+    delta = Command._program_delta(str(prog.id), since)
+
+    assert ind.id in delta["ind_present"]
+
+
+def test_program_delta_soft_deleted_individual_goes_to_removed() -> None:
+    prog = ProgramFactory(status=Program.ACTIVE)
+    since = timezone.now()
+    future = since + datetime.timedelta(hours=1)
+    ind = IndividualFactory(program=prog, business_area=prog.business_area)
+    Individual.all_objects.filter(pk=ind.pk).update(is_removed=True, updated_at=future)
+
+    delta = Command._program_delta(str(prog.id), since)
+
+    assert ind.id in delta["ind_removed"]
+    assert ind.id not in delta["ind_present"]
+
+
+def test_program_delta_direct_household_change_is_present() -> None:
+    prog = ProgramFactory(status=Program.ACTIVE)
+    since = timezone.now() - datetime.timedelta(days=1)
+    hh = HouseholdFactory(program=prog, business_area=prog.business_area)
+
+    delta = Command._program_delta(str(prog.id), since)
+
+    assert hh.id in delta["hh_present"]
+
+
+def test_program_delta_household_change_marks_members_present() -> None:
+    # Individual doc embeds household.unicef_id / admin1 / admin2 -> a household change must
+    # re-index its members even if the member individual itself did not change.
+    prog = ProgramFactory(status=Program.ACTIVE)
+    since = timezone.now()
+    past = since - datetime.timedelta(hours=1)
+    hh = HouseholdFactory(program=prog, business_area=prog.business_area)  # fresh updated_at
+    member = IndividualFactory(program=prog, business_area=prog.business_area, household=hh)
+    Individual.all_merge_status_objects.filter(pk=member.pk).update(updated_at=past)  # not via direct
+
+    delta = Command._program_delta(str(prog.id), since)
+
+    assert member.id in delta["ind_present"]
+
+
+def test_program_delta_head_change_marks_household_present() -> None:
+    # Household doc embeds the head's own name/phone fields -> a change to the head individual
+    # (exactly what es_mutate_stream bumps via given_name) must re-index the household.
+    prog = ProgramFactory(status=Program.ACTIVE)
+    since = timezone.now()
+    past = since - datetime.timedelta(hours=1)
+    head = IndividualFactory(program=prog, business_area=prog.business_area)  # fresh updated_at
+    hh = HouseholdFactory(program=prog, business_area=prog.business_area, head_of_household=head)
+    Household.objects.filter(pk=hh.pk).update(updated_at=past)  # not via direct
+
+    delta = Command._program_delta(str(prog.id), since)
+
+    assert hh.id in delta["hh_present"]
+
+
+def test_program_delta_head_document_marks_household_present() -> None:
+    prog = ProgramFactory(status=Program.ACTIVE)
+    since = timezone.now()
+    past = since - datetime.timedelta(hours=1)
+    head = IndividualFactory(program=prog, business_area=prog.business_area)
+    hh = HouseholdFactory(program=prog, business_area=prog.business_area, head_of_household=head)
+    Household.objects.filter(pk=hh.pk).update(updated_at=past)  # not via direct
+    DocumentFactory(individual=head)  # head's doc changed -> household doc embed must refresh
+
+    delta = Command._program_delta(str(prog.id), since)
+
+    assert hh.id in delta["hh_present"]
+
+
+# ── _reference_data_changed ───────────────────────────────────────────────────
+
+
+def test_reference_data_change_is_detected() -> None:
+    from hope.models import BusinessArea
+
+    since = timezone.now()
+    future = since + datetime.timedelta(hours=1)
+    ba = BusinessAreaFactory()
+    BusinessArea.objects.filter(pk=ba.pk).update(updated_at=future)
+
+    assert "BusinessArea" in Command._reference_data_changed(since)
+
+
+def test_reference_data_unchanged_returns_empty() -> None:
+    BusinessAreaFactory()
+    since = timezone.now() + datetime.timedelta(hours=1)
+    assert Command._reference_data_changed(since) == []
+
+
+# ── _apply_scope_filters ─────────────────────────────────────────────────────
+
+
+def test_apply_scope_filters_by_code_uuid_and_business_area() -> None:
+    ba = BusinessAreaFactory()
+    p1 = ProgramFactory(business_area=ba)
+    p2 = ProgramFactory()
+
+    def ids(**opts: object) -> set:
+        base = Program.objects.all()
+        return set(Command._apply_scope_filters(base, opts).values_list("id", flat=True))
+
+    assert ids(program=p1.code, business_area=None) == {p1.id}
+    assert ids(program=str(p2.id), business_area=None) == {p2.id}
+    assert ids(program=None, business_area=ba.slug) == {p1.id}
+    assert ids(program=str(p2.id), business_area=ba.slug) == set()
+
+
+# ── _process_program (missing index vs delta vs no-delta) ─────────────────────
+
+
+@patch(POPULATE, return_value=(True, "done"))
+@patch(CREATE, return_value=(True, ""))
+@patch(GET_HH_DOC)
+@patch(GET_IND_DOC)
+@patch(GET_CONN)
+def test_process_program_missing_index_creates_and_populates(
+    mock_conn, mock_ind_doc, mock_hh_doc, mock_create, mock_populate
+) -> None:
+    mock_conn.return_value.indices.exists.return_value = False
+
+    status, _ = Command()._process_program(str(uuid.uuid4()), timezone.now(), "default", OPTS)
+
+    assert status.startswith("populated")
+    mock_create.assert_called_once()
+    mock_populate.assert_called_once()
+
+
+@patch(DELTA, return_value={"ind_present": set(), "ind_removed": set(), "hh_present": set(), "hh_removed": set()})
+@patch(GET_HH_DOC)
+@patch(GET_IND_DOC)
+@patch(GET_CONN)
+def test_process_program_existing_index_no_delta(mock_conn, mock_ind_doc, mock_hh_doc, mock_delta) -> None:
+    mock_conn.return_value.indices.exists.return_value = True
+
+    status, _ = Command()._process_program(str(uuid.uuid4()), timezone.now(), "default", OPTS)
+
+    assert status == "no delta"
+
+
+@patch(APPLY)
+@patch(DELTA, return_value={"ind_present": {1}, "ind_removed": set(), "hh_present": set(), "hh_removed": set()})
+@patch(GET_HH_DOC)
+@patch(GET_IND_DOC)
+@patch(GET_CONN)
+def test_process_program_existing_index_applies_delta(
+    mock_conn, mock_ind_doc, mock_hh_doc, mock_delta, mock_apply
+) -> None:
+    mock_conn.return_value.indices.exists.return_value = True
+
+    status, _ = Command()._process_program(str(uuid.uuid4()), timezone.now(), "default", OPTS)
+
+    assert status == "delta synced"
+    mock_apply.assert_called_once()
+
+
+@patch(APPLY)
+@patch(DELTA, return_value={"ind_present": {1}, "ind_removed": set(), "hh_present": set(), "hh_removed": set()})
+@patch(GET_HH_DOC)
+@patch(GET_IND_DOC)
+@patch(GET_CONN)
+def test_process_program_dry_run_does_not_apply(
+    mock_conn, mock_ind_doc, mock_hh_doc, mock_delta, mock_apply
+) -> None:
+    mock_conn.return_value.indices.exists.return_value = True
+    opts = {**OPTS, "dry_run": True}
+
+    status, _ = Command()._process_program(str(uuid.uuid4()), timezone.now(), "default", opts)
+
+    assert status.startswith("would-sync")
+    mock_apply.assert_not_called()
+
+
+# ── _apply_delta: upsert present, delete removed docs, never delete the index ──
+
+
+@patch(REMOVE)
+def test_apply_delta_upserts_present_and_removes_soft_deleted(mock_remove) -> None:
+    prog = ProgramFactory(status=Program.ACTIVE)
+    present = IndividualFactory(program=prog, business_area=prog.business_area)
+    removed_id = uuid.uuid4()
+    ind_doc = MagicMock()
+    hh_doc = MagicMock()
+    delta = {"ind_present": {present.id}, "ind_removed": {removed_id}, "hh_present": set(), "hh_removed": set()}
+
+    Command._apply_delta(str(prog.id), delta, ind_doc, hh_doc, OPTS)
+
+    ind_doc.return_value.update.assert_called_once()
+    assert ind_doc.return_value.update.call_args.kwargs["action"] == "index"
+    mock_remove.assert_called_once_with([str(removed_id)], ind_doc)
+
+
+def test_command_never_imports_index_delete() -> None:
+    # Hard guarantee for "never delete an index": the delete helper is not even in the module.
+    import hope.apps.household.management.commands.es_populate_delta as mod
+
+    assert not hasattr(mod, "delete_program_indexes")
+
+
+# ── handle: argument validation & server version ──────────────────────────────
+
+
+def test_requires_since_or_reconcile() -> None:
+    with pytest.raises(CommandError):
+        call_command(CMD, "--using", "default")
+
+
+def test_unknown_using_alias_raises() -> None:
+    with pytest.raises(CommandError):
+        call_command(CMD, "--using", "does-not-exist", "--reconcile")
+
+
+@patch(GET_CONN)
+def test_print_server_version_prints_host_and_version(mock_conn) -> None:
+    mock_conn.return_value.info.return_value = {"version": {"number": "9.0.1"}, "cluster_name": "shadow"}
+    out = StringIO()
+
+    Command(stdout=out)._print_server_version("default")
+
+    printed = out.getvalue()
+    assert "9.0.1" in printed
+    assert "shadow" in printed
+
+
+@patch(GET_CONN, side_effect=OSError("no route to host"))
+def test_print_server_version_unreachable_raises(mock_conn) -> None:
+    with pytest.raises(CommandError, match="Cannot reach ES"):
+        Command(stdout=StringIO())._print_server_version("default")
+
+
+# ── handle: --since orchestration / --reconcile / scope ───────────────────────
+
+
+@patch(VERSION)
+@patch(PROCESS, return_value=("delta synced", "ind +1/-0 hh +0/-0"))
+def test_since_processes_every_active_program(mock_process, mock_version) -> None:
+    # No cross-program pre-filter: every in-scope program is handed to _process_program.
+    prog = ProgramFactory(status=Program.ACTIVE)
+    since = (timezone.now() - datetime.timedelta(days=1)).isoformat()
+
+    call_command(CMD, "--since", since, stdout=StringIO())
+
+    mock_process.assert_called_once()
+    assert mock_process.call_args.args[0] == str(prog.id)
+
+
+@patch(VERSION)
+@patch(PROCESS, return_value=("failed", "boom"))
+def test_since_failure_is_listed_and_command_errors(mock_process, mock_version) -> None:
+    prog = ProgramFactory(status=Program.ACTIVE)
+    since = (timezone.now() - datetime.timedelta(days=1)).isoformat()
+    out = StringIO()
+
+    with pytest.raises(CommandError):
+        call_command(CMD, "--since", since, stdout=out)
+
+    printed = out.getvalue()
+    assert "Failed programs" in printed
+    assert prog.code in printed
+    assert "boom" in printed
+
+
+@patch(VERSION)
+@patch(CHECK, return_value=(False, "count mismatch"))
+def test_reconcile_reports_drift_read_only(mock_check, mock_version) -> None:
+    prog = ProgramFactory(status=Program.ACTIVE)
+    out = StringIO()
+
+    call_command(CMD, "--reconcile", stdout=out)
+
+    printed = out.getvalue()
+    assert "drift" in printed
+    assert prog.code in printed
+
+
+@patch(VERSION)
+@patch(PROCESS)
+@patch(CHECK, return_value=(True, "ok"))
+def test_reconcile_only_does_not_sync(mock_check, mock_process, mock_version) -> None:
+    ProgramFactory(status=Program.ACTIVE)
+
+    call_command(CMD, "--reconcile", stdout=StringIO())
+
+    mock_process.assert_not_called()
+
+
+@patch(VERSION)
+@patch(PROCESS)
+def test_scope_no_match_warns_and_skips(mock_process, mock_version) -> None:
+    ProgramFactory(status=Program.ACTIVE)
+    since = (timezone.now() - datetime.timedelta(days=1)).isoformat()
+    out = StringIO()
+
+    call_command(CMD, "--since", since, "--program", "no-such-code", stdout=out)
+
+    assert "No programs match" in out.getvalue()
+    mock_process.assert_not_called()


### PR DESCRIPTION
Master-targeted variant of #6164 (that PR targets `develop`). Same two management commands and their tests, adapted **only** where master's code differs — no logic change to the delta.

## Commands
- `es_populate_delta` — incremental per-program ES catch-up from Postgres (`--since` upserts changed docs, deletes soft-removed by `_id`, full-populates only missing indexes; `--reconcile` read-only drift report). Never deletes an index.
- `es_mutate_stream` — dev/test change-stream generator + JSONL log to exercise the delta.

## Why a separate master branch (vs #6164)
Master lacks the develop-only ES bits #6164 assumes, so on a pure-master image #6164's delta would `ImportError`/`TypeError`. Minimal adaptations:
- `from elasticsearch_dsl import connections` (es-py **8**) instead of `elasticsearch.dsl` (es-py 9).
- `create_program_indexes`/`populate_program_indexes`/`check_program_indexes` called without the develop-only `using=`/`parallel=`/`thread_count=` kwargs (that signature refactor came with #6031, not on master).
- dropped the `_es_shadow` `v9` wiring (it imports `elasticsearch.dsl` → ImportError on master, and is a no-op in the default-connection setup).

Interface unchanged (`--using`/`--parallel`/`--threads`/`--chunk-size`/… all kept). 34 tests pass on the ES8 env; ruff clean.

Ref: #6164