### PR TITLE
[GRV REVAMP] Bulk close complaint tickets

### DIFF
--- a/src/frontend/src/components/grievances/GrievancesTable/GrievancesTable.tsx
+++ b/src/frontend/src/components/grievances/GrievancesTable/GrievancesTable.tsx
@@ -33,6 +33,7 @@ import {
 import { GrievancesTableRow } from './GrievancesTableRow';
 import { BulkAddNoteModal } from './bulk/BulkAddNoteModal';
 import { BulkAssignModal } from './bulk/BulkAssignModal';
+import { BulkCloseModal } from './bulk/BulkCloseModal';
 import { BulkSetPriorityModal } from './bulk/BulkSetPriorityModal';
 import { BulkSetUrgencyModal } from './bulk/BulkSetUrgencyModal';
 import { CountResponse } from '@restgenerated/models/CountResponse';
@@ -418,6 +419,10 @@ export const GrievancesTable = ({
             setSelected={setSelectedTickets}
           />
           <BulkAddNoteModal
+            selectedTickets={selectedTickets}
+            setSelected={setSelectedTickets}
+          />
+          <BulkCloseModal
             selectedTickets={selectedTickets}
             setSelected={setSelectedTickets}
           />

--- a/src/frontend/src/components/grievances/GrievancesTable/GrievancesTable.tsx
+++ b/src/frontend/src/components/grievances/GrievancesTable/GrievancesTable.tsx
@@ -24,6 +24,7 @@ import { useTranslation } from 'react-i18next';
 import { useProgramContext } from 'src/programContext';
 import {
   hasCreatorOrOwnerPermissions,
+  hasPermissions,
   PERMISSIONS,
 } from '../../../config/permissions';
 import {
@@ -318,6 +319,15 @@ export const GrievancesTable = ({
   const urgencyChoicesData = choicesData.grievanceTicketUrgencyChoices;
   const currentUserId = currentUserData.id;
 
+  const canBulkClose = hasPermissions(
+    [
+      PERMISSIONS.GRIEVANCES_CLOSE_TICKET_EXCLUDING_FEEDBACK,
+      PERMISSIONS.GRIEVANCES_CLOSE_TICKET_EXCLUDING_FEEDBACK_AS_CREATOR,
+      PERMISSIONS.GRIEVANCES_CLOSE_TICKET_EXCLUDING_FEEDBACK_AS_OWNER,
+    ],
+    permissions,
+  );
+
   const getCanViewDetailsOfTicket = (ticket: GrievanceTicketList): boolean => {
     const isTicketCreator = currentUserId === ticket.createdBy?.id;
     const isTicketOwner = currentUserId === ticket.assignedTo?.id;
@@ -422,10 +432,12 @@ export const GrievancesTable = ({
             selectedTickets={selectedTickets}
             setSelected={setSelectedTickets}
           />
-          <BulkCloseModal
-            selectedTickets={selectedTickets}
-            setSelected={setSelectedTickets}
-          />
+          {canBulkClose && (
+            <BulkCloseModal
+              selectedTickets={selectedTickets}
+              setSelected={setSelectedTickets}
+            />
+          )}
         </Box>
         <UniversalRestTable
           isOnPaper={false}

--- a/src/frontend/src/components/grievances/GrievancesTable/bulk/BulkBaseModal.tsx
+++ b/src/frontend/src/components/grievances/GrievancesTable/bulk/BulkBaseModal.tsx
@@ -41,6 +41,7 @@ interface BulkBaseModalProps {
   children?: ReactNode;
   onSave: (tickets: GrievanceTicketList[]) => Promise<void>;
   disabledSave?: boolean;
+  saveLabel?: string;
 }
 
 export function BulkBaseModal({
@@ -51,6 +52,7 @@ export function BulkBaseModal({
   children,
   onSave,
   disabledSave,
+  saveLabel,
 }: BulkBaseModalProps): ReactElement {
   const [dialogOpen, setDialogOpen] = useState(false);
   const { t } = useTranslation();
@@ -121,7 +123,7 @@ export function BulkBaseModal({
               onClick={onAccept}
               disabled={disabledSave}
             >
-              {t('SAVE')}
+              {saveLabel ?? t('SAVE')}
             </Button>
           </DialogActions>
         </DialogFooter>

--- a/src/frontend/src/components/grievances/GrievancesTable/bulk/BulkCloseModal.tsx
+++ b/src/frontend/src/components/grievances/GrievancesTable/bulk/BulkCloseModal.tsx
@@ -1,0 +1,99 @@
+import { useBaseUrl } from '@hooks/useBaseUrl';
+import { useSnackbar } from '@hooks/useSnackBar';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import { Typography } from '@mui/material';
+import { BulkCloseGrievanceTickets } from '@restgenerated/models/BulkCloseGrievanceTickets';
+import { GrievanceTicketList } from '@restgenerated/models/GrievanceTicketList';
+import { RestService } from '@restgenerated/services/RestService';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { GRIEVANCE_CATEGORIES, GRIEVANCE_TICKET_STATES } from '@utils/constants';
+import { showApiErrorMessages } from '@utils/utils';
+import { ReactElement } from 'react';
+import { useTranslation } from 'react-i18next';
+import { BulkBaseModal } from './BulkBaseModal';
+
+interface BulkCloseModalProps {
+  selectedTickets: GrievanceTicketList[];
+  setSelected;
+}
+
+export function BulkCloseModal({
+  selectedTickets,
+  setSelected,
+}: BulkCloseModalProps): ReactElement {
+  const { t } = useTranslation();
+  const { showMessage } = useSnackbar();
+  const { businessAreaSlug, isAllPrograms, programId } = useBaseUrl();
+  const queryClient = useQueryClient();
+
+  // Only Grievance Complaint tickets in For Approval can be closed. The whole
+  // batch must be closable, otherwise nothing is closed.
+  const notClosableCount = selectedTickets.filter(
+    (ticket) =>
+      ticket.category.toString() !== GRIEVANCE_CATEGORIES.GRIEVANCE_COMPLAINT ||
+      ticket.status !== GRIEVANCE_TICKET_STATES.FOR_APPROVAL,
+  ).length;
+  const allClosable = selectedTickets.length > 0 && notClosableCount === 0;
+
+  const { mutateAsync } = useMutation({
+    mutationFn: (params: BulkCloseGrievanceTickets) =>
+      RestService.restBusinessAreasGrievanceTicketsBulkCloseCreate({
+        businessAreaSlug,
+        requestBody: params,
+      }),
+    onSuccess: () => {
+      if (isAllPrograms) {
+        queryClient.invalidateQueries({
+          queryKey: ['businessAreasGrievanceTickets'],
+        });
+      } else {
+        queryClient.invalidateQueries({
+          queryKey: [
+            'businessAreasProgramsGrievanceTickets',
+            { program: programId },
+          ],
+        });
+      }
+      showMessage(
+        t('{{count}} ticket(s) closed.', { count: selectedTickets.length }),
+      );
+      setSelected([]);
+    },
+    onError: (error: any) => {
+      showApiErrorMessages(error, showMessage);
+    },
+  });
+
+  const onSave = async (): Promise<void> => {
+    await mutateAsync({
+      grievanceTicketIds: selectedTickets.map((ticket) => ticket.id),
+    });
+  };
+
+  return (
+    <BulkBaseModal
+      selectedTickets={selectedTickets}
+      title={t('Close Tickets')}
+      buttonTitle={t('close tickets')}
+      saveLabel={t('CLOSE TICKETS')}
+      onSave={onSave}
+      icon={<CheckCircleIcon />}
+      disabledSave={!allClosable}
+    >
+      {allClosable ? (
+        <Typography data-cy="close-summary">
+          {t('{{count}} ticket(s) will be closed.', {
+            count: selectedTickets.length,
+          })}
+        </Typography>
+      ) : (
+        <Typography color="error" data-cy="close-blocked-summary">
+          {t(
+            '{{count}} of the selected ticket(s) cannot be closed. Only Grievance Complaint tickets in status For Approval can be closed — deselect the others to continue.',
+            { count: notClosableCount },
+          )}
+        </Typography>
+      )}
+    </BulkBaseModal>
+  );
+}

--- a/src/frontend/src/components/grievances/GrievancesTable/bulk/BulkCloseModal.tsx
+++ b/src/frontend/src/components/grievances/GrievancesTable/bulk/BulkCloseModal.tsx
@@ -14,7 +14,7 @@ import { BulkBaseModal } from './BulkBaseModal';
 
 interface BulkCloseModalProps {
   selectedTickets: GrievanceTicketList[];
-  setSelected;
+  setSelected: (tickets: GrievanceTicketList[]) => void;
 }
 
 export function BulkCloseModal({

--- a/src/frontend/src/components/grievances/GrievancesTable/bulk/BulkCloseModal.tsx
+++ b/src/frontend/src/components/grievances/GrievancesTable/bulk/BulkCloseModal.tsx
@@ -39,7 +39,7 @@ export function BulkCloseModal({
     mutationFn: (params: BulkCloseGrievanceTickets) =>
       RestService.restBusinessAreasGrievanceTicketsBulkCloseCreate({
         businessAreaSlug,
-        requestBody: params,
+        formData: params,
       }),
     onSuccess: () => {
       if (isAllPrograms) {

--- a/src/frontend/src/utils/en.json
+++ b/src/frontend/src/utils/en.json
@@ -919,5 +919,7 @@
   "Delegate": "Delegate",
   "Household/Individual IDs listed here will be paid to the Alternative Collector instead of the Primary Collector": "Household/Individual IDs listed here will be paid to the Alternative Collector instead of the Primary Collector",
   "Facility Name": "Facility Name",
-  "Reconciliation Information: Extra Info": "Reconciliation Information: Extra Info"
+  "Reconciliation Information: Extra Info": "Reconciliation Information: Extra Info",
+  "{{count}} of the selected ticket(s) cannot be closed. Only Grievance Complaint tickets in status For Approval can be closed — deselect the others to continue.": "{{count}} of the selected ticket(s) cannot be closed. Only Grievance Complaint tickets in status For Approval can be closed — deselect the others to continue.",
+  "Ticket cannot be closed, primary collector role has to be reassigned": "Ticket cannot be closed, primary collector role has to be reassigned"
 }

--- a/src/hope/apps/grievance/api/serializers/grievance_ticket.py
+++ b/src/hope/apps/grievance/api/serializers/grievance_ticket.py
@@ -792,3 +792,9 @@ class BulkGrievanceTicketsAddNoteSerializer(serializers.Serializer):
         child=serializers.UUIDField(),
     )
     note = serializers.CharField()
+
+
+class BulkCloseGrievanceTicketsSerializer(serializers.Serializer):
+    grievance_ticket_ids = serializers.ListField(
+        child=serializers.UUIDField(),
+    )

--- a/src/hope/apps/grievance/api/views.py
+++ b/src/hope/apps/grievance/api/views.py
@@ -66,6 +66,7 @@ from hope.apps.grievance.api.mixins import (
 )
 from hope.apps.grievance.api.serializers.dashboard import GrievanceDashboardSerializer
 from hope.apps.grievance.api.serializers.grievance_ticket import (
+    BulkCloseGrievanceTicketsSerializer,
     BulkGrievanceTicketsAddNoteSerializer,
     BulkUpdateGrievanceTicketsAssigneesSerializer,
     BulkUpdateGrievanceTicketsPrioritySerializer,
@@ -426,6 +427,7 @@ class GrievanceTicketGlobalViewSet(
         "bulk_update_priority": BulkUpdateGrievanceTicketsPrioritySerializer,
         "bulk_update_urgency": BulkUpdateGrievanceTicketsUrgencySerializer,
         "bulk_add_note": BulkGrievanceTicketsAddNoteSerializer,
+        "bulk_close": BulkCloseGrievanceTicketsSerializer,
     }
     permissions_by_action = {
         "list": [
@@ -536,6 +538,7 @@ class GrievanceTicketGlobalViewSet(
         "bulk_update_priority": [Permissions.GRIEVANCES_UPDATE],
         "bulk_update_urgency": [Permissions.GRIEVANCES_UPDATE],
         "bulk_add_note": [Permissions.GRIEVANCES_UPDATE],
+        "bulk_close": [Permissions.GRIEVANCES_CLOSE_TICKET_EXCLUDING_FEEDBACK],
         "all_edit_household_fields_attributes": [Permissions.GRIEVANCES_CREATE, Permissions.GRIEVANCES_UPDATE],
         "all_edit_people_fields_attributes": [Permissions.GRIEVANCES_CREATE, Permissions.GRIEVANCES_UPDATE],
         "all_add_individuals_fields_attributes": [Permissions.GRIEVANCES_CREATE, Permissions.GRIEVANCES_UPDATE],
@@ -1437,6 +1440,25 @@ class GrievanceTicketGlobalViewSet(
             request.user,  # type: ignore
             serializer.validated_data["grievance_ticket_ids"],
             serializer.validated_data["note"],
+            self.business_area_slug,  # type: ignore
+        )
+        return Response(
+            GrievanceTicketDetailSerializer(tickets, context={"request": request}, many=True).data,
+            status=status.HTTP_202_ACCEPTED,
+        )
+
+    @transaction.atomic
+    @extend_schema(
+        request=BulkCloseGrievanceTicketsSerializer,
+        responses={202: GrievanceTicketDetailSerializer(many=True)},
+    )
+    @action(detail=False, methods=["post"], url_path="bulk-close")
+    def bulk_close(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        tickets = BulkActionService().bulk_close(
+            request.user,  # type: ignore
+            serializer.validated_data["grievance_ticket_ids"],
             self.business_area_slug,  # type: ignore
         )
         return Response(

--- a/src/hope/apps/grievance/api/views.py
+++ b/src/hope/apps/grievance/api/views.py
@@ -538,7 +538,11 @@ class GrievanceTicketGlobalViewSet(
         "bulk_update_priority": [Permissions.GRIEVANCES_UPDATE],
         "bulk_update_urgency": [Permissions.GRIEVANCES_UPDATE],
         "bulk_add_note": [Permissions.GRIEVANCES_UPDATE],
-        "bulk_close": [Permissions.GRIEVANCES_CLOSE_TICKET_EXCLUDING_FEEDBACK],
+        "bulk_close": [
+            Permissions.GRIEVANCES_CLOSE_TICKET_EXCLUDING_FEEDBACK,
+            Permissions.GRIEVANCES_CLOSE_TICKET_EXCLUDING_FEEDBACK_AS_CREATOR,
+            Permissions.GRIEVANCES_CLOSE_TICKET_EXCLUDING_FEEDBACK_AS_OWNER,
+        ],
         "all_edit_household_fields_attributes": [Permissions.GRIEVANCES_CREATE, Permissions.GRIEVANCES_UPDATE],
         "all_edit_people_fields_attributes": [Permissions.GRIEVANCES_CREATE, Permissions.GRIEVANCES_UPDATE],
         "all_add_individuals_fields_attributes": [Permissions.GRIEVANCES_CREATE, Permissions.GRIEVANCES_UPDATE],

--- a/src/hope/apps/grievance/services/bulk_action_service.py
+++ b/src/hope/apps/grievance/services/bulk_action_service.py
@@ -119,7 +119,6 @@ class BulkActionService:
                 "Only Grievance Complaint tickets in status For Approval can be closed."
             )
 
-        # version cache is bumped by the post_save signal on save()
         for ticket in tickets:
             old_ticket = copy.copy(ticket)
             TicketStatusChangerService(ticket, created_by).change_status(GrievanceTicket.STATUS_CLOSED)
@@ -131,6 +130,7 @@ class BulkActionService:
                 old_object=old_ticket,
                 new_object=ticket,
             )
+        # version cache is bumped by the post_save signal on save()
         self._clear_cache(business_area_slug)
         return GrievanceTicket.objects.filter(id__in=tickets_ids)
 

--- a/src/hope/apps/grievance/services/bulk_action_service.py
+++ b/src/hope/apps/grievance/services/bulk_action_service.py
@@ -1,3 +1,4 @@
+import copy
 from typing import Sequence
 
 from django.db import transaction
@@ -9,8 +10,31 @@ from rest_framework.exceptions import ValidationError
 from hope.apps.core.utils import clear_cache_for_key
 from hope.apps.grievance.constants import PRIORITY_CHOICES, URGENCY_CHOICES
 from hope.apps.grievance.models import GrievanceTicket, TicketNote
+from hope.apps.grievance.services.ticket_status_changer_service import TicketStatusChangerService
 from hope.apps.grievance.signals import increment_grievance_ticket_version_cache_for_ticket_ids
-from hope.models import User
+from hope.models import User, log_create
+
+# prevent N+1 queries with Grievance Ticket queries in log_create
+_ACTIVITY_LOG_SELECT_RELATED = (
+    "business_area",
+    "assigned_to",
+    "created_by",
+    "admin2",
+    "complaint_ticket_details__household",
+    "complaint_ticket_details__individual",
+    "complaint_ticket_details__payment",
+    "sensitive_ticket_details",
+    "positive_feedback_ticket_details",
+    "negative_feedback_ticket_details",
+    "referral_ticket_details",
+    "household_data_update_ticket_details",
+    "individual_data_update_ticket_details",
+    "add_individual_ticket_details",
+    "delete_individual_ticket_details",
+    "system_flagging_ticket_details",
+    "needs_adjudication_ticket_details",
+    "payment_verification_ticket_details",
+)
 
 
 class BulkActionService:
@@ -68,6 +92,47 @@ class BulkActionService:
         increment_grievance_ticket_version_cache_for_ticket_ids(business_area_slug, list(map(str, tickets_ids)))
         self._clear_cache(business_area_slug)
         return queryset
+
+    @transaction.atomic
+    def bulk_close(
+        self,
+        created_by: User,
+        tickets_ids: Sequence[str],
+        business_area_slug: str,
+    ) -> QuerySet[GrievanceTicket]:
+        """Close the selected tickets only if every one of them is closable, otherwise close none."""
+        tickets = list(
+            GrievanceTicket.objects.filter(
+                ~Q(status=GrievanceTicket.STATUS_CLOSED),
+                category=GrievanceTicket.CATEGORY_GRIEVANCE_COMPLAINT,
+                business_area__slug=business_area_slug,
+                id__in=tickets_ids,
+            )
+            .select_related(*_ACTIVITY_LOG_SELECT_RELATED)
+            .prefetch_related("programs")
+        )
+        if len(tickets) != len(tickets_ids) or any(
+            not ticket.can_change_status(GrievanceTicket.STATUS_CLOSED) for ticket in tickets
+        ):
+            raise ValidationError(
+                "Some selected tickets cannot be closed. "
+                "Only Grievance Complaint tickets in status For Approval can be closed."
+            )
+
+        # version cache is bumped by the post_save signal on save()
+        for ticket in tickets:
+            old_ticket = copy.copy(ticket)
+            TicketStatusChangerService(ticket, created_by).change_status(GrievanceTicket.STATUS_CLOSED)
+            log_create(
+                GrievanceTicket.ACTIVITY_LOG_MAPPING,
+                "business_area",
+                created_by,
+                ticket.programs.all(),
+                old_object=old_ticket,
+                new_object=ticket,
+            )
+        self._clear_cache(business_area_slug)
+        return GrievanceTicket.objects.filter(id__in=tickets_ids)
 
     @transaction.atomic
     def bulk_add_note(

--- a/src/hope/apps/grievance/services/bulk_action_service.py
+++ b/src/hope/apps/grievance/services/bulk_action_service.py
@@ -7,6 +7,7 @@ from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from rest_framework.exceptions import ValidationError
 
+from hope.apps.account.permissions import Permissions, check_creator_or_owner_permission
 from hope.apps.core.utils import clear_cache_for_key
 from hope.apps.grievance.constants import PRIORITY_CHOICES, URGENCY_CHOICES
 from hope.apps.grievance.models import GrievanceTicket, TicketNote
@@ -117,6 +118,19 @@ class BulkActionService:
             raise ValidationError(
                 "Some selected tickets cannot be closed. "
                 "Only Grievance Complaint tickets in status For Approval can be closed."
+            )
+
+        # every selected ticket must be closable by this user (general, or as creator/owner)
+        for ticket in tickets:
+            check_creator_or_owner_permission(
+                created_by,
+                [
+                    Permissions.GRIEVANCES_CLOSE_TICKET_EXCLUDING_FEEDBACK,
+                    Permissions.GRIEVANCES_CLOSE_TICKET_EXCLUDING_FEEDBACK_AS_CREATOR,
+                    Permissions.GRIEVANCES_CLOSE_TICKET_EXCLUDING_FEEDBACK_AS_OWNER,
+                ],
+                ticket.business_area,
+                ticket,
             )
 
         for ticket in tickets:

--- a/src/hope/apps/grievance/services/bulk_action_service.py
+++ b/src/hope/apps/grievance/services/bulk_action_service.py
@@ -100,7 +100,7 @@ class BulkActionService:
         created_by: User,
         tickets_ids: Sequence[str],
         business_area_slug: str,
-    ) -> QuerySet[GrievanceTicket]:
+    ) -> list[GrievanceTicket]:
         """Close the selected tickets only if every one of them is closable, otherwise close none."""
         tickets = list(
             GrievanceTicket.objects.filter(
@@ -109,6 +109,7 @@ class BulkActionService:
                 business_area__slug=business_area_slug,
                 id__in=tickets_ids,
             )
+            .select_for_update(of=("self",))
             .select_related(*_ACTIVITY_LOG_SELECT_RELATED)
             .prefetch_related("programs")
         )
@@ -146,7 +147,7 @@ class BulkActionService:
             )
         # version cache is bumped by the post_save signal on save()
         self._clear_cache(business_area_slug)
-        return GrievanceTicket.objects.filter(id__in=tickets_ids)
+        return tickets
 
     @transaction.atomic
     def bulk_add_note(

--- a/tests/unit/apps/grievance/test_bulk_close_api.py
+++ b/tests/unit/apps/grievance/test_bulk_close_api.py
@@ -33,6 +33,16 @@ def complaint_for_approval(business_area: BusinessArea, user: User) -> Grievance
 
 
 @pytest.fixture
+def complaint_owned_by_user(business_area: BusinessArea, user: User) -> GrievanceTicket:
+    return TicketComplaintDetailsFactory(
+        ticket__business_area=business_area,
+        ticket__created_by=UserFactory(first_name="other"),
+        ticket__assigned_to=user,
+        ticket__status=GrievanceTicket.STATUS_FOR_APPROVAL,
+    ).ticket
+
+
+@pytest.fixture
 def bulk_close_url(business_area: BusinessArea) -> str:
     return reverse(
         "api:grievance:grievance-tickets-global-bulk-close",
@@ -94,3 +104,88 @@ def test_bulk_close_allowed_with_close_permission(
 
     assert response.status_code == status.HTTP_202_ACCEPTED
     assert complaint_for_approval.status == GrievanceTicket.STATUS_CLOSED
+
+
+def test_bulk_close_allowed_as_creator(
+    api_client: Any,
+    user: User,
+    business_area: BusinessArea,
+    complaint_for_approval: GrievanceTicket,
+    bulk_close_url: str,
+    create_user_role_with_permissions: Callable,
+) -> None:
+    create_user_role_with_permissions(
+        user,
+        [Permissions.GRIEVANCES_CLOSE_TICKET_EXCLUDING_FEEDBACK_AS_CREATOR],
+        business_area,
+        whole_business_area_access=True,
+    )
+
+    client = api_client(user)
+    response = client.post(
+        bulk_close_url,
+        {"grievance_ticket_ids": [str(complaint_for_approval.id)]},
+        format="json",
+    )
+
+    complaint_for_approval.refresh_from_db()
+
+    assert response.status_code == status.HTTP_202_ACCEPTED
+    assert complaint_for_approval.status == GrievanceTicket.STATUS_CLOSED
+
+
+def test_bulk_close_allowed_as_owner(
+    api_client: Any,
+    user: User,
+    business_area: BusinessArea,
+    complaint_owned_by_user: GrievanceTicket,
+    bulk_close_url: str,
+    create_user_role_with_permissions: Callable,
+) -> None:
+    create_user_role_with_permissions(
+        user,
+        [Permissions.GRIEVANCES_CLOSE_TICKET_EXCLUDING_FEEDBACK_AS_OWNER],
+        business_area,
+        whole_business_area_access=True,
+    )
+
+    client = api_client(user)
+    response = client.post(
+        bulk_close_url,
+        {"grievance_ticket_ids": [str(complaint_owned_by_user.id)]},
+        format="json",
+    )
+
+    complaint_owned_by_user.refresh_from_db()
+
+    assert response.status_code == status.HTTP_202_ACCEPTED
+    assert complaint_owned_by_user.status == GrievanceTicket.STATUS_CLOSED
+
+
+def test_bulk_close_forbidden_as_creator_when_not_creator(
+    api_client: Any,
+    user: User,
+    business_area: BusinessArea,
+    complaint_owned_by_user: GrievanceTicket,
+    bulk_close_url: str,
+    create_user_role_with_permissions: Callable,
+) -> None:
+    # user is the owner but only holds the AS_CREATOR permission, and is not the creator
+    create_user_role_with_permissions(
+        user,
+        [Permissions.GRIEVANCES_CLOSE_TICKET_EXCLUDING_FEEDBACK_AS_CREATOR],
+        business_area,
+        whole_business_area_access=True,
+    )
+
+    client = api_client(user)
+    response = client.post(
+        bulk_close_url,
+        {"grievance_ticket_ids": [str(complaint_owned_by_user.id)]},
+        format="json",
+    )
+
+    complaint_owned_by_user.refresh_from_db()
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert complaint_owned_by_user.status == GrievanceTicket.STATUS_FOR_APPROVAL

--- a/tests/unit/apps/grievance/test_bulk_close_api.py
+++ b/tests/unit/apps/grievance/test_bulk_close_api.py
@@ -1,0 +1,96 @@
+from typing import Any, Callable
+
+import pytest
+from rest_framework import status
+from rest_framework.reverse import reverse
+
+from extras.test_utils.factories import BusinessAreaFactory, UserFactory
+from extras.test_utils.factories.grievance import TicketComplaintDetailsFactory
+from hope.apps.account.permissions import Permissions
+from hope.apps.grievance.models import GrievanceTicket
+from hope.models import BusinessArea, User
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def business_area() -> BusinessArea:
+    return BusinessAreaFactory(name="Afghanistan", slug="afghanistan", code="0060")
+
+
+@pytest.fixture
+def user() -> User:
+    return UserFactory(first_name="user")
+
+
+@pytest.fixture
+def complaint_for_approval(business_area: BusinessArea, user: User) -> GrievanceTicket:
+    return TicketComplaintDetailsFactory(
+        ticket__business_area=business_area,
+        ticket__created_by=user,
+        ticket__status=GrievanceTicket.STATUS_FOR_APPROVAL,
+    ).ticket
+
+
+@pytest.fixture
+def bulk_close_url(business_area: BusinessArea) -> str:
+    return reverse(
+        "api:grievance:grievance-tickets-global-bulk-close",
+        kwargs={"business_area_slug": business_area.slug},
+    )
+
+
+def test_bulk_close_forbidden_without_close_permission(
+    api_client: Any,
+    user: User,
+    business_area: BusinessArea,
+    complaint_for_approval: GrievanceTicket,
+    bulk_close_url: str,
+    create_user_role_with_permissions: Callable,
+) -> None:
+    create_user_role_with_permissions(
+        user,
+        [Permissions.GRIEVANCES_VIEW_LIST_EXCLUDING_SENSITIVE],
+        business_area,
+        whole_business_area_access=True,
+    )
+
+    client = api_client(user)
+    response = client.post(
+        bulk_close_url,
+        {"grievance_ticket_ids": [str(complaint_for_approval.id)]},
+        format="json",
+    )
+
+    complaint_for_approval.refresh_from_db()
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert complaint_for_approval.status == GrievanceTicket.STATUS_FOR_APPROVAL
+
+
+def test_bulk_close_allowed_with_close_permission(
+    api_client: Any,
+    user: User,
+    business_area: BusinessArea,
+    complaint_for_approval: GrievanceTicket,
+    bulk_close_url: str,
+    create_user_role_with_permissions: Callable,
+) -> None:
+    create_user_role_with_permissions(
+        user,
+        [Permissions.GRIEVANCES_CLOSE_TICKET_EXCLUDING_FEEDBACK],
+        business_area,
+        whole_business_area_access=True,
+    )
+
+    client = api_client(user)
+    response = client.post(
+        bulk_close_url,
+        {"grievance_ticket_ids": [str(complaint_for_approval.id)]},
+        format="json",
+    )
+
+    complaint_for_approval.refresh_from_db()
+
+    assert response.status_code == status.HTTP_202_ACCEPTED
+    assert complaint_for_approval.status == GrievanceTicket.STATUS_CLOSED

--- a/tests/unit/apps/grievance/test_bulk_close_api.py
+++ b/tests/unit/apps/grievance/test_bulk_close_api.py
@@ -104,62 +104,9 @@ def test_bulk_close_allowed_with_close_permission(
 
     assert response.status_code == status.HTTP_202_ACCEPTED
     assert complaint_for_approval.status == GrievanceTicket.STATUS_CLOSED
-
-
-def test_bulk_close_allowed_as_creator(
-    api_client: Any,
-    user: User,
-    business_area: BusinessArea,
-    complaint_for_approval: GrievanceTicket,
-    bulk_close_url: str,
-    create_user_role_with_permissions: Callable,
-) -> None:
-    create_user_role_with_permissions(
-        user,
-        [Permissions.GRIEVANCES_CLOSE_TICKET_EXCLUDING_FEEDBACK_AS_CREATOR],
-        business_area,
-        whole_business_area_access=True,
-    )
-
-    client = api_client(user)
-    response = client.post(
-        bulk_close_url,
-        {"grievance_ticket_ids": [str(complaint_for_approval.id)]},
-        format="json",
-    )
-
-    complaint_for_approval.refresh_from_db()
-
-    assert response.status_code == status.HTTP_202_ACCEPTED
-    assert complaint_for_approval.status == GrievanceTicket.STATUS_CLOSED
-
-
-def test_bulk_close_allowed_as_owner(
-    api_client: Any,
-    user: User,
-    business_area: BusinessArea,
-    complaint_owned_by_user: GrievanceTicket,
-    bulk_close_url: str,
-    create_user_role_with_permissions: Callable,
-) -> None:
-    create_user_role_with_permissions(
-        user,
-        [Permissions.GRIEVANCES_CLOSE_TICKET_EXCLUDING_FEEDBACK_AS_OWNER],
-        business_area,
-        whole_business_area_access=True,
-    )
-
-    client = api_client(user)
-    response = client.post(
-        bulk_close_url,
-        {"grievance_ticket_ids": [str(complaint_owned_by_user.id)]},
-        format="json",
-    )
-
-    complaint_owned_by_user.refresh_from_db()
-
-    assert response.status_code == status.HTTP_202_ACCEPTED
-    assert complaint_owned_by_user.status == GrievanceTicket.STATUS_CLOSED
+    assert len(response.data) == 1
+    assert response.data[0]["id"] == str(complaint_for_approval.id)
+    assert response.data[0]["status"] == GrievanceTicket.STATUS_CLOSED
 
 
 def test_bulk_close_forbidden_as_creator_when_not_creator(
@@ -189,3 +136,32 @@ def test_bulk_close_forbidden_as_creator_when_not_creator(
 
     assert response.status_code == status.HTTP_403_FORBIDDEN
     assert complaint_owned_by_user.status == GrievanceTicket.STATUS_FOR_APPROVAL
+
+
+def test_bulk_close_forbidden_as_owner_when_not_owner(
+    api_client: Any,
+    user: User,
+    business_area: BusinessArea,
+    complaint_for_approval: GrievanceTicket,
+    bulk_close_url: str,
+    create_user_role_with_permissions: Callable,
+) -> None:
+    # user is the creator but only holds the AS_OWNER permission, and is not the owner
+    create_user_role_with_permissions(
+        user,
+        [Permissions.GRIEVANCES_CLOSE_TICKET_EXCLUDING_FEEDBACK_AS_OWNER],
+        business_area,
+        whole_business_area_access=True,
+    )
+
+    client = api_client(user)
+    response = client.post(
+        bulk_close_url,
+        {"grievance_ticket_ids": [str(complaint_for_approval.id)]},
+        format="json",
+    )
+
+    complaint_for_approval.refresh_from_db()
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert complaint_for_approval.status == GrievanceTicket.STATUS_FOR_APPROVAL

--- a/tests/unit/apps/grievance/test_bulk_close_service.py
+++ b/tests/unit/apps/grievance/test_bulk_close_service.py
@@ -379,7 +379,7 @@ def test_bulk_close_rejects_non_existent_ticket(business_area: BusinessArea, use
 def test_bulk_close_with_empty_list_closes_nothing(business_area: BusinessArea, user: User) -> None:
     result = BulkActionService().bulk_close(user, [], business_area.slug)
 
-    assert result.count() == 0
+    assert len(result) == 0
 
 
 def test_bulk_close_scopes_to_business_area(

--- a/tests/unit/apps/grievance/test_bulk_close_service.py
+++ b/tests/unit/apps/grievance/test_bulk_close_service.py
@@ -251,41 +251,15 @@ def test_bulk_close_rejects_non_complaint_ticket(
 def test_bulk_close_rejects_complaint_ticket_in_wrong_status(
     business_area: BusinessArea, user: User, complaint_new: GrievanceTicket
 ) -> None:
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError) as exc_info:
         BulkActionService().bulk_close(user, [complaint_new.id], business_area.slug)
 
     complaint_new.refresh_from_db()
 
     assert complaint_new.status == GrievanceTicket.STATUS_NEW
-
-
-def test_bulk_close_error_message(business_area: BusinessArea, user: User, complaint_new: GrievanceTicket) -> None:
-    with pytest.raises(ValidationError) as exc_info:
-        BulkActionService().bulk_close(user, [complaint_new.id], business_area.slug)
-
     assert str(exc_info.value.detail[0]) == (
         "Some selected tickets cannot be closed. Only Grievance Complaint tickets in status For Approval can be closed."
     )
-
-
-def test_bulk_close_closes_nothing_when_a_ticket_is_wrong_type(
-    business_area: BusinessArea,
-    user: User,
-    complaint_for_approval: GrievanceTicket,
-    needs_adjudication_for_approval: GrievanceTicket,
-) -> None:
-    with pytest.raises(ValidationError):
-        BulkActionService().bulk_close(
-            user,
-            [complaint_for_approval.id, needs_adjudication_for_approval.id],
-            business_area.slug,
-        )
-
-    complaint_for_approval.refresh_from_db()
-    needs_adjudication_for_approval.refresh_from_db()
-
-    assert complaint_for_approval.status == GrievanceTicket.STATUS_FOR_APPROVAL
-    assert needs_adjudication_for_approval.status == GrievanceTicket.STATUS_FOR_APPROVAL
 
 
 def test_bulk_close_closes_nothing_when_a_complaint_is_wrong_status(

--- a/tests/unit/apps/grievance/test_bulk_close_service.py
+++ b/tests/unit/apps/grievance/test_bulk_close_service.py
@@ -1,8 +1,8 @@
-from typing import Any
+from typing import Any, Callable
 from uuid import uuid4
 
 import pytest
-from rest_framework.exceptions import ValidationError
+from rest_framework.exceptions import PermissionDenied, ValidationError
 
 from extras.test_utils.factories import (
     BusinessAreaFactory,
@@ -12,6 +12,7 @@ from extras.test_utils.factories import (
 )
 from extras.test_utils.factories.grievance import TicketComplaintDetailsFactory
 from hope.api.caches import get_or_create_cache_key
+from hope.apps.account.permissions import Permissions
 from hope.apps.activity_log.utils import create_diff
 from hope.apps.grievance.models import GrievanceTicket
 from hope.apps.grievance.services.bulk_action_service import (
@@ -29,8 +30,70 @@ def business_area() -> BusinessArea:
 
 
 @pytest.fixture
-def user() -> User:
-    return UserFactory(first_name="user")
+def user(business_area: BusinessArea, create_user_role_with_permissions: Callable) -> User:
+    user = UserFactory(first_name="user")
+    create_user_role_with_permissions(
+        user,
+        [Permissions.GRIEVANCES_CLOSE_TICKET_EXCLUDING_FEEDBACK],
+        business_area,
+        whole_business_area_access=True,
+    )
+    return user
+
+
+@pytest.fixture
+def creator_user(business_area: BusinessArea, create_user_role_with_permissions: Callable) -> User:
+    creator = UserFactory(first_name="creator")
+    create_user_role_with_permissions(
+        creator,
+        [Permissions.GRIEVANCES_CLOSE_TICKET_EXCLUDING_FEEDBACK_AS_CREATOR],
+        business_area,
+        whole_business_area_access=True,
+    )
+    return creator
+
+
+@pytest.fixture
+def owner_user(business_area: BusinessArea, create_user_role_with_permissions: Callable) -> User:
+    owner = UserFactory(first_name="owner")
+    create_user_role_with_permissions(
+        owner,
+        [Permissions.GRIEVANCES_CLOSE_TICKET_EXCLUDING_FEEDBACK_AS_OWNER],
+        business_area,
+        whole_business_area_access=True,
+    )
+    return owner
+
+
+@pytest.fixture
+def user_without_close_permission(business_area: BusinessArea, create_user_role_with_permissions: Callable) -> User:
+    other = UserFactory(first_name="no-close")
+    create_user_role_with_permissions(
+        other,
+        [Permissions.GRIEVANCES_VIEW_LIST_EXCLUDING_SENSITIVE],
+        business_area,
+        whole_business_area_access=True,
+    )
+    return other
+
+
+@pytest.fixture
+def complaint_created_by_creator_user(business_area: BusinessArea, creator_user: User) -> GrievanceTicket:
+    return TicketComplaintDetailsFactory(
+        ticket__business_area=business_area,
+        ticket__created_by=creator_user,
+        ticket__status=GrievanceTicket.STATUS_FOR_APPROVAL,
+    ).ticket
+
+
+@pytest.fixture
+def complaint_owned_by_owner_user(business_area: BusinessArea, owner_user: User, user: User) -> GrievanceTicket:
+    return TicketComplaintDetailsFactory(
+        ticket__business_area=business_area,
+        ticket__created_by=user,
+        ticket__assigned_to=owner_user,
+        ticket__status=GrievanceTicket.STATUS_FOR_APPROVAL,
+    ).ticket
 
 
 @pytest.fixture
@@ -120,6 +183,60 @@ def test_bulk_close_closes_complaint_ticket_in_for_approval(
     assert complaint_for_approval.status == GrievanceTicket.STATUS_CLOSED
 
 
+def test_bulk_close_allowed_as_creator(
+    business_area: BusinessArea, creator_user: User, complaint_created_by_creator_user: GrievanceTicket
+) -> None:
+    BulkActionService().bulk_close(creator_user, [complaint_created_by_creator_user.id], business_area.slug)
+
+    complaint_created_by_creator_user.refresh_from_db()
+
+    assert complaint_created_by_creator_user.status == GrievanceTicket.STATUS_CLOSED
+
+
+def test_bulk_close_allowed_as_owner(
+    business_area: BusinessArea, owner_user: User, complaint_owned_by_owner_user: GrievanceTicket
+) -> None:
+    BulkActionService().bulk_close(owner_user, [complaint_owned_by_owner_user.id], business_area.slug)
+
+    complaint_owned_by_owner_user.refresh_from_db()
+
+    assert complaint_owned_by_owner_user.status == GrievanceTicket.STATUS_CLOSED
+
+
+def test_bulk_close_forbidden_without_close_permission(
+    business_area: BusinessArea,
+    user_without_close_permission: User,
+    complaint_for_approval: GrievanceTicket,
+) -> None:
+    with pytest.raises(PermissionDenied):
+        BulkActionService().bulk_close(user_without_close_permission, [complaint_for_approval.id], business_area.slug)
+
+    complaint_for_approval.refresh_from_db()
+
+    assert complaint_for_approval.status == GrievanceTicket.STATUS_FOR_APPROVAL
+
+
+def test_bulk_close_as_creator_closes_nothing_when_not_creator_of_one(
+    business_area: BusinessArea,
+    creator_user: User,
+    complaint_created_by_creator_user: GrievanceTicket,
+    another_complaint_for_approval: GrievanceTicket,
+) -> None:
+    # creator_user created only complaint_created_by_creator_user; another_complaint_for_approval was created by `user`
+    with pytest.raises(PermissionDenied):
+        BulkActionService().bulk_close(
+            creator_user,
+            [complaint_created_by_creator_user.id, another_complaint_for_approval.id],
+            business_area.slug,
+        )
+
+    complaint_created_by_creator_user.refresh_from_db()
+    another_complaint_for_approval.refresh_from_db()
+
+    assert complaint_created_by_creator_user.status == GrievanceTicket.STATUS_FOR_APPROVAL
+    assert another_complaint_for_approval.status == GrievanceTicket.STATUS_FOR_APPROVAL
+
+
 def test_bulk_close_rejects_non_complaint_ticket(
     business_area: BusinessArea, user: User, needs_adjudication_for_approval: GrievanceTicket
 ) -> None:
@@ -206,6 +323,7 @@ def test_bulk_close_bumps_grievance_version_cache(
     assert get_or_create_cache_key(version_key, 1) == version_before + 1
 
 
+@pytest.mark.enable_activity_log
 def test_bulk_close_writes_activity_log(
     business_area: BusinessArea, user: User, complaint_for_approval: GrievanceTicket
 ) -> None:
@@ -242,7 +360,10 @@ def test_bulk_close_query_count_scales_per_ticket(
     another_complaint_for_approval: GrievanceTicket,
     django_assert_max_num_queries: Any,
 ) -> None:
-    with django_assert_max_num_queries(16):
+    # the per-ticket permission check adds a constant cost (the permission set is cached per
+    # user/business-area/program scope, and both tickets share the same scope), so it does not
+    # scale per ticket.
+    with django_assert_max_num_queries(22):
         BulkActionService().bulk_close(
             user,
             [complaint_for_approval.id, another_complaint_for_approval.id],

--- a/tests/unit/apps/grievance/test_bulk_close_service.py
+++ b/tests/unit/apps/grievance/test_bulk_close_service.py
@@ -1,0 +1,298 @@
+from typing import Any
+from uuid import uuid4
+
+import pytest
+from rest_framework.exceptions import ValidationError
+
+from extras.test_utils.factories import (
+    BusinessAreaFactory,
+    GrievanceTicketFactory,
+    ProgramFactory,
+    UserFactory,
+)
+from extras.test_utils.factories.grievance import TicketComplaintDetailsFactory
+from hope.api.caches import get_or_create_cache_key
+from hope.apps.activity_log.utils import create_diff
+from hope.apps.grievance.models import GrievanceTicket
+from hope.apps.grievance.services.bulk_action_service import (
+    _ACTIVITY_LOG_SELECT_RELATED,
+    BulkActionService,
+)
+from hope.models import BusinessArea, LogEntry, Program, User
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def business_area() -> BusinessArea:
+    return BusinessAreaFactory(name="Afghanistan", slug="afghanistan", code="0060")
+
+
+@pytest.fixture
+def user() -> User:
+    return UserFactory(first_name="user")
+
+
+@pytest.fixture
+def business_area_other() -> BusinessArea:
+    return BusinessAreaFactory(name="Ukraine", slug="ukraine", code="4410")
+
+
+@pytest.fixture
+def program(business_area: BusinessArea) -> Program:
+    return ProgramFactory(business_area=business_area)
+
+
+@pytest.fixture
+def complaint_for_approval(business_area: BusinessArea, user: User) -> GrievanceTicket:
+    return TicketComplaintDetailsFactory(
+        ticket__business_area=business_area,
+        ticket__created_by=user,
+        ticket__status=GrievanceTicket.STATUS_FOR_APPROVAL,
+    ).ticket
+
+
+@pytest.fixture
+def another_complaint_for_approval(business_area: BusinessArea, user: User) -> GrievanceTicket:
+    return TicketComplaintDetailsFactory(
+        ticket__business_area=business_area,
+        ticket__created_by=user,
+        ticket__status=GrievanceTicket.STATUS_FOR_APPROVAL,
+    ).ticket
+
+
+@pytest.fixture
+def complaint_for_approval_with_program(business_area: BusinessArea, user: User, program: Program) -> GrievanceTicket:
+    ticket = TicketComplaintDetailsFactory(
+        ticket__business_area=business_area,
+        ticket__created_by=user,
+        ticket__status=GrievanceTicket.STATUS_FOR_APPROVAL,
+    ).ticket
+    ticket.programs.add(program)
+    return ticket
+
+
+@pytest.fixture
+def complaint_new(business_area: BusinessArea, user: User) -> GrievanceTicket:
+    return TicketComplaintDetailsFactory(
+        ticket__business_area=business_area,
+        ticket__created_by=user,
+        ticket__status=GrievanceTicket.STATUS_NEW,
+    ).ticket
+
+
+@pytest.fixture
+def complaint_closed(business_area: BusinessArea, user: User) -> GrievanceTicket:
+    return TicketComplaintDetailsFactory(
+        ticket__business_area=business_area,
+        ticket__created_by=user,
+        ticket__status=GrievanceTicket.STATUS_CLOSED,
+    ).ticket
+
+
+@pytest.fixture
+def complaint_in_other_business_area(business_area_other: BusinessArea, user: User) -> GrievanceTicket:
+    return TicketComplaintDetailsFactory(
+        ticket__business_area=business_area_other,
+        ticket__created_by=user,
+        ticket__status=GrievanceTicket.STATUS_FOR_APPROVAL,
+    ).ticket
+
+
+@pytest.fixture
+def needs_adjudication_for_approval(business_area: BusinessArea, user: User) -> GrievanceTicket:
+    return GrievanceTicketFactory(
+        business_area=business_area,
+        created_by=user,
+        category=GrievanceTicket.CATEGORY_NEEDS_ADJUDICATION,
+        issue_type=GrievanceTicket.ISSUE_TYPE_UNIQUE_IDENTIFIERS_SIMILARITY,
+        status=GrievanceTicket.STATUS_FOR_APPROVAL,
+    )
+
+
+def test_bulk_close_closes_complaint_ticket_in_for_approval(
+    business_area: BusinessArea, user: User, complaint_for_approval: GrievanceTicket
+) -> None:
+    BulkActionService().bulk_close(user, [complaint_for_approval.id], business_area.slug)
+
+    complaint_for_approval.refresh_from_db()
+
+    assert complaint_for_approval.status == GrievanceTicket.STATUS_CLOSED
+
+
+def test_bulk_close_rejects_non_complaint_ticket(
+    business_area: BusinessArea, user: User, needs_adjudication_for_approval: GrievanceTicket
+) -> None:
+    with pytest.raises(ValidationError):
+        BulkActionService().bulk_close(user, [needs_adjudication_for_approval.id], business_area.slug)
+
+    needs_adjudication_for_approval.refresh_from_db()
+
+    assert needs_adjudication_for_approval.status == GrievanceTicket.STATUS_FOR_APPROVAL
+
+
+def test_bulk_close_rejects_complaint_ticket_in_wrong_status(
+    business_area: BusinessArea, user: User, complaint_new: GrievanceTicket
+) -> None:
+    with pytest.raises(ValidationError):
+        BulkActionService().bulk_close(user, [complaint_new.id], business_area.slug)
+
+    complaint_new.refresh_from_db()
+
+    assert complaint_new.status == GrievanceTicket.STATUS_NEW
+
+
+def test_bulk_close_error_message(business_area: BusinessArea, user: User, complaint_new: GrievanceTicket) -> None:
+    with pytest.raises(ValidationError) as exc_info:
+        BulkActionService().bulk_close(user, [complaint_new.id], business_area.slug)
+
+    assert str(exc_info.value.detail[0]) == (
+        "Some selected tickets cannot be closed. Only Grievance Complaint tickets in status For Approval can be closed."
+    )
+
+
+def test_bulk_close_closes_nothing_when_a_ticket_is_wrong_type(
+    business_area: BusinessArea,
+    user: User,
+    complaint_for_approval: GrievanceTicket,
+    needs_adjudication_for_approval: GrievanceTicket,
+) -> None:
+    with pytest.raises(ValidationError):
+        BulkActionService().bulk_close(
+            user,
+            [complaint_for_approval.id, needs_adjudication_for_approval.id],
+            business_area.slug,
+        )
+
+    complaint_for_approval.refresh_from_db()
+    needs_adjudication_for_approval.refresh_from_db()
+
+    assert complaint_for_approval.status == GrievanceTicket.STATUS_FOR_APPROVAL
+    assert needs_adjudication_for_approval.status == GrievanceTicket.STATUS_FOR_APPROVAL
+
+
+def test_bulk_close_closes_nothing_when_a_complaint_is_wrong_status(
+    business_area: BusinessArea,
+    user: User,
+    complaint_for_approval: GrievanceTicket,
+    complaint_new: GrievanceTicket,
+) -> None:
+    with pytest.raises(ValidationError):
+        BulkActionService().bulk_close(
+            user,
+            [complaint_for_approval.id, complaint_new.id],
+            business_area.slug,
+        )
+
+    complaint_for_approval.refresh_from_db()
+    complaint_new.refresh_from_db()
+
+    assert complaint_for_approval.status == GrievanceTicket.STATUS_FOR_APPROVAL
+    assert complaint_new.status == GrievanceTicket.STATUS_NEW
+
+
+def test_bulk_close_bumps_grievance_version_cache(
+    business_area: BusinessArea,
+    user: User,
+    program: Program,
+    complaint_for_approval_with_program: GrievanceTicket,
+) -> None:
+    business_area_version = get_or_create_cache_key(f"{business_area.slug}:version", 1)
+    version_key = f"{business_area.slug}:{business_area_version}:{program.code}:grievance_ticket_list"
+    version_before = get_or_create_cache_key(version_key, 1)
+
+    BulkActionService().bulk_close(user, [complaint_for_approval_with_program.id], business_area.slug)
+
+    assert get_or_create_cache_key(version_key, 1) == version_before + 1
+
+
+def test_bulk_close_writes_activity_log(
+    business_area: BusinessArea, user: User, complaint_for_approval: GrievanceTicket
+) -> None:
+    BulkActionService().bulk_close(user, [complaint_for_approval.id], business_area.slug)
+
+    assert LogEntry.objects.filter(object_id=complaint_for_approval.id, action=LogEntry.UPDATE).exists()
+
+
+def test_bulk_close_select_related_covers_activity_log_diff(
+    complaint_for_approval: GrievanceTicket,
+    django_assert_num_queries: Any,
+) -> None:
+    # bulk_close logs every closed ticket, and create_diff reads every relation in
+    # ACTIVITY_LOG_MAPPING. This guards that _ACTIVITY_LOG_SELECT_RELATED covers them all so the
+    # diff stays query-free (no per-ticket N+1); it fails if a relation is added to the mapping
+    # but not to the select_related tuple.
+    ticket = (
+        GrievanceTicket.objects.filter(pk=complaint_for_approval.pk)
+        .select_related(*_ACTIVITY_LOG_SELECT_RELATED)
+        .prefetch_related("programs")
+        .get()
+    )
+
+    with django_assert_num_queries(0):
+        create_diff(ticket, ticket, GrievanceTicket.ACTIVITY_LOG_MAPPING)
+        assert ticket.business_area is not None
+        assert list(ticket.programs.all()) == []
+
+
+def test_bulk_close_query_count_scales_per_ticket(
+    business_area: BusinessArea,
+    user: User,
+    complaint_for_approval: GrievanceTicket,
+    another_complaint_for_approval: GrievanceTicket,
+    django_assert_max_num_queries: Any,
+) -> None:
+    with django_assert_max_num_queries(16):
+        BulkActionService().bulk_close(
+            user,
+            [complaint_for_approval.id, another_complaint_for_approval.id],
+            business_area.slug,
+        )
+
+
+def test_bulk_close_closes_multiple_complaints(
+    business_area: BusinessArea,
+    user: User,
+    complaint_for_approval: GrievanceTicket,
+    another_complaint_for_approval: GrievanceTicket,
+) -> None:
+    BulkActionService().bulk_close(
+        user,
+        [complaint_for_approval.id, another_complaint_for_approval.id],
+        business_area.slug,
+    )
+
+    complaint_for_approval.refresh_from_db()
+    another_complaint_for_approval.refresh_from_db()
+
+    assert complaint_for_approval.status == GrievanceTicket.STATUS_CLOSED
+    assert another_complaint_for_approval.status == GrievanceTicket.STATUS_CLOSED
+
+
+def test_bulk_close_rejects_already_closed_ticket(
+    business_area: BusinessArea, user: User, complaint_closed: GrievanceTicket
+) -> None:
+    with pytest.raises(ValidationError):
+        BulkActionService().bulk_close(user, [complaint_closed.id], business_area.slug)
+
+
+def test_bulk_close_rejects_non_existent_ticket(business_area: BusinessArea, user: User) -> None:
+    with pytest.raises(ValidationError):
+        BulkActionService().bulk_close(user, [uuid4()], business_area.slug)
+
+
+def test_bulk_close_with_empty_list_closes_nothing(business_area: BusinessArea, user: User) -> None:
+    result = BulkActionService().bulk_close(user, [], business_area.slug)
+
+    assert result.count() == 0
+
+
+def test_bulk_close_scopes_to_business_area(
+    business_area: BusinessArea, user: User, complaint_in_other_business_area: GrievanceTicket
+) -> None:
+    with pytest.raises(ValidationError):
+        BulkActionService().bulk_close(user, [complaint_in_other_business_area.id], business_area.slug)
+
+    complaint_in_other_business_area.refresh_from_db()
+
+    assert complaint_in_other_business_area.status == GrievanceTicket.STATUS_FOR_APPROVAL


### PR DESCRIPTION
[AB#300979](https://unicef.visualstudio.com/4e044e8d-bc28-4768-8074-f80ff6e4a0e5/_workitems/edit/300979)
Bulk close complaint ticket.
Allow selecting any ticket, but close can be done only if all selected tickets are Complaint and in For Approval status - otherwise throw error.
Validation both on BE and FE.
Button:
<img width="748" height="383" alt="Screenshot 2026-07-13 at 13 10 35" src="https://github.com/user-attachments/assets/e8a20627-0651-4e7a-8a78-146846b1ab84" />
Selection error
<img width="456" height="231" alt="Screenshot 2026-07-13 at 13 11 16" src="https://github.com/user-attachments/assets/28017d6d-f44a-4f69-9d95-ccb038fc04c2" />
Selection ok
<img width="336" height="190" alt="Screenshot 2026-07-13 at 13 11 43" src="https://github.com/user-attachments/assets/8f15d17e-453d-4571-9d4a-42ed786f6426" />
No button when no permissions:
<img width="634" height="102" alt="image" src="https://github.com/user-attachments/assets/48f5f99d-9d6b-47bb-a1f8-7e76e1e0b632" />

