### PR TITLE
🔥hotfix- eye icon in PP list does not open modal

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [ "setuptools", "wheel" ]
 
 [project]
 name = "hope"
-version = "4.16.0"
+version = "4.16.1"
 description = "HCT MIS is UNICEF's humanitarian cash transfer platform."
 readme = "README.md"
 license = { text = "None" }

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "4.16.0",
+  "version": "4.16.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/frontend/src/containers/pages/paymentmodule/ProgramCycle/ProgramCycleDetails/LinkedPaymentPlansModal.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/ProgramCycle/ProgramCycleDetails/LinkedPaymentPlansModal.tsx
@@ -1,5 +1,4 @@
 import { ReactElement, useState } from 'react';
-import styled from 'styled-components';
 import VisibilityIcon from '@mui/icons-material/Visibility';
 import { useTranslation } from 'react-i18next';
 import { useBaseUrl } from '@hooks/useBaseUrl';
@@ -30,10 +29,6 @@ interface LinkedPaymentPlansModalProps {
   paymentPlan: PaymentPlanList;
   canViewDetails: boolean;
 }
-
-const BlackEyeIcon = styled(VisibilityIcon)`
-  color: #000;
-`;
 
 export const LinkedPaymentPlansModal = ({
   paymentPlan,
@@ -76,10 +71,13 @@ export const LinkedPaymentPlansModal = ({
         <span>{linkedPlans.length}</span>
         <IconButton
           color="primary"
-          onClick={() => setOpen(true)}
+          onClick={(e) => {
+            e.stopPropagation();
+            setOpen(true);
+          }}
           data-cy="button-eye-linked-plans"
         >
-          <BlackEyeIcon />
+          <VisibilityIcon />
         </IconButton>
       </Box>
       <Dialog open={open} onClose={() => setOpen(false)} scroll="paper">
@@ -124,7 +122,13 @@ export const LinkedPaymentPlansModal = ({
         </DialogContent>
         <DialogFooter>
           <DialogActions>
-            <Button data-cy="button-close" onClick={() => setOpen(false)}>
+            <Button
+              data-cy="button-close"
+              onClick={(e) => {
+                e.stopPropagation();
+                setOpen(false);
+              }}
+            >
               {t('Close')}
             </Button>
           </DialogActions>

--- a/src/frontend/src/containers/pages/paymentmodule/ProgramCycle/ProgramCycleDetails/LinkedPaymentPlansModal.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/ProgramCycle/ProgramCycleDetails/LinkedPaymentPlansModal.tsx
@@ -80,7 +80,12 @@ export const LinkedPaymentPlansModal = ({
           <VisibilityIcon />
         </IconButton>
       </Box>
-      <Dialog open={open} onClose={() => setOpen(false)} scroll="paper">
+      <Dialog
+        open={open}
+        onClose={() => setOpen(false)}
+        onClick={(e) => e.stopPropagation()}
+        scroll="paper"
+      >
         <DialogTitleWrapper>
           <DialogTitle>{t('Linked Payment Plans')}</DialogTitle>
         </DialogTitleWrapper>

--- a/uv.lock
+++ b/uv.lock
@@ -1928,7 +1928,7 @@ wheels = [
 
 [[package]]
 name = "hope"
-version = "4.16.0"
+version = "4.16.1"
 source = { editable = "." }
 dependencies = [
     { name = "black" },


### PR DESCRIPTION
## Problem

In the Payment Plans list, clicking the eye icon in the **Linked Payment Plans** column did not open the modal — instead it navigated to the Payment Plan details page.

The eye button and the modal's Close button live inside a `ClickableTableRow` whose `onClick` navigates to the details page. Because MUI's `Dialog` is portaled but React still replays synthetic events through the component tree, clicks on the eye icon (and on the Close button inside the dialog) bubbled up to the row's navigation handler.

Note: the same `LinkedPaymentPlansModal` is reused in the Program Cycle details table, where the row is **not** clickable — so the bug only surfaced in the Payment Plans list.

## Fix

- Call `e.stopPropagation()` in the eye `IconButton` handler before opening the modal.
- Call `e.stopPropagation()` in the Close `Button` handler before closing the modal.
- Make the eye icon use the Material UI primary color (removed the hard-coded black override and the now-unused styled component).

