### PR TITLE
[329337] Disable Exclude Create button for finished Payment Plans

### DIFF
--- a/src/frontend/src/components/paymentmodule/PaymentPlanDetails/ExcludeSection/ExcludeSection.tsx
+++ b/src/frontend/src/components/paymentmodule/PaymentPlanDetails/ExcludeSection/ExcludeSection.tsx
@@ -273,8 +273,12 @@ function ExcludeSection({
     }
 
     if (noExclusions && !deletedIds.length) {
+      const createExclusionsDisabled =
+        !isActiveProgram || !hasExcludePermission || !hasOpenOrLockedStatus;
+
       return (
-        <Button
+        <ButtonTooltip
+          title={getTooltipText()}
           variant="contained"
           color="primary"
           data-cy="button-create-exclusions"
@@ -282,10 +286,10 @@ function ExcludeSection({
             setExclusionsOpen(true);
             setEdit(true);
           }}
-          disabled={!isActiveProgram}
+          disabled={createExclusionsDisabled}
         >
           {t('Create')}
-        </Button>
+        </ButtonTooltip>
       );
     }
 

--- a/tests/e2e/payment_module/test_e2e_payment_plans.py
+++ b/tests/e2e/payment_module/test_e2e_payment_plans.py
@@ -700,9 +700,8 @@ class TestPaymentPlans:
         page_payment_module.get_nav_payment_module().click()
         page_payment_module.get_nav_payment_plans().click()
         page_payment_module.get_row(0).click()
-        page_payment_module_details.get_button_create_exclusions().click()
         with pytest.raises(ElementClickInterceptedException):
-            page_payment_module_details.get_button_save_exclusions().click()
+            page_payment_module_details.get_button_create_exclusions().click()
 
     def test_payment_plan_save_exclude_people(
         self,


### PR DESCRIPTION
[AB#329337](https://unicef.visualstudio.com/ICTD-HCT-MIS/_workitems/edit/329337)
## Summary
- The Exclude section's `Create` button (shown before any exclusions exist) ignored the `hasOpenOrLockedStatus`/`hasExcludePermission` checks that already gate the `Edit`/`Save`/`Apply` buttons in the same component, so it stayed clickable for Payment Plans in status `Finished` (or any other non-open/locked status).
- Switched it to `ButtonTooltip` with the same `getTooltipText()` explanation used by the sibling buttons, so it's disabled with a tooltip for finished/non-editable Payment Plans, consistent with the rest of the section.

Status Aborted with excluded ids:
<img width="1275" height="155" alt="image" src="https://github.com/user-attachments/assets/26b62801-9198-4bfd-8f6c-730158183de2" />
Status Finished:
<img width="1283" height="125" alt="image" src="https://github.com/user-attachments/assets/7a70fad3-c51a-41a3-9a61-52a6dd626306" />
Status Open:
<img width="1275" height="83" alt="image" src="https://github.com/user-attachments/assets/6544dc5a-caa3-43ab-8f13-013c5bdc5c09" />


