### PR TITLE
Fix flaky Aurora fresh-extract test by ordering default record IDs

### DIFF
--- a/src/hope/contrib/aurora/celery_tasks.py
+++ b/src/hope/contrib/aurora/celery_tasks.py
@@ -72,7 +72,7 @@ def extract_records_async_task(max_records: int = 500) -> None:
 def fresh_extract_records_async_task_action(job: AsyncJob) -> None:
     records_ids = job.config.get("records_ids")
     if not records_ids:
-        records_ids = list(Record.objects.all().only("pk").values_list("pk", flat=True)[:5000])
+        records_ids = list(Record.objects.all().only("pk").order_by("pk").values_list("pk", flat=True)[:5000])
     extract(records_ids)
 
 


### PR DESCRIPTION
## What

Adds an explicit `.order_by("pk")` to the default record-ID query in `fresh_extract_records_async_task_action`.

## Why

The unit test `test_fresh_extract_records_task_action_uses_default_record_ids_when_config_is_empty` was failing intermittently in CI:

```
Expected: extract([44, 45])
Actual:   extract([45, 44])
```

When the job config has no `records_ids`, the task falls back to fetching them from the database:

```python
Record.objects.all().only("pk").values_list("pk", flat=True)[:5000]
```

There was **no `ORDER BY`**, and the `Record` model has no default ordering. Without one, PostgreSQL returns rows in physical (heap) order rather than by ID. Under CI's randomized, parallel test run the two records occasionally came back reversed, which broke the test.

This is not purely a test problem: because the query takes the first `5000` rows, *which* records get extracted in production was also undefined without an explicit order.

## Fix

Order the query by `pk` so the oldest records come first. Behaviour is now deterministic — the test is stable and production always extracts records in a predictable order. No test changes were needed.

