### PR TITLE
Document identity reference and Payment Record extra fields

### DIFF
--- a/docs/guide-user/payment.md
+++ b/docs/guide-user/payment.md
@@ -69,8 +69,14 @@ The entitle formula is used to define the amount that a household or individual 
 8. Upload the filled excel through UPLOAD RECONCILIATION INFO.
     ![Image](_screenshots/payment/pay_28.png)
 
-9. See the reconciliation summary below
+    In addition to the standard reconciliation columns, the file can contain extra columns provided by the Financial Service Provider (FSP), such as an identity or transaction reference. HOPE stores each non-empty value from these columns against the corresponding Payment Record. Empty values are not stored.
+
+9. See the reconciliation summary below.
     ![Image](_screenshots/payment/pay_30.png)
 
-10. Click EXPORT XLSX on the upper right.
+10. Open a Payment Record to review the imported values. They are displayed in the **Reconciliation Information: Extra Info** section. The information can be used, for example, to manually compare an FSP identity reference with the individual's registration-time [Identification Key](population.md#identification-key).
+
+11. Click EXPORT XLSX on the upper right.
     ![Image](_screenshots/payment/pay_29.png)
+
+Support for additional Payment Record reconciliation fields was introduced by [Change Request 299147: Identity Field customisation & PaymentRecord flex fields](https://dev.azure.com/unicef/ICTD-HCT-MIS/_workitems/edit/299147).

--- a/docs/guide-user/population.md
+++ b/docs/guide-user/population.md
@@ -35,3 +35,13 @@ Possible matches will continue to receive cash transfers until a decision has be
 
 4. To view individual details, click on the Individual ID link, bio data, vulnerabilities and an activity log are also displayed.
     ![Image](_screenshots/population/popu_11.png)
+
+### Identification Key
+
+The **Bio Data** section of the individual details page displays an identification key when one is available for the individual. This key can be used as the registration-time identity reference for the individual.
+
+The field label can be configured separately for each programme by a HOPE administrator. For example, a programme can use a label that reflects the identity reference used in its registration process. If no programme-specific label is configured, the field is displayed as **Identification Key**.
+
+The identification key can be manually compared with an identity reference returned by a Financial Service Provider (FSP). References included as additional columns in a reconciliation file are available in the relevant Payment Record details. See [Payment Reconciliation](payment.md#payment-reconciliation).
+
+Programme-specific identification key labels were introduced by [Change Request 299147: Identity Field customisation & PaymentRecord flex fields](https://dev.azure.com/unicef/ICTD-HCT-MIS/_workitems/edit/299147).


### PR DESCRIPTION
## Related change request

- [AB#299147](https://unicef.visualstudio.com/4e044e8d-bc28-4768-8074-f80ff6e4a0e5/_workitems/edit/299147) [Azure DevOps CR 299147: Identity Field customisation & PaymentRecord flex fields](https://dev.azure.com/unicef/ICTD-HCT-MIS/_workitems/edit/299147)
- Implementation: #5691

## What changed

- document the programme-specific Identification Key label shown in Individual Bio Data
- explain the fallback to `Identification Key` when no custom label is configured
- document how additional reconciliation XLSX columns are stored and displayed in Payment Record details
- connect both features through the manual comparison workflow for registration-time and FSP identity references
- identify Change Request 299147 directly in both documentation sections

## Impact

Users and administrators can now find the behavior introduced by CR 299147 in the relevant Population and Payment user-guide sections, including a direct reference to the originating ticket.

## Validation

- pre-commit hooks passed
- `git diff --check`
- `mkdocs build --no-strict` passed

The strict MkDocs build remains blocked by existing CairoSVG warnings caused by a missing system Cairo library; no warnings were introduced by these documentation changes.
