### PR TITLE
Fix two flaky Selenium E2E tests

### DIFF
--- a/tests/e2e/new_selenium/grievance/test_household_data_update_admin_area.py
+++ b/tests/e2e/new_selenium/grievance/test_household_data_update_admin_area.py
@@ -44,7 +44,10 @@ def test_household_data_update_admin_area_resolves_pcode_to_label(
     admin_area_input = '[data-cy="input-householdDataUpdateFields[0].fieldValue"]'
     browser.wait_for_element_visible(admin_area_input).click()
     browser.type(admin_area_input, "Dehsabz")
-    browser.select_listbox_element(ADMIN_AREA_OPTION)
+    # The value field is a FormikAsyncAutocomplete: each keystroke fires a backend
+    # geo-areas query and the listbox only renders once options resolve. Under parallel
+    # CI load that can exceed select_listbox_element's default 10s wait, so give it more.
+    browser.select_listbox_element(ADMIN_AREA_OPTION, timeout=30)
 
     browser.click('button[data-cy="button-submit"]')
 

--- a/tests/e2e/new_selenium/grievance/test_household_data_update_admin_area.py
+++ b/tests/e2e/new_selenium/grievance/test_household_data_update_admin_area.py
@@ -44,9 +44,6 @@ def test_household_data_update_admin_area_resolves_pcode_to_label(
     admin_area_input = '[data-cy="input-householdDataUpdateFields[0].fieldValue"]'
     browser.wait_for_element_visible(admin_area_input).click()
     browser.type(admin_area_input, "Dehsabz")
-    # The value field is a FormikAsyncAutocomplete: each keystroke fires a backend
-    # geo-areas query and the listbox only renders once options resolve. Under parallel
-    # CI load that can exceed select_listbox_element's default 10s wait, so give it more.
     browser.select_listbox_element(ADMIN_AREA_OPTION, timeout=30)
 
     browser.click('button[data-cy="button-submit"]')

--- a/tests/e2e/program_details/test_program_details.py
+++ b/tests/e2e/program_details/test_program_details.py
@@ -584,6 +584,18 @@ class TestProgrammeDetails:
         page_programme_details.get_button_add_new_programme_cycle().click()
         page_programme_details.fill_data_picker_filter(datetime.now().strftime("%Y-%m-%d"))
         page_programme_details.get_button_next().click()
+        # NEXT PATCHes the default cycle's end date and swaps the dialog to the
+        # "create new cycle" step. The date is typed into a MUI X v9 section field and
+        # may not have committed to Formik by the time NEXT fires; if it hasn't, the
+        # PATCH is skipped, the step never advances, and the cancel below closes the
+        # dialog leaving the end date empty ('-'). Wait for the create step to render so
+        # we know the save committed before cancelling.
+        WebDriverWait(page_programme_details.driver, 15).until(
+            lambda d: any(
+                e.is_displayed()
+                for e in d.find_elements(By.CSS_SELECTOR, page_programme_details.button_create_program_cycle)
+            )
+        )
         # Saving the default cycle's end date re-renders the dialog (the step list shrinks
         # from 2 to 1 and swaps UpdateProgramCycle -> CreateProgramCycle), so the cancel
         # button can go stale mid-transition; retry the click until it lands.

--- a/tests/e2e/program_details/test_program_details.py
+++ b/tests/e2e/program_details/test_program_details.py
@@ -584,12 +584,6 @@ class TestProgrammeDetails:
         page_programme_details.get_button_add_new_programme_cycle().click()
         page_programme_details.fill_data_picker_filter(datetime.now().strftime("%Y-%m-%d"))
         page_programme_details.get_button_next().click()
-        # NEXT PATCHes the default cycle's end date and swaps the dialog to the
-        # "create new cycle" step. The date is typed into a MUI X v9 section field and
-        # may not have committed to Formik by the time NEXT fires; if it hasn't, the
-        # PATCH is skipped, the step never advances, and the cancel below closes the
-        # dialog leaving the end date empty ('-'). Wait for the create step to render so
-        # we know the save committed before cancelling.
         WebDriverWait(page_programme_details.driver, 15).until(
             lambda d: any(
                 e.is_displayed()


### PR DESCRIPTION
## Summary

Two Selenium E2E tests failed intermittently in CI (2 of 218; the rest passed). Both are timing races, not product regressions. Fixes are test-side only.

### 1. `test_household_data_update_admin_area_resolves_pcode_to_label` (new_selenium)
The admin-area value field is a `FormikAsyncAutocomplete` that fires a backend `geo-areas?name=…` query on every keystroke; `ul[role="listbox"]` only renders once the query resolves. Under parallel CI load (`-n auto`) this can exceed `select_listbox_element`'s default **10s** wait, giving `NoSuchElementException: Element {ul[role="listbox"]} was not present after 10 seconds!`.

**Fix:** bump the wait to `timeout=30`.

### 2. `test_program_details_edit_default_cycle_by_add_new_cancel` (legacy)
MUI X v9 date-commit race. The end date is typed into a section-based date field, then NEXT is clicked immediately. If the date hasn't committed to Formik yet (un-flushed React state / dropped keystroke under load), `endDate` validation fails → no PATCH → the dialog step never advances → the cancel closes it leaving the default cycle's end date empty, so the assertion sees `'-'` instead of today's date.

**Fix:** after NEXT, gate on the "create new cycle" step (`button-create-program-cycle`) rendering before cancelling — the same `WebDriverWait` pattern already used by the sibling `test_program_details_add_new_programme_cycle_without_end_date`. This confirms the save committed and makes any real failure loud at the right spot.

