### PR TITLE
[HOTFIX] Payment Plan Group add import export for follow-ups and top-ups

### DIFF
--- a/src/frontend/src/containers/pages/paymentmodule/Groups/BatchDetailsHeader.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/Groups/BatchDetailsHeader.tsx
@@ -63,7 +63,7 @@ export function BatchDetailsHeader({
         {hasExportFile ? (
           <DownloadBatchButton groupId={groupId} tag={tag} />
         ) : (
-          <ExportBatchButton groupId={groupId} tag={tag} isBusy={isBusy} />
+          <ExportBatchButton groupId={groupId} tag={tag} planType={planType} isBusy={isBusy} />
         )}
         {hasPassword && <SendXlsxPasswordBatchButton groupId={groupId} tag={tag} />}
       </Box>

--- a/src/frontend/src/containers/pages/paymentmodule/Groups/BatchDetailsHeader.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/Groups/BatchDetailsHeader.tsx
@@ -7,10 +7,12 @@ import { useTranslation } from 'react-i18next';
 import { DownloadBatchButton } from './actions/DownloadBatchButton';
 import { ExportBatchButton } from './actions/ExportBatchButton';
 import { SendXlsxPasswordBatchButton } from './actions/SendXlsxPasswordBatchButton';
+import { batchPlanTypeLabel } from './utils';
 
 interface BatchDetailsHeaderProps {
   groupId: string;
   tag: string;
+  planType?: string;
   hasExportFile: boolean;
   hasPassword: boolean;
   isBusy: boolean;
@@ -19,6 +21,7 @@ interface BatchDetailsHeaderProps {
 export function BatchDetailsHeader({
   groupId,
   tag,
+  planType,
   hasExportFile,
   hasPassword,
   isBusy,
@@ -45,7 +48,10 @@ export function BatchDetailsHeader({
     <PageHeader
       title={
         <Box display="flex" alignItems="baseline" gap={1}>
-          <Box>{t('Batch')}</Box>
+          <Box>
+            {t('Batch')}
+            {batchPlanTypeLabel(planType)}
+          </Box>
           <Box color="text.secondary" fontSize="0.85em">
             {tag}
           </Box>

--- a/src/frontend/src/containers/pages/paymentmodule/Groups/BatchDetailsHeader.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/Groups/BatchDetailsHeader.tsx
@@ -4,6 +4,7 @@ import { useBaseUrl } from '@hooks/useBaseUrl';
 import { Box } from '@mui/material';
 import { ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
+import { PlanTypeEnum } from '@restgenerated/models/PlanTypeEnum';
 import { DownloadBatchButton } from './actions/DownloadBatchButton';
 import { ExportBatchButton } from './actions/ExportBatchButton';
 import { SendXlsxPasswordBatchButton } from './actions/SendXlsxPasswordBatchButton';
@@ -12,7 +13,7 @@ import { batchPlanTypeLabel } from './utils';
 interface BatchDetailsHeaderProps {
   groupId: string;
   tag: string;
-  planType?: string;
+  planType?: PlanTypeEnum;
   hasExportFile: boolean;
   hasPassword: boolean;
   isBusy: boolean;

--- a/src/frontend/src/containers/pages/paymentmodule/Groups/BatchDetailsHeader.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/Groups/BatchDetailsHeader.tsx
@@ -50,7 +50,7 @@ export function BatchDetailsHeader({
         <Box display="flex" alignItems="baseline" gap={1}>
           <Box>
             {t('Batch')}
-            {batchPlanTypeLabel(planType)}
+            {batchPlanTypeLabel(planType) && ` ${t(batchPlanTypeLabel(planType))}`}
           </Box>
           <Box color="text.secondary" fontSize="0.85em">
             {tag}

--- a/src/frontend/src/containers/pages/paymentmodule/Groups/BatchDetailsPage.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/Groups/BatchDetailsPage.tsx
@@ -63,7 +63,7 @@ const BatchDetailsPage = (): ReactElement => {
 
   return (
     <>
-      <BatchDetailsHeader groupId={groupId} tag={tag} hasExportFile={hasExportFile} hasPassword={hasPassword} isBusy={isBusy} />
+      <BatchDetailsHeader groupId={groupId} tag={tag} planType={batch?.planType} hasExportFile={hasExportFile} hasPassword={hasPassword} isBusy={isBusy} />
       <TableWrapper>
         <PaymentPlansTable
           filter={filter}

--- a/src/frontend/src/containers/pages/paymentmodule/Groups/PaymentPlanGroupDetailsHeader.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/Groups/PaymentPlanGroupDetailsHeader.tsx
@@ -67,6 +67,13 @@ export function PaymentPlanGroupDetailsHeader({
             label={t('Export Top Ups')}
           />
         )}
+        {group?.canExportTopUpAmendment && (
+          <DeliveryExportXlsxGroupButton
+            group={group}
+            planType={PaymentPlanGroupDeliveryExportPlanTypeEnum.TOP_UP_AMENDMENT}
+            label={t('Export Top Up Amendments')}
+          />
+        )}
         <DeliveryExportXlsxWithAuthCodeGroupButton group={group} />
         <DeliveryImportXlsxGroupButton group={group} />
         <SendToPaymentGatewayGroupButton group={group} />

--- a/src/frontend/src/containers/pages/paymentmodule/Groups/PaymentPlanGroupDetailsHeader.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/Groups/PaymentPlanGroupDetailsHeader.tsx
@@ -3,6 +3,7 @@ import { BreadCrumbsItem } from '@core/BreadCrumbs';
 import { PageHeader } from '@core/PageHeader';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { Box } from '@mui/material';
+import { PaymentPlanGroupDeliveryExportPlanTypeEnum } from '@restgenerated/models/PaymentPlanGroupDeliveryExportPlanTypeEnum';
 import { ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
 import { DeletePaymentPlanGroup } from './actions/DeletePaymentPlanGroup';
@@ -51,18 +52,18 @@ export function PaymentPlanGroupDetailsHeader({
     >
       <Box display="flex" alignItems="center">
         <EditGroupName group={group} />
-        <DeliveryExportXlsxGroupButton group={group} />
-        {group?.hasFollowUpPlans && (
+        {group?.canExportRegular && <DeliveryExportXlsxGroupButton group={group} />}
+        {group?.canExportFollowUp && (
           <DeliveryExportXlsxGroupButton
             group={group}
-            planType="FOLLOW_UP"
+            planType={PaymentPlanGroupDeliveryExportPlanTypeEnum.FOLLOW_UP}
             label={t('Export Follow Ups')}
           />
         )}
-        {group?.hasTopUpPlans && (
+        {group?.canExportTopUp && (
           <DeliveryExportXlsxGroupButton
             group={group}
-            planType="TOP_UP"
+            planType={PaymentPlanGroupDeliveryExportPlanTypeEnum.TOP_UP}
             label={t('Export Top Ups')}
           />
         )}

--- a/src/frontend/src/containers/pages/paymentmodule/Groups/PaymentPlanGroupDetailsHeader.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/Groups/PaymentPlanGroupDetailsHeader.tsx
@@ -3,7 +3,6 @@ import { BreadCrumbsItem } from '@core/BreadCrumbs';
 import { PageHeader } from '@core/PageHeader';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { Box } from '@mui/material';
-import { PaymentPlanGroupDeliveryExportPlanTypeEnum } from '@restgenerated/models/PaymentPlanGroupDeliveryExportPlanTypeEnum';
 import { ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
 import { DeletePaymentPlanGroup } from './actions/DeletePaymentPlanGroup';
@@ -52,28 +51,7 @@ export function PaymentPlanGroupDetailsHeader({
     >
       <Box display="flex" alignItems="center">
         <EditGroupName group={group} />
-        {group?.canExportRegular && <DeliveryExportXlsxGroupButton group={group} />}
-        {group?.canExportFollowUp && (
-          <DeliveryExportXlsxGroupButton
-            group={group}
-            planType={PaymentPlanGroupDeliveryExportPlanTypeEnum.FOLLOW_UP}
-            label={t('Export Follow Ups')}
-          />
-        )}
-        {group?.canExportTopUp && (
-          <DeliveryExportXlsxGroupButton
-            group={group}
-            planType={PaymentPlanGroupDeliveryExportPlanTypeEnum.TOP_UP}
-            label={t('Export Top Ups')}
-          />
-        )}
-        {group?.canExportTopUpAmendment && (
-          <DeliveryExportXlsxGroupButton
-            group={group}
-            planType={PaymentPlanGroupDeliveryExportPlanTypeEnum.TOP_UP_AMENDMENT}
-            label={t('Export Top Up Amendments')}
-          />
-        )}
+        <DeliveryExportXlsxGroupButton group={group} />
         <DeliveryExportXlsxWithAuthCodeGroupButton group={group} />
         <DeliveryImportXlsxGroupButton group={group} />
         <SendToPaymentGatewayGroupButton group={group} />

--- a/src/frontend/src/containers/pages/paymentmodule/Groups/PaymentPlanGroupDetailsHeader.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/Groups/PaymentPlanGroupDetailsHeader.tsx
@@ -52,6 +52,20 @@ export function PaymentPlanGroupDetailsHeader({
       <Box display="flex" alignItems="center">
         <EditGroupName group={group} />
         <DeliveryExportXlsxGroupButton group={group} />
+        {group?.hasFollowUpPlans && (
+          <DeliveryExportXlsxGroupButton
+            group={group}
+            planType="FOLLOW_UP"
+            label={t('Export Follow Ups')}
+          />
+        )}
+        {group?.hasTopUpPlans && (
+          <DeliveryExportXlsxGroupButton
+            group={group}
+            planType="TOP_UP"
+            label={t('Export Top Ups')}
+          />
+        )}
         <DeliveryExportXlsxWithAuthCodeGroupButton group={group} />
         <DeliveryImportXlsxGroupButton group={group} />
         <SendToPaymentGatewayGroupButton group={group} />

--- a/src/frontend/src/containers/pages/paymentmodule/Groups/PaymentPlanGroupDetailsPage.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/Groups/PaymentPlanGroupDetailsPage.tsx
@@ -134,7 +134,8 @@ const PaymentPlanGroupDetailsPage = (): ReactElement => {
                   to={`/${baseUrl}/payment-module/groups/${groupId}/batches/${encodeURIComponent(String(batch.exportTag))}`}
                 >
                   {t('Batch')} #{batch.exportTag}
-                  {batchPlanTypeLabel(batch.planType)}
+                  {batchPlanTypeLabel(batch.planType) &&
+                    ` ${t(batchPlanTypeLabel(batch.planType))}`}
                 </BlackLink>
                 {batch.exportFileLink ? (
                   <Link

--- a/src/frontend/src/containers/pages/paymentmodule/Groups/PaymentPlanGroupDetailsPage.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/Groups/PaymentPlanGroupDetailsPage.tsx
@@ -18,7 +18,7 @@ import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 import { PaymentPlansTable } from '@containers/pages/paymentmodule/ProgramCycle/ProgramCycleDetails/PaymentPlansTable';
 import { PaymentPlanGroupDetailsHeader } from '@containers/pages/paymentmodule/Groups/PaymentPlanGroupDetailsHeader';
-import { isGroupBackgroundActionBusy } from './utils';
+import { batchPlanTypeLabel, isGroupBackgroundActionBusy } from './utils';
 
 const initialFilter = {
   search: '',
@@ -134,6 +134,7 @@ const PaymentPlanGroupDetailsPage = (): ReactElement => {
                   to={`/${baseUrl}/payment-module/groups/${groupId}/batches/${encodeURIComponent(String(batch.exportTag))}`}
                 >
                   {t('Batch')} #{batch.exportTag}
+                  {batchPlanTypeLabel(batch.planType)}
                 </BlackLink>
                 {batch.exportFileLink ? (
                   <Link

--- a/src/frontend/src/containers/pages/paymentmodule/Groups/actions/DeliveryExportXlsxGroupButton.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/Groups/actions/DeliveryExportXlsxGroupButton.tsx
@@ -3,6 +3,7 @@ import { useBaseUrl } from '@hooks/useBaseUrl';
 import { useSnackbar } from '@hooks/useSnackBar';
 import { GetApp } from '@mui/icons-material';
 import { Box } from '@mui/material';
+import { PaymentPlanGroupDeliveryExportPlanTypeEnum } from '@restgenerated/models/PaymentPlanGroupDeliveryExportPlanTypeEnum';
 import { RestService } from '@restgenerated/services/RestService';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { ReactElement } from 'react';
@@ -14,7 +15,7 @@ import { showApiErrorMessages } from '@utils/utils';
 interface DeliveryExportXlsxGroupButtonProps {
   group: PaymentPlanGroupDetail | null;
   /** When provided, only plans of this type are exported (defaults to REGULAR on the backend). */
-  planType?: 'FOLLOW_UP' | 'TOP_UP';
+  planType?: PaymentPlanGroupDeliveryExportPlanTypeEnum;
   label?: string;
 }
 

--- a/src/frontend/src/containers/pages/paymentmodule/Groups/actions/DeliveryExportXlsxGroupButton.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/Groups/actions/DeliveryExportXlsxGroupButton.tsx
@@ -1,74 +1,34 @@
-import { LoadingButton } from '@core/LoadingButton';
-import { useBaseUrl } from '@hooks/useBaseUrl';
-import { useSnackbar } from '@hooks/useSnackBar';
-import { GetApp } from '@mui/icons-material';
-import { Box } from '@mui/material';
-import { PaymentPlanGroupDeliveryExportPlanTypeEnum } from '@restgenerated/models/PaymentPlanGroupDeliveryExportPlanTypeEnum';
-import { RestService } from '@restgenerated/services/RestService';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
 import { PaymentPlanGroupDetail } from '../types';
-import { isGroupBackgroundActionBusy } from '../utils';
-import { showApiErrorMessages } from '@utils/utils';
+import {
+  exportablePlanTypeOptions,
+  isGroupBackgroundActionBusy,
+} from '../utils';
+import { GroupExportXlsxDialog } from './GroupExportXlsxDialog';
 
 interface DeliveryExportXlsxGroupButtonProps {
   group: PaymentPlanGroupDetail | null;
-  /** When provided, only plans of this type are exported (defaults to REGULAR on the backend). */
-  planType?: PaymentPlanGroupDeliveryExportPlanTypeEnum;
-  label?: string;
 }
 
 export function DeliveryExportXlsxGroupButton({
   group,
-  planType,
-  label,
-}: DeliveryExportXlsxGroupButtonProps): ReactElement {
+}: DeliveryExportXlsxGroupButtonProps): ReactElement | null {
   const { t } = useTranslation();
-  const { businessArea, programId } = useBaseUrl();
-  const { showMessage } = useSnackbar();
-  const queryClient = useQueryClient();
+  const planTypeOptions = exportablePlanTypeOptions(group, t);
 
-  const { mutateAsync: exportXlsx, isPending: loadingExport } = useMutation({
-    mutationFn: () =>
-      RestService.restBusinessAreasProgramsPaymentPlanGroupsDeliveryExportXlsxCreate(
-        {
-          businessAreaSlug: businessArea,
-          programCode: programId,
-          id: group?.id,
-          ...(planType ? { requestBody: { planType } } : {}),
-        },
-      ),
-    onSuccess: () => {
-      showMessage(t('Export started'));
-      queryClient.invalidateQueries({
-        queryKey: ['paymentPlanGroup', businessArea, programId, group?.id],
-      });
-    },
-    onError: (error: any) => {
-      showApiErrorMessages(error, showMessage, t('Export failed'));
-    },
-  });
-
-  const isDisabled =
-    !group || loadingExport || isGroupBackgroundActionBusy(group);
-  const dataCySuffix = planType
-    ? `-${planType.toLowerCase().replaceAll('_', '-')}`
-    : '';
+  if (group && planTypeOptions.length === 0) return null;
 
   return (
-    <Box m={2}>
-      <LoadingButton
-        loading={loadingExport}
-        startIcon={<GetApp />}
-        color="primary"
-        variant="contained"
-        onClick={() => exportXlsx()}
-        disabled={isDisabled}
-        data-cy={`button-delivery-export-xlsx-group${dataCySuffix}`}
-      >
-        {label ?? t('Export')}
-      </LoadingButton>
-    </Box>
+    <GroupExportXlsxDialog
+      groupId={group?.id ?? ''}
+      planTypeOptions={planTypeOptions}
+      showTemplateChoice={false}
+      buttonLabel={t('Export')}
+      dialogTitle={t('Export')}
+      buttonVariant="contained"
+      disabled={!group || isGroupBackgroundActionBusy(group)}
+      dataCySuffix="delivery-export-xlsx-group"
+    />
   );
 }

--- a/src/frontend/src/containers/pages/paymentmodule/Groups/actions/DeliveryExportXlsxGroupButton.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/Groups/actions/DeliveryExportXlsxGroupButton.tsx
@@ -52,7 +52,9 @@ export function DeliveryExportXlsxGroupButton({
 
   const isDisabled =
     !group || loadingExport || isGroupBackgroundActionBusy(group);
-  const dataCySuffix = planType ? `-${planType.toLowerCase().replace('_', '-')}` : '';
+  const dataCySuffix = planType
+    ? `-${planType.toLowerCase().replaceAll('_', '-')}`
+    : '';
 
   return (
     <Box m={2}>

--- a/src/frontend/src/containers/pages/paymentmodule/Groups/actions/DeliveryExportXlsxGroupButton.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/Groups/actions/DeliveryExportXlsxGroupButton.tsx
@@ -13,10 +13,15 @@ import { showApiErrorMessages } from '@utils/utils';
 
 interface DeliveryExportXlsxGroupButtonProps {
   group: PaymentPlanGroupDetail | null;
+  /** When provided, only plans of this type are exported (defaults to REGULAR on the backend). */
+  planType?: 'FOLLOW_UP' | 'TOP_UP';
+  label?: string;
 }
 
 export function DeliveryExportXlsxGroupButton({
   group,
+  planType,
+  label,
 }: DeliveryExportXlsxGroupButtonProps): ReactElement {
   const { t } = useTranslation();
   const { businessArea, programId } = useBaseUrl();
@@ -30,6 +35,7 @@ export function DeliveryExportXlsxGroupButton({
           businessAreaSlug: businessArea,
           programCode: programId,
           id: group?.id,
+          ...(planType ? { requestBody: { planType } } : {}),
         },
       ),
     onSuccess: () => {
@@ -45,6 +51,7 @@ export function DeliveryExportXlsxGroupButton({
 
   const isDisabled =
     !group || loadingExport || isGroupBackgroundActionBusy(group);
+  const dataCySuffix = planType ? `-${planType.toLowerCase().replace('_', '-')}` : '';
 
   return (
     <Box m={2}>
@@ -55,9 +62,9 @@ export function DeliveryExportXlsxGroupButton({
         variant="contained"
         onClick={() => exportXlsx()}
         disabled={isDisabled}
-        data-cy="button-delivery-export-xlsx-group"
+        data-cy={`button-delivery-export-xlsx-group${dataCySuffix}`}
       >
-        {t('Export')}
+        {label ?? t('Export')}
       </LoadingButton>
     </Box>
   );

--- a/src/frontend/src/containers/pages/paymentmodule/Groups/actions/DeliveryExportXlsxWithAuthCodeGroupButton.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/Groups/actions/DeliveryExportXlsxWithAuthCodeGroupButton.tsx
@@ -1,8 +1,12 @@
+import { PaymentPlanGroupDeliveryExportPlanTypeEnum } from '@restgenerated/models/PaymentPlanGroupDeliveryExportPlanTypeEnum';
 import { ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
 import { PaymentPlanGroupDetail } from '../types';
 import { isGroupBackgroundActionBusy } from '../utils';
-import { GroupExportXlsxDialog } from './GroupExportXlsxDialog';
+import {
+  GroupExportPlanTypeOption,
+  GroupExportXlsxDialog,
+} from './GroupExportXlsxDialog';
 
 interface DeliveryExportXlsxWithAuthCodeGroupButtonProps {
   group: PaymentPlanGroupDetail | null;
@@ -10,11 +14,42 @@ interface DeliveryExportXlsxWithAuthCodeGroupButtonProps {
 
 export function DeliveryExportXlsxWithAuthCodeGroupButton({
   group,
-}: DeliveryExportXlsxWithAuthCodeGroupButtonProps): ReactElement {
+}: DeliveryExportXlsxWithAuthCodeGroupButtonProps): ReactElement | null {
   const { t } = useTranslation();
+
+  const planTypeOptions: GroupExportPlanTypeOption[] = [
+    ...(group?.canExportRegular
+      ? [
+          {
+            value: PaymentPlanGroupDeliveryExportPlanTypeEnum.REGULAR,
+            label: t('Regular'),
+          },
+        ]
+      : []),
+    ...(group?.canExportFollowUp
+      ? [
+          {
+            value: PaymentPlanGroupDeliveryExportPlanTypeEnum.FOLLOW_UP,
+            label: t('Follow Up'),
+          },
+        ]
+      : []),
+    ...(group?.canExportTopUp
+      ? [
+          {
+            value: PaymentPlanGroupDeliveryExportPlanTypeEnum.TOP_UP,
+            label: t('Top Up'),
+          },
+        ]
+      : []),
+  ];
+
+  if (group && planTypeOptions.length === 0) return null;
+
   return (
     <GroupExportXlsxDialog
       groupId={group?.id ?? ''}
+      planTypeOptions={planTypeOptions}
       buttonLabel={t('Export with Auth Code')}
       dialogTitle={t('Export with Auth Code')}
       buttonVariant="outlined"

--- a/src/frontend/src/containers/pages/paymentmodule/Groups/actions/DeliveryExportXlsxWithAuthCodeGroupButton.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/Groups/actions/DeliveryExportXlsxWithAuthCodeGroupButton.tsx
@@ -33,6 +33,9 @@ export function DeliveryExportXlsxWithAuthCodeGroupButton({
     ...(group?.canExportTopUp
       ? [toOption(PaymentPlanGroupDeliveryExportPlanTypeEnum.TOP_UP)]
       : []),
+    ...(group?.canExportTopUpAmendment
+      ? [toOption(PaymentPlanGroupDeliveryExportPlanTypeEnum.TOP_UP_AMENDMENT)]
+      : []),
   ];
 
   if (group && planTypeOptions.length === 0) return null;

--- a/src/frontend/src/containers/pages/paymentmodule/Groups/actions/DeliveryExportXlsxWithAuthCodeGroupButton.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/Groups/actions/DeliveryExportXlsxWithAuthCodeGroupButton.tsx
@@ -2,7 +2,7 @@ import { PaymentPlanGroupDeliveryExportPlanTypeEnum } from '@restgenerated/model
 import { ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
 import { PaymentPlanGroupDetail } from '../types';
-import { isGroupBackgroundActionBusy } from '../utils';
+import { isGroupBackgroundActionBusy, planTypeDisplayLabel } from '../utils';
 import {
   GroupExportPlanTypeOption,
   GroupExportXlsxDialog,
@@ -17,30 +17,21 @@ export function DeliveryExportXlsxWithAuthCodeGroupButton({
 }: DeliveryExportXlsxWithAuthCodeGroupButtonProps): ReactElement | null {
   const { t } = useTranslation();
 
+  const toOption = (
+    value: PaymentPlanGroupDeliveryExportPlanTypeEnum,
+  ): GroupExportPlanTypeOption => ({
+    value,
+    label: t(planTypeDisplayLabel(value)),
+  });
   const planTypeOptions: GroupExportPlanTypeOption[] = [
     ...(group?.canExportRegular
-      ? [
-          {
-            value: PaymentPlanGroupDeliveryExportPlanTypeEnum.REGULAR,
-            label: t('Regular'),
-          },
-        ]
+      ? [toOption(PaymentPlanGroupDeliveryExportPlanTypeEnum.REGULAR)]
       : []),
     ...(group?.canExportFollowUp
-      ? [
-          {
-            value: PaymentPlanGroupDeliveryExportPlanTypeEnum.FOLLOW_UP,
-            label: t('Follow Up'),
-          },
-        ]
+      ? [toOption(PaymentPlanGroupDeliveryExportPlanTypeEnum.FOLLOW_UP)]
       : []),
     ...(group?.canExportTopUp
-      ? [
-          {
-            value: PaymentPlanGroupDeliveryExportPlanTypeEnum.TOP_UP,
-            label: t('Top Up'),
-          },
-        ]
+      ? [toOption(PaymentPlanGroupDeliveryExportPlanTypeEnum.TOP_UP)]
       : []),
   ];
 

--- a/src/frontend/src/containers/pages/paymentmodule/Groups/actions/DeliveryExportXlsxWithAuthCodeGroupButton.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/Groups/actions/DeliveryExportXlsxWithAuthCodeGroupButton.tsx
@@ -1,12 +1,11 @@
-import { PaymentPlanGroupDeliveryExportPlanTypeEnum } from '@restgenerated/models/PaymentPlanGroupDeliveryExportPlanTypeEnum';
 import { ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
 import { PaymentPlanGroupDetail } from '../types';
-import { isGroupBackgroundActionBusy, planTypeDisplayLabel } from '../utils';
 import {
-  GroupExportPlanTypeOption,
-  GroupExportXlsxDialog,
-} from './GroupExportXlsxDialog';
+  exportablePlanTypeOptions,
+  isGroupBackgroundActionBusy,
+} from '../utils';
+import { GroupExportXlsxDialog } from './GroupExportXlsxDialog';
 
 interface DeliveryExportXlsxWithAuthCodeGroupButtonProps {
   group: PaymentPlanGroupDetail | null;
@@ -16,27 +15,7 @@ export function DeliveryExportXlsxWithAuthCodeGroupButton({
   group,
 }: DeliveryExportXlsxWithAuthCodeGroupButtonProps): ReactElement | null {
   const { t } = useTranslation();
-
-  const toOption = (
-    value: PaymentPlanGroupDeliveryExportPlanTypeEnum,
-  ): GroupExportPlanTypeOption => ({
-    value,
-    label: t(planTypeDisplayLabel(value)),
-  });
-  const planTypeOptions: GroupExportPlanTypeOption[] = [
-    ...(group?.canExportRegular
-      ? [toOption(PaymentPlanGroupDeliveryExportPlanTypeEnum.REGULAR)]
-      : []),
-    ...(group?.canExportFollowUp
-      ? [toOption(PaymentPlanGroupDeliveryExportPlanTypeEnum.FOLLOW_UP)]
-      : []),
-    ...(group?.canExportTopUp
-      ? [toOption(PaymentPlanGroupDeliveryExportPlanTypeEnum.TOP_UP)]
-      : []),
-    ...(group?.canExportTopUpAmendment
-      ? [toOption(PaymentPlanGroupDeliveryExportPlanTypeEnum.TOP_UP_AMENDMENT)]
-      : []),
-  ];
+  const planTypeOptions = exportablePlanTypeOptions(group, t);
 
   if (group && planTypeOptions.length === 0) return null;
 

--- a/src/frontend/src/containers/pages/paymentmodule/Groups/actions/ExportBatchButton.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/Groups/actions/ExportBatchButton.tsx
@@ -5,12 +5,14 @@ import { GroupExportXlsxDialog } from './GroupExportXlsxDialog';
 interface ExportBatchButtonProps {
   groupId: string;
   tag: string;
+  planType?: string;
   isBusy?: boolean;
 }
 
 export function ExportBatchButton({
   groupId,
   tag,
+  planType,
   isBusy = false,
 }: ExportBatchButtonProps): ReactElement {
   const { t } = useTranslation();
@@ -18,6 +20,7 @@ export function ExportBatchButton({
     <GroupExportXlsxDialog
       groupId={groupId}
       exportTag={parseInt(tag, 10)}
+      lockedPlanType={planType}
       buttonLabel={t('Re-export Batch')}
       dialogTitle={t('Re-export Batch #{{tag}}', { tag })}
       buttonVariant="contained"

--- a/src/frontend/src/containers/pages/paymentmodule/Groups/actions/ExportBatchButton.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/Groups/actions/ExportBatchButton.tsx
@@ -1,3 +1,4 @@
+import { PlanTypeEnum } from '@restgenerated/models/PlanTypeEnum';
 import { ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
 import { GroupExportXlsxDialog } from './GroupExportXlsxDialog';
@@ -5,7 +6,7 @@ import { GroupExportXlsxDialog } from './GroupExportXlsxDialog';
 interface ExportBatchButtonProps {
   groupId: string;
   tag: string;
-  planType?: string;
+  planType?: PlanTypeEnum;
   isBusy?: boolean;
 }
 

--- a/src/frontend/src/containers/pages/paymentmodule/Groups/actions/GroupExportXlsxDialog.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/Groups/actions/GroupExportXlsxDialog.tsx
@@ -13,18 +13,15 @@ import {
   DialogTitle,
   TextField,
 } from '@mui/material';
-import { PaymentPlanGroupDeliveryExportPlanTypeEnum } from '@restgenerated/models/PaymentPlanGroupDeliveryExportPlanTypeEnum';
 import { RestService } from '@restgenerated/services/RestService';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { showApiErrorMessages } from '@utils/utils';
 import { ReactElement, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { planTypeDisplayLabel } from '../utils';
-
-export interface GroupExportPlanTypeOption {
-  value: PaymentPlanGroupDeliveryExportPlanTypeEnum;
-  label: string;
-}
+import {
+  GroupExportPlanTypeOption,
+  planTypeDisplayLabel,
+} from '../utils';
 
 interface GroupExportXlsxDialogProps {
   groupId: string;
@@ -41,6 +38,8 @@ interface GroupExportXlsxDialogProps {
    * re-export: the batch's own type); shown as a locked field, never sent.
    */
   lockedPlanType?: string;
+  /** Hide the FSP XLSX template picker (plain export resolves templates per plan). */
+  showTemplateChoice?: boolean;
   buttonLabel: string;
   dialogTitle: string;
   buttonVariant?: 'contained' | 'outlined';
@@ -58,6 +57,7 @@ export function GroupExportXlsxDialog({
   exportTag,
   planTypeOptions,
   lockedPlanType,
+  showTemplateChoice = true,
   buttonLabel,
   dialogTitle,
   buttonVariant = 'contained',
@@ -84,7 +84,7 @@ export function GroupExportXlsxDialog({
         programCode: programId,
         limit: 200,
       }),
-    enabled: open && !!businessArea && !!programId,
+    enabled: open && showTemplateChoice && !!businessArea && !!programId,
   });
   const templateOptions = (templatesData?.results ?? []).map((tmpl) => ({
     id: tmpl.id,
@@ -188,21 +188,23 @@ export function GroupExportXlsxDialog({
                 sx={{ mt: 1, mb: 2 }}
               />
             )}
-            <Autocomplete
-              options={templateOptions}
-              value={selectedTemplate}
-              onChange={(_, value) => setSelectedTemplate(value)}
-              getOptionLabel={(opt) => opt.label}
-              isOptionEqualToValue={(a, b) => a.id === b.id}
-              renderInput={(params) => (
-                <TextField
-                  {...params}
-                  label={t('FSP XLSX Template (optional)')}
-                  size="small"
-                />
-              )}
-              sx={{ mt: 1 }}
-            />
+            {showTemplateChoice && (
+              <Autocomplete
+                options={templateOptions}
+                value={selectedTemplate}
+                onChange={(_, value) => setSelectedTemplate(value)}
+                getOptionLabel={(opt) => opt.label}
+                isOptionEqualToValue={(a, b) => a.id === b.id}
+                renderInput={(params) => (
+                  <TextField
+                    {...params}
+                    label={t('FSP XLSX Template (optional)')}
+                    size="small"
+                  />
+                )}
+                sx={{ mt: 1 }}
+              />
+            )}
           </DialogContent>
           <DialogActions>
             <Button onClick={handleClose}>{t('CANCEL')}</Button>

--- a/src/frontend/src/containers/pages/paymentmodule/Groups/actions/GroupExportXlsxDialog.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/Groups/actions/GroupExportXlsxDialog.tsx
@@ -19,6 +19,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { showApiErrorMessages } from '@utils/utils';
 import { ReactElement, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { planTypeDisplayLabel } from '../utils';
 
 export interface GroupExportPlanTypeOption {
   value: PaymentPlanGroupDeliveryExportPlanTypeEnum;
@@ -31,9 +32,15 @@ interface GroupExportXlsxDialogProps {
   exportTag?: number;
   /**
    * Exportable plan types to choose from; a select is shown when there is more than
-   * one. Omit (batch re-export) to send no planType at all.
+   * one, a locked read-only field when there is exactly one. Omit (batch re-export)
+   * to send no planType at all.
    */
   planTypeOptions?: GroupExportPlanTypeOption[];
+  /**
+   * Display-only plan type of the exported data when it is already fixed (batch
+   * re-export: the batch's own type); shown as a locked field, never sent.
+   */
+  lockedPlanType?: string;
   buttonLabel: string;
   dialogTitle: string;
   buttonVariant?: 'contained' | 'outlined';
@@ -50,6 +57,7 @@ export function GroupExportXlsxDialog({
   groupId,
   exportTag,
   planTypeOptions,
+  lockedPlanType,
   buttonLabel,
   dialogTitle,
   buttonVariant = 'contained',
@@ -144,10 +152,27 @@ export function GroupExportXlsxDialog({
       >
         <DialogTitleWrapper data-cy={`dialog-${dataCySuffix}`}>
           <DialogTitle>{dialogTitle}</DialogTitle>
-          <DialogContent>
-            {planTypeOptions && planTypeOptions.length > 1 && (
+          {/* keep top padding despite MUI's `DialogTitle + DialogContent { padding-top: 0 }`,
+              otherwise the first field's shrunk label is clipped */}
+          <DialogContent sx={{ pt: '12px !important' }}>
+            {(lockedPlanType || planTypeOptions?.length === 1) && (
+              <TextField
+                label={t('Plan Type')}
+                value={
+                  lockedPlanType
+                    ? planTypeDisplayLabel(lockedPlanType)
+                    : (planTypeOptions?.[0]?.label ?? '')
+                }
+                size="small"
+                fullWidth
+                disabled
+                data-cy={`locked-${dataCySuffix}-plan-type`}
+                sx={{ mt: 1, mb: 2 }}
+              />
+            )}
+            {!lockedPlanType && (planTypeOptions?.length ?? 0) > 1 && (
               <Autocomplete
-                options={planTypeOptions}
+                options={planTypeOptions ?? []}
                 value={selectedPlanType}
                 onChange={(_, value) => setSelectedPlanType(value)}
                 getOptionLabel={(opt) => opt.label}

--- a/src/frontend/src/containers/pages/paymentmodule/Groups/actions/GroupExportXlsxDialog.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/Groups/actions/GroupExportXlsxDialog.tsx
@@ -13,16 +13,27 @@ import {
   DialogTitle,
   TextField,
 } from '@mui/material';
+import { PaymentPlanGroupDeliveryExportPlanTypeEnum } from '@restgenerated/models/PaymentPlanGroupDeliveryExportPlanTypeEnum';
 import { RestService } from '@restgenerated/services/RestService';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { showApiErrorMessages } from '@utils/utils';
 import { ReactElement, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+export interface GroupExportPlanTypeOption {
+  value: PaymentPlanGroupDeliveryExportPlanTypeEnum;
+  label: string;
+}
+
 interface GroupExportXlsxDialogProps {
   groupId: string;
   /** When provided, sent as `exportTag` in the export request (batch re-export). */
   exportTag?: number;
+  /**
+   * Exportable plan types to choose from; a select is shown when there is more than
+   * one. Omit (batch re-export) to send no planType at all.
+   */
+  planTypeOptions?: GroupExportPlanTypeOption[];
   buttonLabel: string;
   dialogTitle: string;
   buttonVariant?: 'contained' | 'outlined';
@@ -38,6 +49,7 @@ interface GroupExportXlsxDialogProps {
 export function GroupExportXlsxDialog({
   groupId,
   exportTag,
+  planTypeOptions,
   buttonLabel,
   dialogTitle,
   buttonVariant = 'contained',
@@ -50,6 +62,8 @@ export function GroupExportXlsxDialog({
     id: string;
     label: string;
   } | null>(null);
+  const [selectedPlanType, setSelectedPlanType] =
+    useState<GroupExportPlanTypeOption | null>(planTypeOptions?.[0] ?? null);
   const { businessArea, programId } = useBaseUrl();
   const { showMessage } = useSnackbar();
   const queryClient = useQueryClient();
@@ -78,6 +92,7 @@ export function GroupExportXlsxDialog({
           id: groupId,
           requestBody: {
             ...(exportTag !== undefined ? { exportTag } : {}),
+            ...(selectedPlanType ? { planType: selectedPlanType.value } : {}),
             fspXlsxTemplateId: selectedTemplate?.id ?? null,
           },
         },
@@ -95,6 +110,11 @@ export function GroupExportXlsxDialog({
     },
   });
 
+  const handleOpen = (): void => {
+    setSelectedPlanType(planTypeOptions?.[0] ?? null);
+    setOpen(true);
+  };
+
   const handleClose = (): void => {
     setOpen(false);
     setSelectedTemplate(null);
@@ -108,7 +128,7 @@ export function GroupExportXlsxDialog({
           startIcon={<GetApp />}
           color="primary"
           variant={buttonVariant}
-          onClick={() => setOpen(true)}
+          onClick={handleOpen}
           disabled={disabled || loadingExport}
           data-cy={`button-${dataCySuffix}`}
         >
@@ -125,6 +145,24 @@ export function GroupExportXlsxDialog({
         <DialogTitleWrapper data-cy={`dialog-${dataCySuffix}`}>
           <DialogTitle>{dialogTitle}</DialogTitle>
           <DialogContent>
+            {planTypeOptions && planTypeOptions.length > 1 && (
+              <Autocomplete
+                options={planTypeOptions}
+                value={selectedPlanType}
+                onChange={(_, value) => setSelectedPlanType(value)}
+                getOptionLabel={(opt) => opt.label}
+                isOptionEqualToValue={(a, b) => a.value === b.value}
+                renderInput={(params) => (
+                  <TextField
+                    {...params}
+                    label={t('Plan Type')}
+                    size="small"
+                    data-cy={`select-${dataCySuffix}-plan-type`}
+                  />
+                )}
+                sx={{ mt: 1, mb: 2 }}
+              />
+            )}
             <Autocomplete
               options={templateOptions}
               value={selectedTemplate}
@@ -148,6 +186,7 @@ export function GroupExportXlsxDialog({
               color="primary"
               variant="contained"
               onClick={() => exportXlsx()}
+              disabled={!!planTypeOptions?.length && !selectedPlanType}
               data-cy={`button-${dataCySuffix}-submit`}
             >
               {t('EXPORT')}

--- a/src/frontend/src/containers/pages/paymentmodule/Groups/actions/GroupExportXlsxDialog.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/Groups/actions/GroupExportXlsxDialog.tsx
@@ -13,6 +13,7 @@ import {
   DialogTitle,
   TextField,
 } from '@mui/material';
+import { PlanTypeEnum } from '@restgenerated/models/PlanTypeEnum';
 import { RestService } from '@restgenerated/services/RestService';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { showApiErrorMessages } from '@utils/utils';
@@ -37,7 +38,7 @@ interface GroupExportXlsxDialogProps {
    * Display-only plan type of the exported data when it is already fixed (batch
    * re-export: the batch's own type); shown as a locked field, never sent.
    */
-  lockedPlanType?: string;
+  lockedPlanType?: PlanTypeEnum;
   /** Hide the FSP XLSX template picker (plain export resolves templates per plan). */
   showTemplateChoice?: boolean;
   buttonLabel: string;

--- a/src/frontend/src/containers/pages/paymentmodule/Groups/utils.ts
+++ b/src/frontend/src/containers/pages/paymentmodule/Groups/utils.ts
@@ -14,6 +14,7 @@ export function isGroupBackgroundActionBusy(
   );
 }
 
+// Untranslated label for a plan type — pass the result through t() when rendering.
 export function planTypeDisplayLabel(planType: string | undefined): string {
   switch (planType) {
     case 'REGULAR':
@@ -27,9 +28,8 @@ export function planTypeDisplayLabel(planType: string | undefined): string {
   }
 }
 
-// Suffix shown next to a batch name for non-regular batches, e.g. " Follow Up".
+// Untranslated label shown next to a batch name; empty for regular batches.
 export function batchPlanTypeLabel(planType: string | undefined): string {
-  if (planType === undefined || planType === 'REGULAR') return '';
-  const label = planTypeDisplayLabel(planType);
-  return label ? ` ${label}` : '';
+  if (planType === 'REGULAR') return '';
+  return planTypeDisplayLabel(planType);
 }

--- a/src/frontend/src/containers/pages/paymentmodule/Groups/utils.ts
+++ b/src/frontend/src/containers/pages/paymentmodule/Groups/utils.ts
@@ -14,14 +14,22 @@ export function isGroupBackgroundActionBusy(
   );
 }
 
-// Suffix shown next to a batch name for non-regular batches, e.g. " Follow Up".
-export function batchPlanTypeLabel(planType: string | undefined): string {
+export function planTypeDisplayLabel(planType: string | undefined): string {
   switch (planType) {
+    case 'REGULAR':
+      return 'Regular';
     case 'FOLLOW_UP':
-      return ' Follow Up';
+      return 'Follow Up';
     case 'TOP_UP':
-      return ' Top Up';
+      return 'Top Up';
     default:
       return '';
   }
+}
+
+// Suffix shown next to a batch name for non-regular batches, e.g. " Follow Up".
+export function batchPlanTypeLabel(planType: string | undefined): string {
+  if (planType === undefined || planType === 'REGULAR') return '';
+  const label = planTypeDisplayLabel(planType);
+  return label ? ` ${label}` : '';
 }

--- a/src/frontend/src/containers/pages/paymentmodule/Groups/utils.ts
+++ b/src/frontend/src/containers/pages/paymentmodule/Groups/utils.ts
@@ -13,3 +13,15 @@ export function isGroupBackgroundActionBusy(
     status === PaymentPlanGroupDetailBackgroundActionStatusEnum.XLSX_IMPORTING_RECONCILIATION
   );
 }
+
+// Suffix shown next to a batch name for non-regular batches, e.g. " Follow Up".
+export function batchPlanTypeLabel(planType: string | undefined): string {
+  switch (planType) {
+    case 'FOLLOW_UP':
+      return ' Follow Up';
+    case 'TOP_UP':
+      return ' Top Up';
+    default:
+      return '';
+  }
+}

--- a/src/frontend/src/containers/pages/paymentmodule/Groups/utils.ts
+++ b/src/frontend/src/containers/pages/paymentmodule/Groups/utils.ts
@@ -1,3 +1,4 @@
+import { PaymentPlanGroupDeliveryExportPlanTypeEnum } from '@restgenerated/models/PaymentPlanGroupDeliveryExportPlanTypeEnum';
 import { PaymentPlanGroupDetailBackgroundActionStatusEnum } from '@restgenerated/models/PaymentPlanGroupDetailBackgroundActionStatusEnum';
 import { PaymentPlanGroupDetail } from './types';
 
@@ -34,4 +35,33 @@ export function planTypeDisplayLabel(planType: string | undefined): string {
 export function batchPlanTypeLabel(planType: string | undefined): string {
   if (planType === 'REGULAR') return '';
   return planTypeDisplayLabel(planType);
+}
+
+export interface GroupExportPlanTypeOption {
+  value: PaymentPlanGroupDeliveryExportPlanTypeEnum;
+  label: string;
+}
+
+// Plan types the group can currently export, as translated dialog options.
+export function exportablePlanTypeOptions(
+  group: PaymentPlanGroupDetail | null,
+  t: (key: string) => string,
+): GroupExportPlanTypeOption[] {
+  const flagged: Array<
+    [boolean | undefined, PaymentPlanGroupDeliveryExportPlanTypeEnum]
+  > = [
+    [group?.canExportRegular, PaymentPlanGroupDeliveryExportPlanTypeEnum.REGULAR],
+    [
+      group?.canExportFollowUp,
+      PaymentPlanGroupDeliveryExportPlanTypeEnum.FOLLOW_UP,
+    ],
+    [group?.canExportTopUp, PaymentPlanGroupDeliveryExportPlanTypeEnum.TOP_UP],
+    [
+      group?.canExportTopUpAmendment,
+      PaymentPlanGroupDeliveryExportPlanTypeEnum.TOP_UP_AMENDMENT,
+    ],
+  ];
+  return flagged
+    .filter(([canExport]) => canExport)
+    .map(([, value]) => ({ value, label: t(planTypeDisplayLabel(value)) }));
 }

--- a/src/frontend/src/containers/pages/paymentmodule/Groups/utils.ts
+++ b/src/frontend/src/containers/pages/paymentmodule/Groups/utils.ts
@@ -23,6 +23,8 @@ export function planTypeDisplayLabel(planType: string | undefined): string {
       return 'Follow Up';
     case 'TOP_UP':
       return 'Top Up';
+    case 'TOP_UP_AMENDMENT':
+      return 'Top Up Amendment';
     default:
       return '';
   }

--- a/src/frontend/src/containers/pages/paymentmodule/Groups/utils.ts
+++ b/src/frontend/src/containers/pages/paymentmodule/Groups/utils.ts
@@ -1,5 +1,5 @@
-import { PaymentPlanGroupDeliveryExportPlanTypeEnum } from '@restgenerated/models/PaymentPlanGroupDeliveryExportPlanTypeEnum';
 import { PaymentPlanGroupDetailBackgroundActionStatusEnum } from '@restgenerated/models/PaymentPlanGroupDetailBackgroundActionStatusEnum';
+import { PlanTypeEnum } from '@restgenerated/models/PlanTypeEnum';
 import { PaymentPlanGroupDetail } from './types';
 
 // A group runs one background XLSX action at a time. Export/import may start only
@@ -16,15 +16,15 @@ export function isGroupBackgroundActionBusy(
 }
 
 // Untranslated label for a plan type — pass the result through t() when rendering.
-export function planTypeDisplayLabel(planType: string | undefined): string {
+export function planTypeDisplayLabel(planType: PlanTypeEnum | undefined): string {
   switch (planType) {
-    case 'REGULAR':
+    case PlanTypeEnum.REGULAR:
       return 'Regular';
-    case 'FOLLOW_UP':
+    case PlanTypeEnum.FOLLOW_UP:
       return 'Follow Up';
-    case 'TOP_UP':
+    case PlanTypeEnum.TOP_UP:
       return 'Top Up';
-    case 'TOP_UP_AMENDMENT':
+    case PlanTypeEnum.TOP_UP_AMENDMENT:
       return 'Top Up Amendment';
     default:
       return '';
@@ -32,13 +32,13 @@ export function planTypeDisplayLabel(planType: string | undefined): string {
 }
 
 // Untranslated label shown next to a batch name; empty for regular batches.
-export function batchPlanTypeLabel(planType: string | undefined): string {
-  if (planType === 'REGULAR') return '';
+export function batchPlanTypeLabel(planType: PlanTypeEnum | undefined): string {
+  if (planType === PlanTypeEnum.REGULAR) return '';
   return planTypeDisplayLabel(planType);
 }
 
 export interface GroupExportPlanTypeOption {
-  value: PaymentPlanGroupDeliveryExportPlanTypeEnum;
+  value: PlanTypeEnum;
   label: string;
 }
 
@@ -47,19 +47,11 @@ export function exportablePlanTypeOptions(
   group: PaymentPlanGroupDetail | null,
   t: (key: string) => string,
 ): GroupExportPlanTypeOption[] {
-  const flagged: Array<
-    [boolean | undefined, PaymentPlanGroupDeliveryExportPlanTypeEnum]
-  > = [
-    [group?.canExportRegular, PaymentPlanGroupDeliveryExportPlanTypeEnum.REGULAR],
-    [
-      group?.canExportFollowUp,
-      PaymentPlanGroupDeliveryExportPlanTypeEnum.FOLLOW_UP,
-    ],
-    [group?.canExportTopUp, PaymentPlanGroupDeliveryExportPlanTypeEnum.TOP_UP],
-    [
-      group?.canExportTopUpAmendment,
-      PaymentPlanGroupDeliveryExportPlanTypeEnum.TOP_UP_AMENDMENT,
-    ],
+  const flagged: Array<[boolean | undefined, PlanTypeEnum]> = [
+    [group?.canExportRegular, PlanTypeEnum.REGULAR],
+    [group?.canExportFollowUp, PlanTypeEnum.FOLLOW_UP],
+    [group?.canExportTopUp, PlanTypeEnum.TOP_UP],
+    [group?.canExportTopUpAmendment, PlanTypeEnum.TOP_UP_AMENDMENT],
   ];
   return flagged
     .filter(([canExport]) => canExport)

--- a/src/hope/apps/payment/api/serializers.py
+++ b/src/hope/apps/payment/api/serializers.py
@@ -132,6 +132,7 @@ class PaymentPlanGroupDeliveryExportSerializer(serializers.Serializer):
             PaymentPlan.PlanType.REGULAR,
             PaymentPlan.PlanType.FOLLOW_UP,
             PaymentPlan.PlanType.TOP_UP,
+            PaymentPlan.PlanType.TOP_UP_AMENDMENT,
         ],
         required=False,
         default=PaymentPlan.PlanType.REGULAR,
@@ -1937,6 +1938,7 @@ class PaymentPlanGroupDetailSerializer(AdminUrlSerializerMixin, PaymentPlanGroup
     can_export_regular = serializers.SerializerMethodField()
     can_export_follow_up = serializers.SerializerMethodField()
     can_export_top_up = serializers.SerializerMethodField()
+    can_export_top_up_amendment = serializers.SerializerMethodField()
 
     class Meta(PaymentPlanGroupListSerializer.Meta):
         fields = PaymentPlanGroupListSerializer.Meta.fields + [
@@ -1952,6 +1954,7 @@ class PaymentPlanGroupDetailSerializer(AdminUrlSerializerMixin, PaymentPlanGroup
             "can_export_regular",
             "can_export_follow_up",
             "can_export_top_up",
+            "can_export_top_up_amendment",
         ]
 
     @extend_schema_field(PaymentPlanGroupBatchSerializer(many=True))
@@ -2006,6 +2009,9 @@ class PaymentPlanGroupDetailSerializer(AdminUrlSerializerMixin, PaymentPlanGroup
 
     def get_can_export_top_up(self, obj: PaymentPlanGroup) -> bool:
         return self._has_exportable_plans(obj, PaymentPlan.PlanType.TOP_UP)
+
+    def get_can_export_top_up_amendment(self, obj: PaymentPlanGroup) -> bool:
+        return self._has_exportable_plans(obj, PaymentPlan.PlanType.TOP_UP_AMENDMENT)
 
     def get_total_entitled_quantity_usd(self, obj: PaymentPlanGroup) -> Decimal:
         result = obj.payment_plans.aggregate(total=Sum("total_entitled_quantity_usd"))

--- a/src/hope/apps/payment/api/serializers.py
+++ b/src/hope/apps/payment/api/serializers.py
@@ -1991,7 +1991,7 @@ class PaymentPlanGroupDetailSerializer(AdminUrlSerializerMixin, PaymentPlanGroup
         ]
 
     def _has_exportable_plans(self, obj: PaymentPlanGroup, plan_type: str) -> bool:
-        """Whether the plan-type export button has anything to export (mirrors the export view filter)."""
+        """Whether any plan of a plan_type can be exported."""
         return obj.payment_plans.filter(
             plan_type=plan_type,
             status__in=[PaymentPlan.Status.ACCEPTED, PaymentPlan.Status.FINISHED],

--- a/src/hope/apps/payment/api/serializers.py
+++ b/src/hope/apps/payment/api/serializers.py
@@ -1934,8 +1934,9 @@ class PaymentPlanGroupDetailSerializer(AdminUrlSerializerMixin, PaymentPlanGroup
     can_send_to_payment_gateway = serializers.SerializerMethodField()
     batches = serializers.SerializerMethodField()
     delivery_import_file = serializers.SerializerMethodField()
-    has_follow_up_plans = serializers.SerializerMethodField()
-    has_top_up_plans = serializers.SerializerMethodField()
+    can_export_regular = serializers.SerializerMethodField()
+    can_export_follow_up = serializers.SerializerMethodField()
+    can_export_top_up = serializers.SerializerMethodField()
 
     class Meta(PaymentPlanGroupListSerializer.Meta):
         fields = PaymentPlanGroupListSerializer.Meta.fields + [
@@ -1948,8 +1949,9 @@ class PaymentPlanGroupDetailSerializer(AdminUrlSerializerMixin, PaymentPlanGroup
             "can_send_to_payment_gateway",
             "batches",
             "delivery_import_file",
-            "has_follow_up_plans",
-            "has_top_up_plans",
+            "can_export_regular",
+            "can_export_follow_up",
+            "can_export_top_up",
         ]
 
     @extend_schema_field(PaymentPlanGroupBatchSerializer(many=True))
@@ -1988,11 +1990,22 @@ class PaymentPlanGroupDetailSerializer(AdminUrlSerializerMixin, PaymentPlanGroup
             for row in tags_qs
         ]
 
-    def get_has_follow_up_plans(self, obj: PaymentPlanGroup) -> bool:
-        return obj.payment_plans.filter(plan_type=PaymentPlan.PlanType.FOLLOW_UP).exists()
+    def _has_exportable_plans(self, obj: PaymentPlanGroup, plan_type: str) -> bool:
+        """Whether the plan-type export button has anything to export (mirrors the export view filter)."""
+        return obj.payment_plans.filter(
+            plan_type=plan_type,
+            status__in=[PaymentPlan.Status.ACCEPTED, PaymentPlan.Status.FINISHED],
+            export_tag__isnull=True,
+        ).exists()
 
-    def get_has_top_up_plans(self, obj: PaymentPlanGroup) -> bool:
-        return obj.payment_plans.filter(plan_type=PaymentPlan.PlanType.TOP_UP).exists()
+    def get_can_export_regular(self, obj: PaymentPlanGroup) -> bool:
+        return self._has_exportable_plans(obj, PaymentPlan.PlanType.REGULAR)
+
+    def get_can_export_follow_up(self, obj: PaymentPlanGroup) -> bool:
+        return self._has_exportable_plans(obj, PaymentPlan.PlanType.FOLLOW_UP)
+
+    def get_can_export_top_up(self, obj: PaymentPlanGroup) -> bool:
+        return self._has_exportable_plans(obj, PaymentPlan.PlanType.TOP_UP)
 
     def get_total_entitled_quantity_usd(self, obj: PaymentPlanGroup) -> Decimal:
         result = obj.payment_plans.aggregate(total=Sum("total_entitled_quantity_usd"))

--- a/src/hope/apps/payment/api/serializers.py
+++ b/src/hope/apps/payment/api/serializers.py
@@ -127,6 +127,15 @@ class AcceptanceProcessSerializer(serializers.Serializer):
 class PaymentPlanGroupDeliveryExportSerializer(serializers.Serializer):
     export_tag = serializers.IntegerField(min_value=1, required=False, allow_null=True, default=None)
     fsp_xlsx_template_id = serializers.CharField(required=False, allow_null=True, default=None)
+    plan_type = serializers.ChoiceField(
+        choices=[
+            PaymentPlan.PlanType.REGULAR,
+            PaymentPlan.PlanType.FOLLOW_UP,
+            PaymentPlan.PlanType.TOP_UP,
+        ],
+        required=False,
+        default=PaymentPlan.PlanType.REGULAR,
+    )
 
 
 class PaymentPlanGroupSendXlsxPasswordSerializer(serializers.Serializer):
@@ -1912,6 +1921,7 @@ class PaymentPlanGroupUpdateSerializer(serializers.ModelSerializer):
 
 class PaymentPlanGroupBatchSerializer(serializers.Serializer):
     export_tag = serializers.IntegerField()
+    plan_type = serializers.CharField()
     export_file_link = serializers.CharField(allow_null=True)
     has_password = serializers.BooleanField()
 
@@ -1924,6 +1934,8 @@ class PaymentPlanGroupDetailSerializer(AdminUrlSerializerMixin, PaymentPlanGroup
     can_send_to_payment_gateway = serializers.SerializerMethodField()
     batches = serializers.SerializerMethodField()
     delivery_import_file = serializers.SerializerMethodField()
+    has_follow_up_plans = serializers.SerializerMethodField()
+    has_top_up_plans = serializers.SerializerMethodField()
 
     class Meta(PaymentPlanGroupListSerializer.Meta):
         fields = PaymentPlanGroupListSerializer.Meta.fields + [
@@ -1936,6 +1948,8 @@ class PaymentPlanGroupDetailSerializer(AdminUrlSerializerMixin, PaymentPlanGroup
             "can_send_to_payment_gateway",
             "batches",
             "delivery_import_file",
+            "has_follow_up_plans",
+            "has_top_up_plans",
         ]
 
     @extend_schema_field(PaymentPlanGroupBatchSerializer(many=True))
@@ -1955,12 +1969,15 @@ class PaymentPlanGroupDetailSerializer(AdminUrlSerializerMixin, PaymentPlanGroup
                         output_field=IntegerField(),
                     )
                 ),
+                # a batch is exported for a single plan type, so Max just picks that type
+                batch_plan_type=Max("plan_type"),
             )
             .order_by("export_tag")
         )
         return [
             {
                 "export_tag": row["export_tag"],
+                "plan_type": row["batch_plan_type"],
                 "export_file_link": (
                     reverse("download-payment-plan-group-batch", args=[str(obj.id), row["export_tag"]])
                     if row["has_file"]
@@ -1970,6 +1987,12 @@ class PaymentPlanGroupDetailSerializer(AdminUrlSerializerMixin, PaymentPlanGroup
             }
             for row in tags_qs
         ]
+
+    def get_has_follow_up_plans(self, obj: PaymentPlanGroup) -> bool:
+        return obj.payment_plans.filter(plan_type=PaymentPlan.PlanType.FOLLOW_UP).exists()
+
+    def get_has_top_up_plans(self, obj: PaymentPlanGroup) -> bool:
+        return obj.payment_plans.filter(plan_type=PaymentPlan.PlanType.TOP_UP).exists()
 
     def get_total_entitled_quantity_usd(self, obj: PaymentPlanGroup) -> Decimal:
         result = obj.payment_plans.aggregate(total=Sum("total_entitled_quantity_usd"))

--- a/src/hope/apps/payment/api/serializers.py
+++ b/src/hope/apps/payment/api/serializers.py
@@ -128,12 +128,7 @@ class PaymentPlanGroupDeliveryExportSerializer(serializers.Serializer):
     export_tag = serializers.IntegerField(min_value=1, required=False, allow_null=True, default=None)
     fsp_xlsx_template_id = serializers.CharField(required=False, allow_null=True, default=None)
     plan_type = serializers.ChoiceField(
-        choices=[
-            PaymentPlan.PlanType.REGULAR,
-            PaymentPlan.PlanType.FOLLOW_UP,
-            PaymentPlan.PlanType.TOP_UP,
-            PaymentPlan.PlanType.TOP_UP_AMENDMENT,
-        ],
+        choices=PaymentPlan.PlanType.choices,
         required=False,
         default=PaymentPlan.PlanType.REGULAR,
     )
@@ -1922,7 +1917,7 @@ class PaymentPlanGroupUpdateSerializer(serializers.ModelSerializer):
 
 class PaymentPlanGroupBatchSerializer(serializers.Serializer):
     export_tag = serializers.IntegerField()
-    plan_type = serializers.CharField()
+    plan_type = serializers.ChoiceField(choices=PaymentPlan.PlanType.choices)
     export_file_link = serializers.CharField(allow_null=True)
     has_password = serializers.BooleanField()
 

--- a/src/hope/apps/payment/api/views.py
+++ b/src/hope/apps/payment/api/views.py
@@ -2574,6 +2574,7 @@ class PaymentPlanGroupViewSet(
         serializer.is_valid(raise_exception=True)
         export_tag = serializer.validated_data["export_tag"]
         fsp_xlsx_template_id = serializer.validated_data["fsp_xlsx_template_id"]
+        plan_type = serializer.validated_data["plan_type"]
 
         if fsp_xlsx_template_id is not None:
             template = get_object_or_404(FinancialServiceProviderXlsxTemplate, pk=fsp_xlsx_template_id)
@@ -2589,7 +2590,7 @@ class PaymentPlanGroupViewSet(
         else:
             exportable_plans = payment_plan_group.payment_plans.filter(
                 status__in=[PaymentPlan.Status.ACCEPTED, PaymentPlan.Status.FINISHED],
-                plan_type=PaymentPlan.PlanType.REGULAR,
+                plan_type=plan_type,
                 export_tag__isnull=True,
             )
             if not exportable_plans.exists():
@@ -2602,7 +2603,10 @@ class PaymentPlanGroupViewSet(
             # Reject up-front if every plan would be filtered out (e.g. no FSP XLSX template mapping),
             # so the user gets the error on click instead of a silently failing background task.
             exportable_ids = XlsxPaymentPlanGroupDeliveryExportService(
-                payment_plan_group, fsp_xlsx_template_id=fsp_xlsx_template_id, export_tag=export_tag
+                payment_plan_group,
+                fsp_xlsx_template_id=fsp_xlsx_template_id,
+                export_tag=export_tag,
+                plan_type=plan_type,
             ).preview_export()
             if not exportable_ids:
                 raise ValidationError(EmptyDeliveryExportError.MESSAGE)
@@ -2611,7 +2615,7 @@ class PaymentPlanGroupViewSet(
         payment_plan_group.save(update_fields=["background_action_status"])
         transaction.on_commit(
             lambda: export_payment_plan_group_delivery_xlsx_async_task(
-                payment_plan_group, str(request.user.pk), fsp_xlsx_template_id, export_tag
+                payment_plan_group, str(request.user.pk), fsp_xlsx_template_id, export_tag, plan_type
             )
         )
         return Response(
@@ -2658,7 +2662,6 @@ class PaymentPlanGroupViewSet(
             raise ValidationError("Another background action is already in progress.")
         importable_plans = payment_plan_group.payment_plans.filter(
             status__in=[PaymentPlan.Status.ACCEPTED, PaymentPlan.Status.FINISHED],
-            plan_type=PaymentPlan.PlanType.REGULAR,
         )
         if not importable_plans.exists():
             raise ValidationError("Import requires at least one payment plan in ACCEPTED or FINISHED status.")

--- a/src/hope/apps/payment/celery_tasks.py
+++ b/src/hope/apps/payment/celery_tasks.py
@@ -232,7 +232,7 @@ def export_payment_plan_group_delivery_xlsx_async_task_action(job: AsyncRetryJob
         EmptyDeliveryExportError,
         XlsxPaymentPlanGroupDeliveryExportService,
     )
-    from hope.models import PaymentPlanGroup, User
+    from hope.models import PaymentPlan, PaymentPlanGroup, User
 
     payment_plan_group_id = job.config["payment_plan_group_id"]
     with cache.lock(
@@ -246,9 +246,13 @@ def export_payment_plan_group_delivery_xlsx_async_task_action(job: AsyncRetryJob
         user = User.objects.get(pk=job.config["user_id"])
         export_tag = job.config.get("export_tag")
         fsp_xlsx_template_id = job.config.get("fsp_xlsx_template_id")
+        plan_type = job.config.get("plan_type", PaymentPlan.PlanType.REGULAR)
         try:
             service = XlsxPaymentPlanGroupDeliveryExportService(
-                payment_plan_group, fsp_xlsx_template_id=fsp_xlsx_template_id, export_tag=export_tag
+                payment_plan_group,
+                fsp_xlsx_template_id=fsp_xlsx_template_id,
+                export_tag=export_tag,
+                plan_type=plan_type,
             )
             if service.payment_plans and service.payment_generate_token_and_order_numbers:
                 program = payment_plan_group.cycle.program
@@ -290,11 +294,14 @@ def export_payment_plan_group_delivery_xlsx_async_task(
     user_id: str,
     fsp_xlsx_template_id: str | None = None,
     export_tag: int | None = None,
+    plan_type: str | None = None,
 ) -> None:
     payment_plan_group_id = str(payment_plan_group.id)
     config: dict = {"payment_plan_group_id": payment_plan_group_id, "user_id": user_id}
     if fsp_xlsx_template_id is not None:
         config["fsp_xlsx_template_id"] = fsp_xlsx_template_id
+    if plan_type is not None:
+        config["plan_type"] = plan_type
     if export_tag is not None:
         config["export_tag"] = export_tag
         description = f"Re-export payment plan group delivery xlsx batch {export_tag} for {payment_plan_group_id}"

--- a/src/hope/apps/payment/xlsx/xlsx_payment_plan_group_delivery_export_service.py
+++ b/src/hope/apps/payment/xlsx/xlsx_payment_plan_group_delivery_export_service.py
@@ -45,10 +45,10 @@ class XlsxPaymentPlanGroupDeliveryExportService(XlsxExportBaseService):
     A group is bound to a single FSP, so every exported payment plan shares the same FSP XLSX
     template and the sheet has a single, flat header.
 
-    Each export is a batch: only ACCEPTED/FINISHED plans of one ``plan_type`` (REGULAR by default,
-    FOLLOW_UP or TOP_UP on demand) that have not been exported yet (``export_tag`` is null) are
-    included. On success the exported plans are stamped with the next sequential ``export_tag`` so
-    they are excluded from the next export.
+    Each export is a batch: only ACCEPTED/FINISHED plans of one ``plan_type`` (REGULAR by
+    default) that have not been exported yet (``export_tag`` is null) are included. On success
+    the exported plans are stamped with the next sequential ``export_tag`` so they are excluded
+    from the next export.
     """
 
     TITLE = "Payment Plan Group - Payment List"

--- a/src/hope/apps/payment/xlsx/xlsx_payment_plan_group_delivery_export_service.py
+++ b/src/hope/apps/payment/xlsx/xlsx_payment_plan_group_delivery_export_service.py
@@ -45,10 +45,10 @@ class XlsxPaymentPlanGroupDeliveryExportService(XlsxExportBaseService):
     A group is bound to a single FSP, so every exported payment plan shares the same FSP XLSX
     template and the sheet has a single, flat header.
 
-    Each export is a batch: only ACCEPTED/FINISHED, REGULAR (no follow-ups / top-ups) plans that
-    have not been exported yet (``export_tag`` is null) are included. On success the exported plans
-    are stamped with the next sequential ``export_tag`` so they are
-    excluded from the next export.
+    Each export is a batch: only ACCEPTED/FINISHED plans of one ``plan_type`` (REGULAR by default,
+    FOLLOW_UP or TOP_UP on demand) that have not been exported yet (``export_tag`` is null) are
+    included. On success the exported plans are stamped with the next sequential ``export_tag`` so
+    they are excluded from the next export.
     """
 
     TITLE = "Payment Plan Group - Payment List"
@@ -59,9 +59,11 @@ class XlsxPaymentPlanGroupDeliveryExportService(XlsxExportBaseService):
         payment_plan_group: "PaymentPlanGroup",
         fsp_xlsx_template_id: str | None = None,
         export_tag: int | None = None,
+        plan_type: str = PaymentPlan.PlanType.REGULAR,
     ) -> None:
         self.payment_plan_group = payment_plan_group
         self.export_tag = export_tag
+        self.plan_type = plan_type
         self.applied_export_tag: int | None = None
         self.payment_generate_token_and_order_numbers = True
         self.allow_export_fsp_auth_code = False
@@ -70,12 +72,15 @@ class XlsxPaymentPlanGroupDeliveryExportService(XlsxExportBaseService):
         else:
             plan_qs = payment_plan_group.payment_plans.filter(
                 status__in=[PaymentPlan.Status.ACCEPTED, PaymentPlan.Status.FINISHED],
-                plan_type=PaymentPlan.PlanType.REGULAR,
+                plan_type=plan_type,
                 export_tag__isnull=True,
             )
         self.payment_plans = list(
             plan_qs.select_related("financial_service_provider", "delivery_mechanism").order_by("unicef_id")
         )
+        if export_tag is not None and self.payment_plans:
+            # a batch is homogeneous by plan type; on re-export recover it from the batch itself
+            self.plan_type = self.payment_plans[0].plan_type
         self.exported_plan_ids: list = []
         self.skipped_reasons: list[str] = []
         self.fsp_xlsx_template: FinancialServiceProviderXlsxTemplate | None = (
@@ -158,20 +163,32 @@ class XlsxPaymentPlanGroupDeliveryExportService(XlsxExportBaseService):
         all_eligible = Payment.objects.filter(parent__in=self.payment_plans).eligible()
         XlsxPaymentPlanDeliveryExportService.generate_token_and_order_numbers(all_eligible, program)
 
+    def _batch_name(self, tag: int | None) -> str:
+        """Human-readable batch name, e.g. "Batch 2" or "Batch 3 Follow Up"."""
+        if self.plan_type == PaymentPlan.PlanType.REGULAR:
+            return f"Batch {tag}"
+        return f"Batch {tag} {PaymentPlan.PlanType(self.plan_type).label}"
+
+    def _filename_suffix(self) -> str:
+        if self.plan_type == PaymentPlan.PlanType.REGULAR:
+            return ""
+        return f"_{self.plan_type.lower()}"
+
     def get_email_context(self, user: "User") -> dict:
         group = self.payment_plan_group
         tag = self.applied_export_tag
+        batch_name = self._batch_name(tag)
         link = reverse("download-payment-plan-group-batch", args=[str(group.id), tag])
         return {
             "first_name": getattr(user, "first_name", ""),
             "last_name": getattr(user, "last_name", ""),
             "email": getattr(user, "email", ""),
             "message": (
-                f"Payment Plan Group {group.unicef_id} Batch {tag} Payment List xlsx file "
+                f"Payment Plan Group {group.unicef_id} {batch_name} Payment List xlsx file "
                 "was generated and below you have the link to download this file."
             ),
             "link": link or "",
-            "title": f"Payment Plan Group {group.unicef_id} Batch {tag} Payment List Generated",
+            "title": f"Payment Plan Group {group.unicef_id} {batch_name} Payment List Generated",
         }
 
     def _next_export_tag(self) -> int:
@@ -232,7 +249,7 @@ class XlsxPaymentPlanGroupDeliveryExportService(XlsxExportBaseService):
             self._save_plain_xlsx_file(group, tag, user)
 
     def _save_plain_xlsx_file(self, group: "PaymentPlanGroup", tag: int, user: "User") -> None:
-        filename = f"payment_plan_group_{group.unicef_id}_payment_list_batch_{tag}.xlsx"
+        filename = f"payment_plan_group_{group.unicef_id}_payment_list_batch_{tag}{self._filename_suffix()}.xlsx"
         with NamedTemporaryFile() as tmp:
             file_temp = FileTemp(
                 object_id=str(group.pk),
@@ -256,8 +273,8 @@ class XlsxPaymentPlanGroupDeliveryExportService(XlsxExportBaseService):
     def _save_xlsx_file_with_auth_code(self, group: "PaymentPlanGroup", tag: int, user: "User") -> None:
         zip_password = get_random_string(12)
         xlsx_password = get_random_string(12)
-        zip_filename = f"payment_plan_group_{group.unicef_id}_payment_list_batch_{tag}.zip"
-        xlsx_filename = f"payment_plan_group_{group.unicef_id}_payment_list_batch_{tag}.xlsx"
+        zip_filename = f"payment_plan_group_{group.unicef_id}_payment_list_batch_{tag}{self._filename_suffix()}.zip"
+        xlsx_filename = f"payment_plan_group_{group.unicef_id}_payment_list_batch_{tag}{self._filename_suffix()}.xlsx"
 
         with NamedTemporaryFile(suffix=".zip") as tmp_zip:
             with pyzipper.AESZipFile(

--- a/src/hope/apps/payment/xlsx/xlsx_payment_plan_group_delivery_export_service.py
+++ b/src/hope/apps/payment/xlsx/xlsx_payment_plan_group_delivery_export_service.py
@@ -79,7 +79,7 @@ class XlsxPaymentPlanGroupDeliveryExportService(XlsxExportBaseService):
             plan_qs.select_related("financial_service_provider", "delivery_mechanism").order_by("unicef_id")
         )
         if export_tag is not None and self.payment_plans:
-            # a batch is homogeneous by plan type; on re-export recover it from the batch itself
+            # in batch all payment plans are of the same type
             self.plan_type = self.payment_plans[0].plan_type
         self.exported_plan_ids: list = []
         self.skipped_reasons: list[str] = []
@@ -164,7 +164,6 @@ class XlsxPaymentPlanGroupDeliveryExportService(XlsxExportBaseService):
         XlsxPaymentPlanDeliveryExportService.generate_token_and_order_numbers(all_eligible, program)
 
     def _batch_name(self, tag: int | None) -> str:
-        """Human-readable batch name, e.g. "Batch 2" or "Batch 3 Follow Up"."""
         if self.plan_type == PaymentPlan.PlanType.REGULAR:
             return f"Batch {tag}"
         return f"Batch {tag} {PaymentPlan.PlanType(self.plan_type).label}"

--- a/src/hope/apps/payment/xlsx/xlsx_payment_plan_group_delivery_export_service.py
+++ b/src/hope/apps/payment/xlsx/xlsx_payment_plan_group_delivery_export_service.py
@@ -45,8 +45,8 @@ class XlsxPaymentPlanGroupDeliveryExportService(XlsxExportBaseService):
     A group is bound to a single FSP, so every exported payment plan shares the same FSP XLSX
     template and the sheet has a single, flat header.
 
-    Each export is a batch: only ACCEPTED/FINISHED plans of one ``plan_type`` (REGULAR by
-    default) that have not been exported yet (``export_tag`` is null) are included. On success
+    Each export is a batch: only ACCEPTED/FINISHED plans of the requested ``plan_type``
+    that have not been exported yet (``export_tag`` is null) are included. On success
     the exported plans are stamped with the next sequential ``export_tag`` so they are excluded
     from the next export.
     """
@@ -59,17 +59,18 @@ class XlsxPaymentPlanGroupDeliveryExportService(XlsxExportBaseService):
         payment_plan_group: "PaymentPlanGroup",
         fsp_xlsx_template_id: str | None = None,
         export_tag: int | None = None,
-        plan_type: str = PaymentPlan.PlanType.REGULAR,
+        plan_type: str | None = None,
     ) -> None:
         self.payment_plan_group = payment_plan_group
         self.export_tag = export_tag
-        self.plan_type = plan_type
         self.applied_export_tag: int | None = None
         self.payment_generate_token_and_order_numbers = True
         self.allow_export_fsp_auth_code = False
         if export_tag is not None:
             plan_qs = payment_plan_group.payment_plans.filter(export_tag=export_tag)
         else:
+            if plan_type is None:
+                raise ValueError("plan_type is required when creating a new export batch.")
             plan_qs = payment_plan_group.payment_plans.filter(
                 status__in=[PaymentPlan.Status.ACCEPTED, PaymentPlan.Status.FINISHED],
                 plan_type=plan_type,
@@ -78,9 +79,8 @@ class XlsxPaymentPlanGroupDeliveryExportService(XlsxExportBaseService):
         self.payment_plans = list(
             plan_qs.select_related("financial_service_provider", "delivery_mechanism").order_by("unicef_id")
         )
-        if export_tag is not None and self.payment_plans:
-            # in batch all payment plans are of the same type
-            self.plan_type = self.payment_plans[0].plan_type
+        # in a batch all payment plans are of the same type
+        self.plan_type: str | None = self.payment_plans[0].plan_type if self.payment_plans else plan_type
         self.exported_plan_ids: list = []
         self.skipped_reasons: list[str] = []
         self.fsp_xlsx_template: FinancialServiceProviderXlsxTemplate | None = (
@@ -164,12 +164,12 @@ class XlsxPaymentPlanGroupDeliveryExportService(XlsxExportBaseService):
         XlsxPaymentPlanDeliveryExportService.generate_token_and_order_numbers(all_eligible, program)
 
     def _batch_name(self, tag: int | None) -> str:
-        if self.plan_type == PaymentPlan.PlanType.REGULAR:
+        if not self.plan_type or self.plan_type == PaymentPlan.PlanType.REGULAR:
             return f"Batch {tag}"
         return f"Batch {tag} {PaymentPlan.PlanType(self.plan_type).label}"
 
     def _filename_suffix(self) -> str:
-        if self.plan_type == PaymentPlan.PlanType.REGULAR:
+        if not self.plan_type or self.plan_type == PaymentPlan.PlanType.REGULAR:
             return ""
         return f"_{self.plan_type.lower()}"
 

--- a/src/hope/apps/payment/xlsx/xlsx_payment_plan_group_delivery_import_service.py
+++ b/src/hope/apps/payment/xlsx/xlsx_payment_plan_group_delivery_import_service.py
@@ -42,7 +42,6 @@ class XlsxPaymentPlanGroupDeliveryImportService:
         self.payment_plans: list[PaymentPlan] = list(
             payment_plan_group.payment_plans.filter(
                 status__in=[PaymentPlan.Status.ACCEPTED, PaymentPlan.Status.FINISHED],
-                plan_type=PaymentPlan.PlanType.REGULAR,
             ).order_by("unicef_id")
         )
         self.eligible_plans: list[PaymentPlan] = []

--- a/src/hope/config/fragments/drf_spectacular.py
+++ b/src/hope/config/fragments/drf_spectacular.py
@@ -9,6 +9,7 @@ SPECTACULAR_SETTINGS = {
     "ENUM_ADD_EXPLICIT_BLANK_NULL_CHOICE": False,
     "ENUM_NAME_OVERRIDES": {
         "PaymentPlanStatusEnum": "hope.models.payment_plan.PaymentPlan.Status",
+        "PlanTypeEnum": "hope.models.payment_plan.PaymentPlan.PlanType",
         "PaymentStatusEnum": "hope.models.payment.Payment.STATUS_CHOICE",
         "ProgramStatusEnum": "hope.models.program.Program.STATUS_CHOICE",
         "GrievanceTicketStatusEnum": "hope.apps.grievance.models.GrievanceTicket.STATUS_CHOICES",

--- a/tests/e2e/new_selenium/payment_module/test_payment_plan_group.py
+++ b/tests/e2e/new_selenium/payment_module/test_payment_plan_group.py
@@ -116,7 +116,9 @@ def reconciliation_file(tmp_path, exportable_group: tuple[PaymentPlanGroup, Paym
     group, _ = exportable_group
     # Build the file from the real export service so its header matches exactly what the
     # import expects, then fill in a delivered_quantity for the single payment row.
-    workbook = XlsxPaymentPlanGroupDeliveryExportService(group).generate_workbook()
+    workbook = XlsxPaymentPlanGroupDeliveryExportService(
+        group, plan_type=PaymentPlan.PlanType.REGULAR
+    ).generate_workbook()
     worksheet = workbook.active
     headers = [cell.value for cell in worksheet[1]]
     delivered_col = headers.index("delivered_quantity") + 1

--- a/tests/e2e/new_selenium/payment_module/test_payment_plan_group.py
+++ b/tests/e2e/new_selenium/payment_module/test_payment_plan_group.py
@@ -324,6 +324,10 @@ def test_export_payment_plan_group(
         browser.wait_for_element_clickable('[data-cy="button-delivery-export-xlsx-group"]')
         browser.click('[data-cy="button-delivery-export-xlsx-group"]')
 
+        browser.wait_for_element_visible('[data-cy="dialog-delivery-export-xlsx-group"]')
+        browser.wait_for_element_clickable('[data-cy="button-delivery-export-xlsx-group-submit"]')
+        browser.click('[data-cy="button-delivery-export-xlsx-group-submit"]')
+
         browser.wait_for_text("Export started")
 
         browser.open(f"/{business_area.slug}/programs/{program.code}/payment-module/groups/{group.id}")
@@ -358,7 +362,12 @@ def test_export_payment_plan_group_with_auth_code(
         browser.click('[data-cy="button-delivery-export-xlsx-with-auth-code-group"]')
 
         browser.wait_for_element_visible('[data-cy="dialog-delivery-export-xlsx-with-auth-code-group"]')
-        template_input = browser.find_element('[data-cy="dialog-delivery-export-xlsx-with-auth-code-group"] input')
+        # single exportable plan type -> shown as a locked field; the template picker
+        # is the only enabled input in the dialog
+        browser.wait_for_element_visible('[data-cy="locked-delivery-export-xlsx-with-auth-code-group-plan-type"]')
+        template_input = browser.find_element(
+            '[data-cy="dialog-delivery-export-xlsx-with-auth-code-group"] input:not([disabled])'
+        )
         template_input.click()
         template_input.send_keys("Auth Code Template")
         browser.select_listbox_element("Auth Code Template")

--- a/tests/unit/apps/payment/test_payment_celery_tasks.py
+++ b/tests/unit/apps/payment/test_payment_celery_tasks.py
@@ -198,6 +198,34 @@ def payment_plan_group_with_accepted_plan():
     return group
 
 
+@pytest.fixture
+def payment_plan_group_with_regular_and_follow_up_plans():
+    group = PaymentPlanGroupFactory()
+    fsp = FinancialServiceProviderFactory()
+    delivery_mechanism = DeliveryMechanismFactory()
+    FspXlsxTemplatePerDeliveryMechanismFactory(
+        financial_service_provider=fsp,
+        delivery_mechanism=delivery_mechanism,
+    )
+    regular_plan = PaymentPlanFactory(
+        status=PaymentPlan.Status.ACCEPTED,
+        payment_plan_group=group,
+        program_cycle=group.cycle,
+        financial_service_provider=fsp,
+        delivery_mechanism=delivery_mechanism,
+    )
+    follow_up_plan = PaymentPlanFactory(
+        status=PaymentPlan.Status.ACCEPTED,
+        payment_plan_group=group,
+        program_cycle=group.cycle,
+        financial_service_provider=fsp,
+        delivery_mechanism=delivery_mechanism,
+        plan_type=PaymentPlan.PlanType.FOLLOW_UP,
+        source_payment_plan=regular_plan,
+    )
+    return group, regular_plan, follow_up_plan
+
+
 @pytest.mark.parametrize(
     ("task", "job_model", "args_builder", "expected_job_name"),
     [
@@ -1710,6 +1738,41 @@ def test_export_delivery_task_queues_job_with_fsp_xlsx_template_id(payment_plan_
 
     job = AsyncRetryJob.objects.latest("pk")
     assert job.config["fsp_xlsx_template_id"] == str(template.pk)
+
+
+def test_export_delivery_task_queues_job_with_plan_type(payment_plan_group_with_accepted_plan, user) -> None:
+    group = payment_plan_group_with_accepted_plan
+
+    with patch("hope.apps.payment.celery_tasks.AsyncRetryJob.queue", autospec=True):
+        export_payment_plan_group_delivery_xlsx_async_task(
+            group, str(user.pk), plan_type=PaymentPlan.PlanType.FOLLOW_UP
+        )
+
+    job = AsyncRetryJob.objects.latest("pk")
+    assert job.config["plan_type"] == PaymentPlan.PlanType.FOLLOW_UP
+
+
+def test_export_delivery_task_with_plan_type_exports_only_that_type(
+    payment_plan_group_with_regular_and_follow_up_plans, user
+) -> None:
+    group, regular_plan, follow_up_plan = payment_plan_group_with_regular_and_follow_up_plans
+    group.background_action_status = PaymentPlanGroup.BackgroundActionStatus.XLSX_EXPORTING
+    group.save(update_fields=["background_action_status"])
+
+    queue_and_run_retry_task(
+        export_payment_plan_group_delivery_xlsx_async_task,
+        group,
+        str(user.pk),
+        plan_type=PaymentPlan.PlanType.FOLLOW_UP,
+    )
+
+    regular_plan.refresh_from_db()
+    follow_up_plan.refresh_from_db()
+    assert follow_up_plan.export_tag == 1
+    assert follow_up_plan.export_file_delivery is not None
+    assert "_follow_up" in follow_up_plan.export_file_delivery.file.name
+    assert regular_plan.export_tag is None
+    assert regular_plan.export_file_delivery is None
 
 
 def test_export_delivery_task_keeps_previous_batch_file(payment_plan_group_with_accepted_plan, user) -> None:

--- a/tests/unit/apps/payment/test_payment_plan_group_views.py
+++ b/tests/unit/apps/payment/test_payment_plan_group_views.py
@@ -198,6 +198,52 @@ def group_with_accepted_plan_and_payment(business_area: Any, cycle: Any) -> Any:
 
 
 @pytest.fixture
+def group_with_accepted_follow_up_plan_and_payment(business_area: Any, cycle: Any) -> Any:
+    group = cycle.payment_plan_groups.first()
+    fsp = FinancialServiceProviderFactory()
+    delivery_mechanism = DeliveryMechanismFactory()
+    FspXlsxTemplatePerDeliveryMechanismFactory(
+        financial_service_provider=fsp,
+        delivery_mechanism=delivery_mechanism,
+    )
+    plan = PaymentPlanFactory(
+        business_area=business_area,
+        program_cycle=cycle,
+        payment_plan_group=group,
+        financial_service_provider=fsp,
+        delivery_mechanism=delivery_mechanism,
+        status=PaymentPlan.Status.ACCEPTED,
+        plan_type=PaymentPlan.PlanType.FOLLOW_UP,
+    )
+    payment = PaymentFactory(parent=plan, financial_service_provider=fsp, delivery_type=delivery_mechanism)
+    PaymentHouseholdSnapshotFactory(payment=payment, snapshot_data={})
+    return group
+
+
+@pytest.fixture
+def group_with_accepted_top_up_plan_and_payment(business_area: Any, cycle: Any) -> Any:
+    group = cycle.payment_plan_groups.first()
+    fsp = FinancialServiceProviderFactory()
+    delivery_mechanism = DeliveryMechanismFactory()
+    FspXlsxTemplatePerDeliveryMechanismFactory(
+        financial_service_provider=fsp,
+        delivery_mechanism=delivery_mechanism,
+    )
+    plan = PaymentPlanFactory(
+        business_area=business_area,
+        program_cycle=cycle,
+        payment_plan_group=group,
+        financial_service_provider=fsp,
+        delivery_mechanism=delivery_mechanism,
+        status=PaymentPlan.Status.ACCEPTED,
+        plan_type=PaymentPlan.PlanType.TOP_UP,
+    )
+    payment = PaymentFactory(parent=plan, financial_service_provider=fsp, delivery_type=delivery_mechanism)
+    PaymentHouseholdSnapshotFactory(payment=payment, snapshot_data={})
+    return group
+
+
+@pytest.fixture
 def group_with_accepted_plan_and_payment_no_template(business_area: Any, cycle: Any) -> Any:
     """Accepted plan with an eligible payment but no resolvable FSP XLSX template - export yields no rows."""
     group = cycle.payment_plan_groups.first()
@@ -490,6 +536,68 @@ def test_retrieve_detail_aggregated_totals(
     assert Decimal(data["total_delivered_quantity_usd"]) == Decimal("210.00")
     assert Decimal(data["total_undelivered_quantity_usd"]) == Decimal("90.00")
     assert data["payment_plans_count"] == 2
+
+
+def test_retrieve_detail_has_follow_up_plans_flag(
+    client: Any,
+    user: Any,
+    business_area: Any,
+    program: Any,
+    group_with_accepted_follow_up_plan_and_payment: Any,
+    create_user_role_with_permissions: Any,
+) -> None:
+    create_user_role_with_permissions(
+        user, [Permissions.PM_PAYMENT_PLAN_GROUP_VIEW_DETAIL], business_area, program=program
+    )
+    group = group_with_accepted_follow_up_plan_and_payment
+
+    response = client.get(_detail_url(business_area.slug, program.code, group.id))
+
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert data["has_follow_up_plans"] is True
+    assert data["has_top_up_plans"] is False
+
+
+def test_retrieve_detail_has_top_up_plans_flag(
+    client: Any,
+    user: Any,
+    business_area: Any,
+    program: Any,
+    group_with_accepted_top_up_plan_and_payment: Any,
+    create_user_role_with_permissions: Any,
+) -> None:
+    create_user_role_with_permissions(
+        user, [Permissions.PM_PAYMENT_PLAN_GROUP_VIEW_DETAIL], business_area, program=program
+    )
+    group = group_with_accepted_top_up_plan_and_payment
+
+    response = client.get(_detail_url(business_area.slug, program.code, group.id))
+
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert data["has_follow_up_plans"] is False
+    assert data["has_top_up_plans"] is True
+
+
+def test_retrieve_detail_plan_type_flags_false_for_regular_only_group(
+    client: Any,
+    user: Any,
+    business_area: Any,
+    program: Any,
+    group_with_plan: Any,
+    create_user_role_with_permissions: Any,
+) -> None:
+    create_user_role_with_permissions(
+        user, [Permissions.PM_PAYMENT_PLAN_GROUP_VIEW_DETAIL], business_area, program=program
+    )
+
+    response = client.get(_detail_url(business_area.slug, program.code, group_with_plan.id))
+
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert data["has_follow_up_plans"] is False
+    assert data["has_top_up_plans"] is False
 
 
 def test_delete_group_with_no_plans_succeeds(
@@ -1159,6 +1267,110 @@ def test_export_excludes_follow_up_plan_returns_400(
     mocked_task.assert_not_called()
 
 
+def test_export_follow_up_plan_type_queues_task_with_plan_type(
+    client: Any,
+    user: Any,
+    business_area: Any,
+    program: Any,
+    group_with_accepted_follow_up_plan_and_payment: Any,
+    create_user_role_with_permissions: Any,
+) -> None:
+    create_user_role_with_permissions(
+        user, [Permissions.PM_PAYMENT_PLAN_GROUP_EXPORT_XLSX], business_area, program=program
+    )
+    group = group_with_accepted_follow_up_plan_and_payment
+
+    with (
+        patch("hope.apps.payment.api.views.export_payment_plan_group_delivery_xlsx_async_task") as mocked_task,
+        TestCase.captureOnCommitCallbacks(execute=True),
+    ):
+        response = client.post(
+            _export_url(business_area.slug, program.code, group.id),
+            {"plan_type": PaymentPlan.PlanType.FOLLOW_UP},
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    mocked_task.assert_called_once()
+    called_plan_type = mocked_task.call_args[0][4]
+    assert called_plan_type == PaymentPlan.PlanType.FOLLOW_UP
+
+
+def test_export_follow_up_plan_type_without_follow_up_plans_returns_400(
+    client: Any,
+    user: Any,
+    business_area: Any,
+    program: Any,
+    group_with_accepted_plan_and_payment: Any,
+    create_user_role_with_permissions: Any,
+) -> None:
+    create_user_role_with_permissions(
+        user, [Permissions.PM_PAYMENT_PLAN_GROUP_EXPORT_XLSX], business_area, program=program
+    )
+    group = group_with_accepted_plan_and_payment
+
+    with patch("hope.apps.payment.api.views.export_payment_plan_group_delivery_xlsx_async_task") as mocked_task:
+        response = client.post(
+            _export_url(business_area.slug, program.code, group.id),
+            {"plan_type": PaymentPlan.PlanType.FOLLOW_UP},
+        )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "not-yet-exported" in str(response.json())
+    mocked_task.assert_not_called()
+
+
+def test_export_top_up_plan_type_queues_task_with_plan_type(
+    client: Any,
+    user: Any,
+    business_area: Any,
+    program: Any,
+    group_with_accepted_top_up_plan_and_payment: Any,
+    create_user_role_with_permissions: Any,
+) -> None:
+    create_user_role_with_permissions(
+        user, [Permissions.PM_PAYMENT_PLAN_GROUP_EXPORT_XLSX], business_area, program=program
+    )
+    group = group_with_accepted_top_up_plan_and_payment
+
+    with (
+        patch("hope.apps.payment.api.views.export_payment_plan_group_delivery_xlsx_async_task") as mocked_task,
+        TestCase.captureOnCommitCallbacks(execute=True),
+    ):
+        response = client.post(
+            _export_url(business_area.slug, program.code, group.id),
+            {"plan_type": PaymentPlan.PlanType.TOP_UP},
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    mocked_task.assert_called_once()
+    called_plan_type = mocked_task.call_args[0][4]
+    assert called_plan_type == PaymentPlan.PlanType.TOP_UP
+
+
+def test_export_invalid_plan_type_returns_400(
+    client: Any,
+    user: Any,
+    business_area: Any,
+    program: Any,
+    group_with_accepted_plan_and_payment: Any,
+    create_user_role_with_permissions: Any,
+) -> None:
+    create_user_role_with_permissions(
+        user, [Permissions.PM_PAYMENT_PLAN_GROUP_EXPORT_XLSX], business_area, program=program
+    )
+    group = group_with_accepted_plan_and_payment
+
+    with patch("hope.apps.payment.api.views.export_payment_plan_group_delivery_xlsx_async_task") as mocked_task:
+        response = client.post(
+            _export_url(business_area.slug, program.code, group.id),
+            {"plan_type": PaymentPlan.PlanType.TOP_UP_AMENDMENT},
+        )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "plan_type" in response.json()
+    mocked_task.assert_not_called()
+
+
 def test_export_without_eligible_payments_returns_400(
     client: Any,
     user: Any,
@@ -1226,11 +1438,12 @@ def test_export_queues_async_task_on_commit(
 
     assert response.status_code == status.HTTP_200_OK
     mocked_task.assert_called_once()
-    called_group, called_user_id, called_template_id, called_tag = mocked_task.call_args[0]
+    called_group, called_user_id, called_template_id, called_tag, called_plan_type = mocked_task.call_args[0]
     assert called_group.id == group.id
     assert called_user_id == str(user.pk)
     assert called_template_id is None
     assert called_tag is None
+    assert called_plan_type == PaymentPlan.PlanType.REGULAR
 
 
 def test_export_rejected_for_group_in_other_business_area(
@@ -1609,7 +1822,14 @@ def test_get_batches_sets_link_when_file_present(cycle: Any, business_area: Any)
     result = PaymentPlanGroupDetailSerializer().get_batches(group)
 
     expected_link = reverse("download-payment-plan-group-batch", args=[str(group.id), 1])
-    assert result == [{"export_tag": 1, "export_file_link": expected_link, "has_password": False}]
+    assert result == [
+        {
+            "export_tag": 1,
+            "plan_type": PaymentPlan.PlanType.REGULAR,
+            "export_file_link": expected_link,
+            "has_password": False,
+        }
+    ]
 
 
 def test_get_batches_link_is_none_when_file_missing(cycle: Any, business_area: Any) -> None:
@@ -1624,7 +1844,14 @@ def test_get_batches_link_is_none_when_file_missing(cycle: Any, business_area: A
 
     result = PaymentPlanGroupDetailSerializer().get_batches(group)
 
-    assert result == [{"export_tag": 1, "export_file_link": None, "has_password": False}]
+    assert result == [
+        {
+            "export_tag": 1,
+            "plan_type": PaymentPlan.PlanType.REGULAR,
+            "export_file_link": None,
+            "has_password": False,
+        }
+    ]
 
 
 def test_get_batches_orders_by_export_tag(cycle: Any, business_area: Any) -> None:
@@ -1635,6 +1862,21 @@ def test_get_batches_orders_by_export_tag(cycle: Any, business_area: Any) -> Non
     result = PaymentPlanGroupDetailSerializer().get_batches(group)
 
     assert [batch["export_tag"] for batch in result] == [1, 2]
+
+
+def test_get_batches_carries_plan_type_of_batch(cycle: Any, business_area: Any) -> None:
+    group = cycle.payment_plan_groups.first()
+    PaymentPlanFactory(
+        business_area=business_area,
+        program_cycle=cycle,
+        payment_plan_group=group,
+        export_tag=1,
+        plan_type=PaymentPlan.PlanType.FOLLOW_UP,
+    )
+
+    result = PaymentPlanGroupDetailSerializer().get_batches(group)
+
+    assert result[0]["plan_type"] == PaymentPlan.PlanType.FOLLOW_UP
 
 
 def test_delivery_import_xlsx_returns_400_when_no_file(
@@ -1865,7 +2107,7 @@ def test_delivery_import_xlsx_without_accepted_plan_returns_400(
     assert "Import requires at least one payment plan in ACCEPTED or FINISHED status." in str(response.json())
 
 
-def test_delivery_import_xlsx_with_only_follow_up_plan_returns_400(
+def test_delivery_import_xlsx_with_only_follow_up_plan_passes_plan_check(
     client: Any,
     user: Any,
     business_area: Any,
@@ -1892,8 +2134,11 @@ def test_delivery_import_xlsx_with_only_follow_up_plan_returns_400(
         format="multipart",
     )
 
+    # the follow-up plan satisfies the importable-plans gate; the request fails
+    # later on the unreadable file, not on the plan-type check
     assert response.status_code == status.HTTP_400_BAD_REQUEST
-    assert "Import requires at least one payment plan in ACCEPTED or FINISHED status." in str(response.json())
+    assert "Import requires at least one payment plan" not in str(response.json())
+    assert "Wrong file type" in str(response.json())
 
 
 def test_delivery_import_xlsx_queues_async_task_on_commit(
@@ -2049,11 +2294,12 @@ def test_export_with_template_queues_task_with_template_id_on_commit(
 
     assert response.status_code == status.HTTP_200_OK
     mocked_task.assert_called_once()
-    called_group, called_user_id, called_template_id, called_tag = mocked_task.call_args[0]
+    called_group, called_user_id, called_template_id, called_tag, called_plan_type = mocked_task.call_args[0]
     assert called_group.id == group.id
     assert called_user_id == str(user.pk)
     assert called_template_id == str(template.pk)
     assert called_tag is None
+    assert called_plan_type == PaymentPlan.PlanType.REGULAR
 
 
 @pytest.mark.parametrize(
@@ -2340,7 +2586,7 @@ def test_export_for_batch_queues_task_without_template_on_commit(
 
     assert response.status_code == status.HTTP_200_OK
     mocked_task.assert_called_once()
-    called_group, called_user_id, called_template_id, called_tag = mocked_task.call_args[0]
+    called_group, called_user_id, called_template_id, called_tag, _called_plan_type = mocked_task.call_args[0]
     assert called_group.id == group.id
     assert called_user_id == str(user.pk)
     assert called_tag == 5
@@ -2372,7 +2618,7 @@ def test_export_for_batch_queues_task_with_template_id_on_commit(
 
     assert response.status_code == status.HTTP_200_OK
     mocked_task.assert_called_once()
-    called_group, called_user_id, called_template_id, called_tag = mocked_task.call_args[0]
+    called_group, called_user_id, called_template_id, called_tag, _called_plan_type = mocked_task.call_args[0]
     assert called_group.id == group.id
     assert called_user_id == str(user.pk)
     assert called_tag == 5

--- a/tests/unit/apps/payment/test_payment_plan_group_views.py
+++ b/tests/unit/apps/payment/test_payment_plan_group_views.py
@@ -538,7 +538,7 @@ def test_retrieve_detail_aggregated_totals(
     assert data["payment_plans_count"] == 2
 
 
-def test_retrieve_detail_has_follow_up_plans_flag(
+def test_retrieve_detail_can_export_follow_up_flag(
     client: Any,
     user: Any,
     business_area: Any,
@@ -555,11 +555,12 @@ def test_retrieve_detail_has_follow_up_plans_flag(
 
     assert response.status_code == status.HTTP_200_OK
     data = response.json()
-    assert data["has_follow_up_plans"] is True
-    assert data["has_top_up_plans"] is False
+    assert data["can_export_regular"] is False
+    assert data["can_export_follow_up"] is True
+    assert data["can_export_top_up"] is False
 
 
-def test_retrieve_detail_has_top_up_plans_flag(
+def test_retrieve_detail_can_export_top_up_flag(
     client: Any,
     user: Any,
     business_area: Any,
@@ -576,11 +577,33 @@ def test_retrieve_detail_has_top_up_plans_flag(
 
     assert response.status_code == status.HTTP_200_OK
     data = response.json()
-    assert data["has_follow_up_plans"] is False
-    assert data["has_top_up_plans"] is True
+    assert data["can_export_regular"] is False
+    assert data["can_export_follow_up"] is False
+    assert data["can_export_top_up"] is True
 
 
-def test_retrieve_detail_plan_type_flags_false_for_regular_only_group(
+def test_retrieve_detail_can_export_regular_flag(
+    client: Any,
+    user: Any,
+    business_area: Any,
+    program: Any,
+    group_with_accepted_plan: Any,
+    create_user_role_with_permissions: Any,
+) -> None:
+    create_user_role_with_permissions(
+        user, [Permissions.PM_PAYMENT_PLAN_GROUP_VIEW_DETAIL], business_area, program=program
+    )
+
+    response = client.get(_detail_url(business_area.slug, program.code, group_with_accepted_plan.id))
+
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert data["can_export_regular"] is True
+    assert data["can_export_follow_up"] is False
+    assert data["can_export_top_up"] is False
+
+
+def test_retrieve_detail_can_export_flags_false_for_open_plan(
     client: Any,
     user: Any,
     business_area: Any,
@@ -596,8 +619,28 @@ def test_retrieve_detail_plan_type_flags_false_for_regular_only_group(
 
     assert response.status_code == status.HTTP_200_OK
     data = response.json()
-    assert data["has_follow_up_plans"] is False
-    assert data["has_top_up_plans"] is False
+    assert data["can_export_regular"] is False
+    assert data["can_export_follow_up"] is False
+    assert data["can_export_top_up"] is False
+
+
+def test_retrieve_detail_can_export_regular_false_when_already_exported(
+    client: Any,
+    user: Any,
+    business_area: Any,
+    program: Any,
+    group_with_exported_batch: Any,
+    create_user_role_with_permissions: Any,
+) -> None:
+    create_user_role_with_permissions(
+        user, [Permissions.PM_PAYMENT_PLAN_GROUP_VIEW_DETAIL], business_area, program=program
+    )
+
+    response = client.get(_detail_url(business_area.slug, program.code, group_with_exported_batch.id))
+
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert data["can_export_regular"] is False
 
 
 def test_delete_group_with_no_plans_succeeds(

--- a/tests/unit/apps/payment/test_payment_plan_group_views.py
+++ b/tests/unit/apps/payment/test_payment_plan_group_views.py
@@ -244,6 +244,29 @@ def group_with_accepted_top_up_plan_and_payment(business_area: Any, cycle: Any) 
 
 
 @pytest.fixture
+def group_with_accepted_top_up_amendment_plan_and_payment(business_area: Any, cycle: Any) -> Any:
+    group = cycle.payment_plan_groups.first()
+    fsp = FinancialServiceProviderFactory()
+    delivery_mechanism = DeliveryMechanismFactory()
+    FspXlsxTemplatePerDeliveryMechanismFactory(
+        financial_service_provider=fsp,
+        delivery_mechanism=delivery_mechanism,
+    )
+    plan = PaymentPlanFactory(
+        business_area=business_area,
+        program_cycle=cycle,
+        payment_plan_group=group,
+        financial_service_provider=fsp,
+        delivery_mechanism=delivery_mechanism,
+        status=PaymentPlan.Status.ACCEPTED,
+        plan_type=PaymentPlan.PlanType.TOP_UP_AMENDMENT,
+    )
+    payment = PaymentFactory(parent=plan, financial_service_provider=fsp, delivery_type=delivery_mechanism)
+    PaymentHouseholdSnapshotFactory(payment=payment, snapshot_data={})
+    return group
+
+
+@pytest.fixture
 def group_with_accepted_plan_and_payment_no_template(business_area: Any, cycle: Any) -> Any:
     """Accepted plan with an eligible payment but no resolvable FSP XLSX template - export yields no rows."""
     group = cycle.payment_plan_groups.first()
@@ -558,6 +581,7 @@ def test_retrieve_detail_can_export_follow_up_flag(
     assert data["can_export_regular"] is False
     assert data["can_export_follow_up"] is True
     assert data["can_export_top_up"] is False
+    assert data["can_export_top_up_amendment"] is False
 
 
 def test_retrieve_detail_can_export_top_up_flag(
@@ -580,6 +604,7 @@ def test_retrieve_detail_can_export_top_up_flag(
     assert data["can_export_regular"] is False
     assert data["can_export_follow_up"] is False
     assert data["can_export_top_up"] is True
+    assert data["can_export_top_up_amendment"] is False
 
 
 def test_retrieve_detail_can_export_regular_flag(
@@ -601,6 +626,7 @@ def test_retrieve_detail_can_export_regular_flag(
     assert data["can_export_regular"] is True
     assert data["can_export_follow_up"] is False
     assert data["can_export_top_up"] is False
+    assert data["can_export_top_up_amendment"] is False
 
 
 def test_retrieve_detail_can_export_flags_false_for_open_plan(
@@ -622,6 +648,30 @@ def test_retrieve_detail_can_export_flags_false_for_open_plan(
     assert data["can_export_regular"] is False
     assert data["can_export_follow_up"] is False
     assert data["can_export_top_up"] is False
+    assert data["can_export_top_up_amendment"] is False
+
+
+def test_retrieve_detail_can_export_top_up_amendment_flag(
+    client: Any,
+    user: Any,
+    business_area: Any,
+    program: Any,
+    group_with_accepted_top_up_amendment_plan_and_payment: Any,
+    create_user_role_with_permissions: Any,
+) -> None:
+    create_user_role_with_permissions(
+        user, [Permissions.PM_PAYMENT_PLAN_GROUP_VIEW_DETAIL], business_area, program=program
+    )
+    group = group_with_accepted_top_up_amendment_plan_and_payment
+
+    response = client.get(_detail_url(business_area.slug, program.code, group.id))
+
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert data["can_export_regular"] is False
+    assert data["can_export_follow_up"] is False
+    assert data["can_export_top_up"] is False
+    assert data["can_export_top_up_amendment"] is True
 
 
 def test_retrieve_detail_can_export_regular_false_when_already_exported(
@@ -1390,6 +1440,34 @@ def test_export_top_up_plan_type_queues_task_with_plan_type(
     assert called_plan_type == PaymentPlan.PlanType.TOP_UP
 
 
+def test_export_top_up_amendment_plan_type_queues_task_with_plan_type(
+    client: Any,
+    user: Any,
+    business_area: Any,
+    program: Any,
+    group_with_accepted_top_up_amendment_plan_and_payment: Any,
+    create_user_role_with_permissions: Any,
+) -> None:
+    create_user_role_with_permissions(
+        user, [Permissions.PM_PAYMENT_PLAN_GROUP_EXPORT_XLSX], business_area, program=program
+    )
+    group = group_with_accepted_top_up_amendment_plan_and_payment
+
+    with (
+        patch("hope.apps.payment.api.views.export_payment_plan_group_delivery_xlsx_async_task") as mocked_task,
+        TestCase.captureOnCommitCallbacks(execute=True),
+    ):
+        response = client.post(
+            _export_url(business_area.slug, program.code, group.id),
+            {"plan_type": PaymentPlan.PlanType.TOP_UP_AMENDMENT},
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    mocked_task.assert_called_once()
+    called_plan_type = mocked_task.call_args[0][4]
+    assert called_plan_type == PaymentPlan.PlanType.TOP_UP_AMENDMENT
+
+
 def test_export_invalid_plan_type_returns_400(
     client: Any,
     user: Any,
@@ -1406,7 +1484,7 @@ def test_export_invalid_plan_type_returns_400(
     with patch("hope.apps.payment.api.views.export_payment_plan_group_delivery_xlsx_async_task") as mocked_task:
         response = client.post(
             _export_url(business_area.slug, program.code, group.id),
-            {"plan_type": PaymentPlan.PlanType.TOP_UP_AMENDMENT},
+            {"plan_type": "NOT_A_PLAN_TYPE"},
         )
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/tests/unit/apps/payment/test_xlsx_payment_plan_group_delivery_export_service.py
+++ b/tests/unit/apps/payment/test_xlsx_payment_plan_group_delivery_export_service.py
@@ -387,6 +387,31 @@ def make_payment_gateway_group(
     return build_group
 
 
+@pytest.fixture
+def make_auth_code_group_with_typed_plan(
+    program_cycle, business_area, payment_gateway_fsp, delivery_mechanism, auth_code_template
+):
+    """Build a group with one exportable payment-gateway plan of the given plan type."""
+
+    def build_group(plan_type):
+        group = PaymentPlanGroupFactory(cycle=program_cycle)
+        plan = PaymentPlanFactory(
+            program_cycle=program_cycle,
+            payment_plan_group=group,
+            business_area=business_area,
+            financial_service_provider=payment_gateway_fsp,
+            delivery_mechanism=delivery_mechanism,
+            status=PaymentPlan.Status.ACCEPTED,
+            plan_type=plan_type,
+        )
+        PaymentFactory(
+            parent=plan, financial_service_provider=payment_gateway_fsp, status=Payment.STATUS_DISTRIBUTION_SUCCESS
+        )
+        return group, plan
+
+    return build_group
+
+
 def test_workbook_has_single_sheet_with_group_title(group_with_one_accepted_plan):
     wb = XlsxPaymentPlanGroupDeliveryExportService(group_with_one_accepted_plan).generate_workbook()
 
@@ -835,6 +860,36 @@ def test_save_xlsx_file_with_auth_code_produces_encrypted_zip(
     assert plan.export_tag == 1
     file_temp = plan.export_file_delivery
     assert file_temp is not None
+    assert file_temp.file.name.endswith(".zip")
+    assert file_temp.password is not None
+    assert file_temp.xlsx_password is not None
+
+
+def test_save_xlsx_file_with_auth_code_follow_up_produces_zip_with_suffix(make_auth_code_group_with_typed_plan, user):
+    group, plan = make_auth_code_group_with_typed_plan(PaymentPlan.PlanType.FOLLOW_UP)
+
+    XlsxPaymentPlanGroupDeliveryExportService(group, plan_type=PaymentPlan.PlanType.FOLLOW_UP).save_xlsx_file(user)
+
+    plan.refresh_from_db()
+    assert plan.export_tag == 1
+    file_temp = plan.export_file_delivery
+    assert file_temp is not None
+    assert "_follow_up" in file_temp.file.name
+    assert file_temp.file.name.endswith(".zip")
+    assert file_temp.password is not None
+    assert file_temp.xlsx_password is not None
+
+
+def test_save_xlsx_file_with_auth_code_top_up_produces_zip_with_suffix(make_auth_code_group_with_typed_plan, user):
+    group, plan = make_auth_code_group_with_typed_plan(PaymentPlan.PlanType.TOP_UP)
+
+    XlsxPaymentPlanGroupDeliveryExportService(group, plan_type=PaymentPlan.PlanType.TOP_UP).save_xlsx_file(user)
+
+    plan.refresh_from_db()
+    assert plan.export_tag == 1
+    file_temp = plan.export_file_delivery
+    assert file_temp is not None
+    assert "_top_up" in file_temp.file.name
     assert file_temp.file.name.endswith(".zip")
     assert file_temp.password is not None
     assert file_temp.xlsx_password is not None

--- a/tests/unit/apps/payment/test_xlsx_payment_plan_group_delivery_export_service.py
+++ b/tests/unit/apps/payment/test_xlsx_payment_plan_group_delivery_export_service.py
@@ -492,7 +492,7 @@ def group_with_follow_up_and_top_up_plans(program_cycle, business_area, fsp, del
         status=PaymentPlan.Status.ACCEPTED,
         plan_type=PaymentPlan.PlanType.REGULAR,
     )
-    PaymentPlanFactory(
+    follow_up_plan = PaymentPlanFactory(
         program_cycle=program_cycle,
         payment_plan_group=group,
         business_area=business_area,
@@ -501,7 +501,7 @@ def group_with_follow_up_and_top_up_plans(program_cycle, business_area, fsp, del
         status=PaymentPlan.Status.ACCEPTED,
         plan_type=PaymentPlan.PlanType.FOLLOW_UP,
     )
-    PaymentPlanFactory(
+    top_up_plan = PaymentPlanFactory(
         program_cycle=program_cycle,
         payment_plan_group=group,
         business_area=business_area,
@@ -510,7 +510,7 @@ def group_with_follow_up_and_top_up_plans(program_cycle, business_area, fsp, del
         status=PaymentPlan.Status.ACCEPTED,
         plan_type=PaymentPlan.PlanType.TOP_UP,
     )
-    return group, regular_plan
+    return group, regular_plan, follow_up_plan, top_up_plan
 
 
 @pytest.fixture
@@ -537,12 +537,83 @@ def group_with_tagged_and_untagged_plans(program_cycle, business_area, fsp, deli
     return group, tagged_plan, untagged_plan
 
 
-def test_follow_up_and_top_up_plans_are_excluded(group_with_follow_up_and_top_up_plans):
-    group, regular_plan = group_with_follow_up_and_top_up_plans
+def test_follow_up_and_top_up_plans_are_excluded_by_default(group_with_follow_up_and_top_up_plans):
+    group, regular_plan, _follow_up_plan, _top_up_plan = group_with_follow_up_and_top_up_plans
 
     service = XlsxPaymentPlanGroupDeliveryExportService(group)
 
     assert [plan.id for plan in service.payment_plans] == [regular_plan.id]
+
+
+def test_plan_type_follow_up_selects_only_follow_up_plans(group_with_follow_up_and_top_up_plans):
+    group, _regular_plan, follow_up_plan, _top_up_plan = group_with_follow_up_and_top_up_plans
+
+    service = XlsxPaymentPlanGroupDeliveryExportService(group, plan_type=PaymentPlan.PlanType.FOLLOW_UP)
+
+    assert [plan.id for plan in service.payment_plans] == [follow_up_plan.id]
+
+
+def test_plan_type_top_up_selects_only_top_up_plans(group_with_follow_up_and_top_up_plans):
+    group, _regular_plan, _follow_up_plan, top_up_plan = group_with_follow_up_and_top_up_plans
+
+    service = XlsxPaymentPlanGroupDeliveryExportService(group, plan_type=PaymentPlan.PlanType.TOP_UP)
+
+    assert [plan.id for plan in service.payment_plans] == [top_up_plan.id]
+
+
+def test_save_xlsx_file_follow_up_filename_contains_follow_up(group_with_follow_up_and_top_up_plans, user):
+    group, _regular_plan, follow_up_plan, _top_up_plan = group_with_follow_up_and_top_up_plans
+
+    XlsxPaymentPlanGroupDeliveryExportService(group, plan_type=PaymentPlan.PlanType.FOLLOW_UP).save_xlsx_file(user)
+
+    follow_up_plan.refresh_from_db()
+    assert follow_up_plan.export_file_delivery is not None
+    assert "_follow_up" in follow_up_plan.export_file_delivery.file.name
+    assert follow_up_plan.export_file_delivery.file.name.endswith(".xlsx")
+
+
+def test_save_xlsx_file_top_up_filename_contains_top_up(group_with_follow_up_and_top_up_plans, user):
+    group, _regular_plan, _follow_up_plan, top_up_plan = group_with_follow_up_and_top_up_plans
+
+    XlsxPaymentPlanGroupDeliveryExportService(group, plan_type=PaymentPlan.PlanType.TOP_UP).save_xlsx_file(user)
+
+    top_up_plan.refresh_from_db()
+    assert top_up_plan.export_file_delivery is not None
+    assert "_top_up" in top_up_plan.export_file_delivery.file.name
+
+
+def test_save_xlsx_file_follow_up_leaves_other_plan_types_untagged(group_with_follow_up_and_top_up_plans, user):
+    group, regular_plan, follow_up_plan, top_up_plan = group_with_follow_up_and_top_up_plans
+
+    XlsxPaymentPlanGroupDeliveryExportService(group, plan_type=PaymentPlan.PlanType.FOLLOW_UP).save_xlsx_file(user)
+
+    regular_plan.refresh_from_db()
+    follow_up_plan.refresh_from_db()
+    top_up_plan.refresh_from_db()
+    assert follow_up_plan.export_tag == 1
+    assert regular_plan.export_tag is None
+    assert top_up_plan.export_tag is None
+
+
+def test_reexport_batch_recovers_plan_type_from_batch(group_with_follow_up_and_top_up_plans, user):
+    group, _regular_plan, follow_up_plan, _top_up_plan = group_with_follow_up_and_top_up_plans
+    XlsxPaymentPlanGroupDeliveryExportService(group, plan_type=PaymentPlan.PlanType.FOLLOW_UP).save_xlsx_file(user)
+    follow_up_plan.refresh_from_db()
+
+    reexport_service = XlsxPaymentPlanGroupDeliveryExportService(group, export_tag=follow_up_plan.export_tag)
+
+    assert reexport_service.plan_type == PaymentPlan.PlanType.FOLLOW_UP
+
+
+def test_get_email_context_follow_up_batch_name_carries_plan_type(group_with_follow_up_and_top_up_plans, user):
+    group, _regular_plan, _follow_up_plan, _top_up_plan = group_with_follow_up_and_top_up_plans
+    service = XlsxPaymentPlanGroupDeliveryExportService(group, plan_type=PaymentPlan.PlanType.FOLLOW_UP)
+    service.save_xlsx_file(user)
+
+    context = service.get_email_context(user)
+
+    assert "Batch 1 Follow Up" in context["title"]
+    assert "Batch 1 Follow Up" in context["message"]
 
 
 def test_already_tagged_plans_are_excluded_from_export(group_with_tagged_and_untagged_plans):

--- a/tests/unit/apps/payment/test_xlsx_payment_plan_group_delivery_export_service.py
+++ b/tests/unit/apps/payment/test_xlsx_payment_plan_group_delivery_export_service.py
@@ -413,13 +413,17 @@ def make_auth_code_group_with_typed_plan(
 
 
 def test_workbook_has_single_sheet_with_group_title(group_with_one_accepted_plan):
-    wb = XlsxPaymentPlanGroupDeliveryExportService(group_with_one_accepted_plan).generate_workbook()
+    wb = XlsxPaymentPlanGroupDeliveryExportService(
+        group_with_one_accepted_plan, plan_type=PaymentPlan.PlanType.REGULAR
+    ).generate_workbook()
 
     assert wb.sheetnames == ["Payment Plan Group - Payment List"]
 
 
 def test_header_row_contains_fsp_template_columns(group_with_one_accepted_plan):
-    wb = XlsxPaymentPlanGroupDeliveryExportService(group_with_one_accepted_plan).generate_workbook()
+    wb = XlsxPaymentPlanGroupDeliveryExportService(
+        group_with_one_accepted_plan, plan_type=PaymentPlan.PlanType.REGULAR
+    ).generate_workbook()
     header_row = [cell.value for cell in wb.active[1]]
 
     assert header_row[0] == "payment_id"
@@ -429,28 +433,36 @@ def test_header_row_contains_fsp_template_columns(group_with_one_accepted_plan):
 
 
 def test_empty_group_produces_workbook_with_no_payment_rows(empty_group):
-    wb = XlsxPaymentPlanGroupDeliveryExportService(empty_group).generate_workbook()
+    wb = XlsxPaymentPlanGroupDeliveryExportService(
+        empty_group, plan_type=PaymentPlan.PlanType.REGULAR
+    ).generate_workbook()
     ws = wb.active
 
     assert ws.max_row == 1
 
 
 def test_plan_whose_fsp_has_no_template_is_skipped(group_with_plan_without_template):
-    wb = XlsxPaymentPlanGroupDeliveryExportService(group_with_plan_without_template).generate_workbook()
+    wb = XlsxPaymentPlanGroupDeliveryExportService(
+        group_with_plan_without_template, plan_type=PaymentPlan.PlanType.REGULAR
+    ).generate_workbook()
     ws = wb.active
 
     assert ws.max_row == 1
 
 
 def test_open_plans_are_not_exported(group_with_open_plan):
-    wb = XlsxPaymentPlanGroupDeliveryExportService(group_with_open_plan).generate_workbook()
+    wb = XlsxPaymentPlanGroupDeliveryExportService(
+        group_with_open_plan, plan_type=PaymentPlan.PlanType.REGULAR
+    ).generate_workbook()
     ws = wb.active
 
     assert ws.max_row == 1
 
 
 def test_headers_for_social_worker_program(group_with_social_worker_program):
-    wb = XlsxPaymentPlanGroupDeliveryExportService(group_with_social_worker_program).generate_workbook()
+    wb = XlsxPaymentPlanGroupDeliveryExportService(
+        group_with_social_worker_program, plan_type=PaymentPlan.PlanType.REGULAR
+    ).generate_workbook()
     header_row = [cell.value for cell in wb.active[1]]
 
     assert "individual_id" in header_row
@@ -459,7 +471,9 @@ def test_headers_for_social_worker_program(group_with_social_worker_program):
 
 
 def test_payment_row_contains_entitlement_quantities(group_with_payment_and_full_snapshot):
-    wb = XlsxPaymentPlanGroupDeliveryExportService(group_with_payment_and_full_snapshot).generate_workbook()
+    wb = XlsxPaymentPlanGroupDeliveryExportService(
+        group_with_payment_and_full_snapshot, plan_type=PaymentPlan.PlanType.REGULAR
+    ).generate_workbook()
     ws = wb.active
     headers = [cell.value for cell in ws[1]]
     entitlement_col = headers.index("entitlement_quantity") + 1
@@ -470,7 +484,9 @@ def test_payment_row_contains_entitlement_quantities(group_with_payment_and_full
 
 
 def test_payment_row_contains_snapshot_household_data(group_with_payment_and_full_snapshot):
-    wb = XlsxPaymentPlanGroupDeliveryExportService(group_with_payment_and_full_snapshot).generate_workbook()
+    wb = XlsxPaymentPlanGroupDeliveryExportService(
+        group_with_payment_and_full_snapshot, plan_type=PaymentPlan.PlanType.REGULAR
+    ).generate_workbook()
     ws = wb.active
     headers = [cell.value for cell in ws[1]]
     household_id_col = headers.index("household_id") + 1
@@ -493,7 +509,7 @@ def test_payments_grouped_by_plan_and_sorted_within_each_plan(group_with_two_pla
     )
     expected_order = plan_one_payment_ids + plan_two_payment_ids
 
-    wb = XlsxPaymentPlanGroupDeliveryExportService(group).generate_workbook()
+    wb = XlsxPaymentPlanGroupDeliveryExportService(group, plan_type=PaymentPlan.PlanType.REGULAR).generate_workbook()
     ws = wb.active
     payment_ids_in_order = [ws.cell(row=row, column=1).value for row in range(2, ws.max_row + 1)]
 
@@ -562,12 +578,19 @@ def group_with_tagged_and_untagged_plans(program_cycle, business_area, fsp, deli
     return group, tagged_plan, untagged_plan
 
 
-def test_follow_up_and_top_up_plans_are_excluded_by_default(group_with_follow_up_and_top_up_plans):
+def test_follow_up_and_top_up_plans_are_excluded_from_regular_export(group_with_follow_up_and_top_up_plans):
     group, regular_plan, _follow_up_plan, _top_up_plan = group_with_follow_up_and_top_up_plans
 
-    service = XlsxPaymentPlanGroupDeliveryExportService(group)
+    service = XlsxPaymentPlanGroupDeliveryExportService(group, plan_type=PaymentPlan.PlanType.REGULAR)
 
     assert [plan.id for plan in service.payment_plans] == [regular_plan.id]
+
+
+def test_new_export_without_plan_type_raises(group_with_follow_up_and_top_up_plans):
+    group, _regular_plan, _follow_up_plan, _top_up_plan = group_with_follow_up_and_top_up_plans
+
+    with pytest.raises(ValueError, match="plan_type is required when creating a new export batch."):
+        XlsxPaymentPlanGroupDeliveryExportService(group)
 
 
 def test_plan_type_follow_up_selects_only_follow_up_plans(group_with_follow_up_and_top_up_plans):
@@ -644,7 +667,7 @@ def test_get_email_context_follow_up_batch_name_carries_plan_type(group_with_fol
 def test_already_tagged_plans_are_excluded_from_export(group_with_tagged_and_untagged_plans):
     group, _tagged_plan, untagged_plan = group_with_tagged_and_untagged_plans
 
-    service = XlsxPaymentPlanGroupDeliveryExportService(group)
+    service = XlsxPaymentPlanGroupDeliveryExportService(group, plan_type=PaymentPlan.PlanType.REGULAR)
 
     assert [plan.id for plan in service.payment_plans] == [untagged_plan.id]
 
@@ -652,7 +675,9 @@ def test_already_tagged_plans_are_excluded_from_export(group_with_tagged_and_unt
 def test_save_xlsx_file_stamps_first_batch_with_tag_one(group_with_one_accepted_plan, user):
     plan = group_with_one_accepted_plan.payment_plans.first()
 
-    XlsxPaymentPlanGroupDeliveryExportService(group_with_one_accepted_plan).save_xlsx_file(user)
+    XlsxPaymentPlanGroupDeliveryExportService(
+        group_with_one_accepted_plan, plan_type=PaymentPlan.PlanType.REGULAR
+    ).save_xlsx_file(user)
 
     plan.refresh_from_db()
     assert plan.export_tag == 1
@@ -661,7 +686,9 @@ def test_save_xlsx_file_stamps_first_batch_with_tag_one(group_with_one_accepted_
 def test_save_xlsx_file_stores_batch_file_on_plan(group_with_one_accepted_plan, user):
     plan = group_with_one_accepted_plan.payment_plans.first()
 
-    XlsxPaymentPlanGroupDeliveryExportService(group_with_one_accepted_plan).save_xlsx_file(user)
+    XlsxPaymentPlanGroupDeliveryExportService(
+        group_with_one_accepted_plan, plan_type=PaymentPlan.PlanType.REGULAR
+    ).save_xlsx_file(user)
 
     plan.refresh_from_db()
     assert plan.export_file_delivery is not None
@@ -671,13 +698,17 @@ def test_save_xlsx_file_stores_batch_file_on_plan(group_with_one_accepted_plan, 
 
 def test_save_xlsx_file_no_eligible_plans_raises_and_creates_no_file(empty_group, user):
     with pytest.raises(EmptyDeliveryExportError):
-        XlsxPaymentPlanGroupDeliveryExportService(empty_group).save_xlsx_file(user)
+        XlsxPaymentPlanGroupDeliveryExportService(empty_group, plan_type=PaymentPlan.PlanType.REGULAR).save_xlsx_file(
+            user
+        )
 
     assert not empty_group.payment_plans.filter(export_file_delivery__isnull=False).exists()
 
 
 def test_save_xlsx_file_all_plans_skipped_reports_reasons(group_with_plan_without_template, user):
-    service = XlsxPaymentPlanGroupDeliveryExportService(group_with_plan_without_template)
+    service = XlsxPaymentPlanGroupDeliveryExportService(
+        group_with_plan_without_template, plan_type=PaymentPlan.PlanType.REGULAR
+    )
 
     with pytest.raises(EmptyDeliveryExportError) as exc_info:
         service.save_xlsx_file(user)
@@ -690,7 +721,7 @@ def test_save_xlsx_file_all_plans_skipped_reports_reasons(group_with_plan_withou
 def test_save_xlsx_file_exports_mapped_plan_and_leaves_skipped_untouched(group_one_exportable_two_skipped, user):
     group, exportable_plan, skipped_plan_one, skipped_plan_two = group_one_exportable_two_skipped
 
-    XlsxPaymentPlanGroupDeliveryExportService(group).save_xlsx_file(user)
+    XlsxPaymentPlanGroupDeliveryExportService(group, plan_type=PaymentPlan.PlanType.REGULAR).save_xlsx_file(user)
 
     exportable_plan.refresh_from_db()
     skipped_plan_one.refresh_from_db()
@@ -704,7 +735,9 @@ def test_save_xlsx_file_exports_mapped_plan_and_leaves_skipped_untouched(group_o
 
 
 def test_save_xlsx_file_multiple_plans_all_skipped_raises_with_all_reasons(group_with_two_plans_without_template, user):
-    service = XlsxPaymentPlanGroupDeliveryExportService(group_with_two_plans_without_template)
+    service = XlsxPaymentPlanGroupDeliveryExportService(
+        group_with_two_plans_without_template, plan_type=PaymentPlan.PlanType.REGULAR
+    )
 
     with pytest.raises(EmptyDeliveryExportError) as exc_info:
         service.save_xlsx_file(user)
@@ -717,7 +750,7 @@ def test_save_xlsx_file_multiple_plans_all_skipped_raises_with_all_reasons(group
 def test_save_xlsx_file_one_batch_tags_all_plans_and_shares_file(group_with_two_plans_and_payments, user):
     group = group_with_two_plans_and_payments
 
-    XlsxPaymentPlanGroupDeliveryExportService(group).save_xlsx_file(user)
+    XlsxPaymentPlanGroupDeliveryExportService(group, plan_type=PaymentPlan.PlanType.REGULAR).save_xlsx_file(user)
 
     plans = list(group.payment_plans.order_by("unicef_id"))
     assert all(plan.export_tag == 1 for plan in plans)
@@ -737,7 +770,7 @@ def test_save_xlsx_file_second_export_increments_tag_and_excludes_first_batch(
         delivery_mechanism=delivery_mechanism,
         status=PaymentPlan.Status.ACCEPTED,
     )
-    XlsxPaymentPlanGroupDeliveryExportService(group).save_xlsx_file(user)
+    XlsxPaymentPlanGroupDeliveryExportService(group, plan_type=PaymentPlan.PlanType.REGULAR).save_xlsx_file(user)
     second_plan = PaymentPlanFactory(
         program_cycle=program_cycle,
         payment_plan_group=group,
@@ -747,7 +780,7 @@ def test_save_xlsx_file_second_export_increments_tag_and_excludes_first_batch(
         status=PaymentPlan.Status.ACCEPTED,
     )
 
-    second_service = XlsxPaymentPlanGroupDeliveryExportService(group)
+    second_service = XlsxPaymentPlanGroupDeliveryExportService(group, plan_type=PaymentPlan.PlanType.REGULAR)
     assert [plan.id for plan in second_service.payment_plans] == [second_plan.id]
     second_service.save_xlsx_file(user)
 
@@ -768,7 +801,9 @@ def test_resolve_template_returns_explicitly_requested_template(program_cycle, b
         status=PaymentPlan.Status.ACCEPTED,
     )
     explicit_template = FinancialServiceProviderXlsxTemplateFactory()
-    service = XlsxPaymentPlanGroupDeliveryExportService(group, fsp_xlsx_template_id=str(explicit_template.pk))
+    service = XlsxPaymentPlanGroupDeliveryExportService(
+        group, fsp_xlsx_template_id=str(explicit_template.pk), plan_type=PaymentPlan.PlanType.REGULAR
+    )
 
     assert service._resolve_template(plan) == explicit_template
 
@@ -783,13 +818,15 @@ def test_resolve_template_returns_none_when_plan_has_no_fsp_or_delivery_mechanis
         delivery_mechanism=None,
         status=PaymentPlan.Status.ACCEPTED,
     )
-    service = XlsxPaymentPlanGroupDeliveryExportService(group)
+    service = XlsxPaymentPlanGroupDeliveryExportService(group, plan_type=PaymentPlan.PlanType.REGULAR)
 
     assert service._resolve_template(plan) is None
 
 
 def test_save_xlsx_file_reexport_with_export_tag_replaces_file_and_keeps_tag(group_with_one_accepted_plan, user):
-    XlsxPaymentPlanGroupDeliveryExportService(group_with_one_accepted_plan).save_xlsx_file(user)
+    XlsxPaymentPlanGroupDeliveryExportService(
+        group_with_one_accepted_plan, plan_type=PaymentPlan.PlanType.REGULAR
+    ).save_xlsx_file(user)
     plan = group_with_one_accepted_plan.payment_plans.first()
     plan.refresh_from_db()
     first_file_id = plan.export_file_delivery_id
@@ -806,7 +843,9 @@ def test_save_xlsx_file_does_not_tag_plan_whose_fsp_has_no_template(group_with_p
     plan = group_with_plan_without_template.payment_plans.first()
 
     with pytest.raises(EmptyDeliveryExportError):
-        XlsxPaymentPlanGroupDeliveryExportService(group_with_plan_without_template).save_xlsx_file(user)
+        XlsxPaymentPlanGroupDeliveryExportService(
+            group_with_plan_without_template, plan_type=PaymentPlan.PlanType.REGULAR
+        ).save_xlsx_file(user)
 
     plan.refresh_from_db()
     assert plan.export_tag is None
@@ -828,7 +867,7 @@ def test_plan_with_unprocessed_payments_is_skipped_when_template_requires_auth_c
     PaymentFactory(parent=plan, financial_service_provider=payment_gateway_fsp, status=Payment.STATUS_PENDING)
 
     with pytest.raises(EmptyDeliveryExportError):
-        XlsxPaymentPlanGroupDeliveryExportService(group).save_xlsx_file(user)
+        XlsxPaymentPlanGroupDeliveryExportService(group, plan_type=PaymentPlan.PlanType.REGULAR).save_xlsx_file(user)
 
     plan.refresh_from_db()
     assert plan.export_tag is None
@@ -854,7 +893,7 @@ def test_save_xlsx_file_with_auth_code_produces_encrypted_zip(
         status=Payment.STATUS_DISTRIBUTION_SUCCESS,
     )
 
-    XlsxPaymentPlanGroupDeliveryExportService(group).save_xlsx_file(user)
+    XlsxPaymentPlanGroupDeliveryExportService(group, plan_type=PaymentPlan.PlanType.REGULAR).save_xlsx_file(user)
 
     plan.refresh_from_db()
     assert plan.export_tag == 1
@@ -911,7 +950,7 @@ def test_save_xlsx_file_with_auth_code_reexport_with_export_tag_replaces_file_an
         parent=plan, financial_service_provider=payment_gateway_fsp, status=Payment.STATUS_DISTRIBUTION_SUCCESS
     )
 
-    XlsxPaymentPlanGroupDeliveryExportService(group).save_xlsx_file(user)
+    XlsxPaymentPlanGroupDeliveryExportService(group, plan_type=PaymentPlan.PlanType.REGULAR).save_xlsx_file(user)
     plan.refresh_from_db()
     first_file_id = plan.export_file_delivery_id
     assert plan.export_tag == 1
@@ -924,7 +963,9 @@ def test_save_xlsx_file_with_auth_code_reexport_with_export_tag_replaces_file_an
 
 
 def test_get_email_context_returns_user_recipient_fields(group_with_one_accepted_plan, user):
-    service = XlsxPaymentPlanGroupDeliveryExportService(group_with_one_accepted_plan)
+    service = XlsxPaymentPlanGroupDeliveryExportService(
+        group_with_one_accepted_plan, plan_type=PaymentPlan.PlanType.REGULAR
+    )
     service.applied_export_tag = 1
 
     context = service.get_email_context(user)
@@ -935,7 +976,9 @@ def test_get_email_context_returns_user_recipient_fields(group_with_one_accepted
 
 
 def test_get_email_context_link_points_to_batch_download(group_with_one_accepted_plan, user):
-    service = XlsxPaymentPlanGroupDeliveryExportService(group_with_one_accepted_plan)
+    service = XlsxPaymentPlanGroupDeliveryExportService(
+        group_with_one_accepted_plan, plan_type=PaymentPlan.PlanType.REGULAR
+    )
     service.applied_export_tag = 1
 
     context = service.get_email_context(user)
@@ -946,7 +989,7 @@ def test_get_email_context_link_points_to_batch_download(group_with_one_accepted
 
 def test_get_email_context_message_and_title_carry_group_and_batch(group_with_one_accepted_plan, user):
     group = group_with_one_accepted_plan
-    service = XlsxPaymentPlanGroupDeliveryExportService(group)
+    service = XlsxPaymentPlanGroupDeliveryExportService(group, plan_type=PaymentPlan.PlanType.REGULAR)
     service.applied_export_tag = 1
 
     context = service.get_email_context(user)
@@ -995,14 +1038,20 @@ def test_per_plan_service_uses_provided_shared_lookups_without_reloading(group_w
 def test_group_export_builds_shared_lookups_once_for_multiple_plans(group_with_two_plans_and_payments, mocker):
     build_spy = mocker.spy(XlsxPaymentPlanDeliveryExportService, "build_shared_lookups")
 
-    XlsxPaymentPlanGroupDeliveryExportService(group_with_two_plans_and_payments).generate_workbook()
+    XlsxPaymentPlanGroupDeliveryExportService(
+        group_with_two_plans_and_payments, plan_type=PaymentPlan.PlanType.REGULAR
+    ).generate_workbook()
 
     assert build_spy.call_count == 1
 
 
 def test_preview_export_query_count_is_independent_of_plan_count(make_payment_gateway_group):
-    service_two_plans = XlsxPaymentPlanGroupDeliveryExportService(make_payment_gateway_group(2))
-    service_three_plans = XlsxPaymentPlanGroupDeliveryExportService(make_payment_gateway_group(3))
+    service_two_plans = XlsxPaymentPlanGroupDeliveryExportService(
+        make_payment_gateway_group(2), plan_type=PaymentPlan.PlanType.REGULAR
+    )
+    service_three_plans = XlsxPaymentPlanGroupDeliveryExportService(
+        make_payment_gateway_group(3), plan_type=PaymentPlan.PlanType.REGULAR
+    )
 
     with CaptureQueriesContext(connection) as queries_two_plans:
         exported_two_plans = service_two_plans.preview_export()
@@ -1018,7 +1067,9 @@ def test_preview_export_query_count_is_independent_of_plan_count(make_payment_ga
 
 def test_preview_export_runs_single_query_for_non_gateway_plans(group_with_two_plans_and_payments):
     # XLSX (non-payment-gateway) FSPs short-circuit before the blocking-payments query, leaving only the template map
-    service = XlsxPaymentPlanGroupDeliveryExportService(group_with_two_plans_and_payments)
+    service = XlsxPaymentPlanGroupDeliveryExportService(
+        group_with_two_plans_and_payments, plan_type=PaymentPlan.PlanType.REGULAR
+    )
 
     with CaptureQueriesContext(connection) as queries:
         exported = service.preview_export()

--- a/tests/unit/apps/payment/test_xlsx_payment_plan_group_delivery_import_service.py
+++ b/tests/unit/apps/payment/test_xlsx_payment_plan_group_delivery_import_service.py
@@ -180,7 +180,21 @@ def group_with_follow_up_and_top_up_plans(program_cycle, business_area, fsp, del
         status=PaymentPlan.Status.ACCEPTED,
         plan_type=PaymentPlan.PlanType.FOLLOW_UP,
     )
-    return {"group": group, "regular_plan": regular_plan, "follow_up_plan": follow_up_plan}
+    top_up_plan = PaymentPlanFactory(
+        program_cycle=program_cycle,
+        payment_plan_group=group,
+        business_area=business_area,
+        financial_service_provider=fsp,
+        delivery_mechanism=delivery_mechanism,
+        status=PaymentPlan.Status.ACCEPTED,
+        plan_type=PaymentPlan.PlanType.TOP_UP,
+    )
+    return {
+        "group": group,
+        "regular_plan": regular_plan,
+        "follow_up_plan": follow_up_plan,
+        "top_up_plan": top_up_plan,
+    }
 
 
 @pytest.fixture
@@ -414,7 +428,11 @@ def test_follow_up_and_top_up_plans_are_included(group_with_follow_up_and_top_up
     service = XlsxPaymentPlanGroupDeliveryImportService(ctx["group"], file)
     service.open_workbook()
 
-    assert {plan.id for plan in service.payment_plans} == {ctx["regular_plan"].id, ctx["follow_up_plan"].id}
+    assert {plan.id for plan in service.payment_plans} == {
+        ctx["regular_plan"].id,
+        ctx["follow_up_plan"].id,
+        ctx["top_up_plan"].id,
+    }
 
 
 def test_payment_gateway_plan_is_skipped_and_its_payments_emit_specific_error(

--- a/tests/unit/apps/payment/test_xlsx_payment_plan_group_delivery_import_service.py
+++ b/tests/unit/apps/payment/test_xlsx_payment_plan_group_delivery_import_service.py
@@ -408,13 +408,13 @@ def test_open_plans_are_not_indexed(group_with_open_plan):
     assert service.eligible_plans == []
 
 
-def test_follow_up_and_top_up_plans_are_excluded(group_with_follow_up_and_top_up_plans):
+def test_follow_up_and_top_up_plans_are_included(group_with_follow_up_and_top_up_plans):
     ctx = group_with_follow_up_and_top_up_plans
     file = _make_workbook(["payment_id", "delivered_quantity"], [])
     service = XlsxPaymentPlanGroupDeliveryImportService(ctx["group"], file)
     service.open_workbook()
 
-    assert [plan.id for plan in service.payment_plans] == [ctx["regular_plan"].id]
+    assert {plan.id for plan in service.payment_plans} == {ctx["regular_plan"].id, ctx["follow_up_plan"].id}
 
 
 def test_payment_gateway_plan_is_skipped_and_its_payments_emit_specific_error(


### PR DESCRIPTION
Exporting Follow Ups and Top Ups is not possible currently. 
Export buttons are visible only when any plan is exportable.
Export and Export with auth code open modal with Plan Type selection. When there are no exportable pps of some type the selection option is not visible.

Batch names have "Follow up" or "Top up" or "Top up amendment".

Export button modal:
<img width="458" height="138" alt="Screenshot 2026-07-16 at 18 11 59" src="https://github.com/user-attachments/assets/cf715be9-adef-4f17-b6e4-beca6694ce31" />

All exports exhausted:

<img width="1468" height="503" alt="Screenshot 2026-07-16 at 16 13 21" src="https://github.com/user-attachments/assets/4521bfd4-70a6-4971-92bf-2620673e0c02" />

Modal after clicking "Export with auth code" with Plan Type selection:
<img width="466" height="182" alt="Screenshot 2026-07-16 at 16 14 20" src="https://github.com/user-attachments/assets/52ea7ce1-eea8-41dc-8324-8b08d156e78f" />


