### PR TITLE
[AB#330306]-Add missing FE permission checks to Payment Plan Group buttons

### DIFF
--- a/src/frontend/src/components/targeting/EditTargetPopulation/EditTargetPopulation.tsx
+++ b/src/frontend/src/components/targeting/EditTargetPopulation/EditTargetPopulation.tsx
@@ -1,6 +1,7 @@
 import { AutoSubmitFormOnEnter } from '@core/AutoSubmitFormOnEnter';
 import { PaymentPlanStatusEnum } from '@restgenerated/models/PaymentPlanStatusEnum';
 import { useBaseUrl } from '@hooks/useBaseUrl';
+import { usePermissions } from '@hooks/usePermissions';
 import { useSnackbar } from '@hooks/useSnackBar';
 import {
   Box,
@@ -37,6 +38,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { PatchedTargetPopulationCreate } from '@restgenerated/models/PatchedTargetPopulationCreate';
 import { RestService } from '@restgenerated/services/RestService';
 import { showApiErrorMessages } from '@utils/utils';
+import { hasPermissions, PERMISSIONS } from '../../../config/permissions';
 
 interface EditTargetPopulationProps {
   paymentPlan: TargetPopulationDetail;
@@ -55,6 +57,7 @@ const EditTargetPopulation = ({
   const { selectedProgram, isSocialDctType, isStandardDctType } =
     useProgramContext();
   const beneficiaryGroup = selectedProgram?.beneficiaryGroup;
+  const permissions = usePermissions();
   const [createGroupModalOpen, setCreateGroupModalOpen] = useState(false);
   const [modalCycle, setModalCycle] = useState<{ value: string; name: string }>(
     {
@@ -294,20 +297,24 @@ const EditTargetPopulation = ({
                     variant="outlined"
                     size="small"
                   />
-                  {paymentPlan.status === PaymentPlanStatusEnum.TP_OPEN && (
-                    <Button
-                      variant="outlined"
-                      color="primary"
-                      onClick={() => {
-                        setModalCycle(values.programCycleId);
-                        setCreateGroupModalOpen(true);
-                      }}
-                      data-cy="button-change-group"
-                      sx={{ whiteSpace: 'nowrap', flexShrink: 0 }}
-                    >
-                      {t('Change Group')}
-                    </Button>
-                  )}
+                  {paymentPlan.status === PaymentPlanStatusEnum.TP_OPEN &&
+                    hasPermissions(
+                      PERMISSIONS.PM_PAYMENT_PLAN_GROUP_CREATE,
+                      permissions,
+                    ) && (
+                      <Button
+                        variant="outlined"
+                        color="primary"
+                        onClick={() => {
+                          setModalCycle(values.programCycleId);
+                          setCreateGroupModalOpen(true);
+                        }}
+                        data-cy="button-change-group"
+                        sx={{ whiteSpace: 'nowrap', flexShrink: 0 }}
+                      >
+                        {t('Change Group')}
+                      </Button>
+                    )}
                 </Box>
               </Grid>
             </Grid>

--- a/src/frontend/src/containers/pages/paymentmodule/Groups/PaymentPlanGroupsPage.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/Groups/PaymentPlanGroupsPage.tsx
@@ -26,9 +26,9 @@ const PaymentPlanGroupsPage = (): ReactElement => {
   );
 
   if (permissions === null) return null;
-  if (!hasPermissions(PERMISSIONS.PM_PAYMENT_PLAN_GROUP_VIEW_DETAIL, permissions))
+  if (!hasPermissions(PERMISSIONS.PM_PAYMENT_PLAN_GROUP_VIEW_LIST, permissions))
     return (
-      <PermissionDenied permission={PERMISSIONS.PM_PAYMENT_PLAN_GROUP_VIEW_DETAIL} />
+      <PermissionDenied permission={PERMISSIONS.PM_PAYMENT_PLAN_GROUP_VIEW_LIST} />
     );
 
   return (

--- a/src/frontend/src/containers/pages/paymentmodule/Groups/actions/DeliveryExportXlsxGroupButton.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/Groups/actions/DeliveryExportXlsxGroupButton.tsx
@@ -1,5 +1,6 @@
 import { LoadingButton } from '@core/LoadingButton';
 import { useBaseUrl } from '@hooks/useBaseUrl';
+import { usePermissions } from '@hooks/usePermissions';
 import { useSnackbar } from '@hooks/useSnackBar';
 import { GetApp } from '@mui/icons-material';
 import { Box } from '@mui/material';
@@ -7,6 +8,7 @@ import { RestService } from '@restgenerated/services/RestService';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
+import { hasPermissions, PERMISSIONS } from '../../../../../config/permissions';
 import { PaymentPlanGroupDetail } from '../types';
 import { isGroupBackgroundActionBusy } from '../utils';
 import { showApiErrorMessages } from '@utils/utils';
@@ -17,11 +19,12 @@ interface DeliveryExportXlsxGroupButtonProps {
 
 export function DeliveryExportXlsxGroupButton({
   group,
-}: DeliveryExportXlsxGroupButtonProps): ReactElement {
+}: DeliveryExportXlsxGroupButtonProps): ReactElement | null {
   const { t } = useTranslation();
   const { businessArea, programId } = useBaseUrl();
   const { showMessage } = useSnackbar();
   const queryClient = useQueryClient();
+  const permissions = usePermissions();
 
   const { mutateAsync: exportXlsx, isPending: loadingExport } = useMutation({
     mutationFn: () =>
@@ -42,6 +45,11 @@ export function DeliveryExportXlsxGroupButton({
       showApiErrorMessages(error, showMessage, t('Export failed'));
     },
   });
+
+  if (
+    !hasPermissions(PERMISSIONS.PM_PAYMENT_PLAN_GROUP_EXPORT_XLSX, permissions)
+  )
+    return null;
 
   const isDisabled =
     !group || loadingExport || isGroupBackgroundActionBusy(group);

--- a/src/frontend/src/containers/pages/paymentmodule/Groups/actions/DeliveryExportXlsxWithAuthCodeGroupButton.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/Groups/actions/DeliveryExportXlsxWithAuthCodeGroupButton.tsx
@@ -1,5 +1,7 @@
+import { usePermissions } from '@hooks/usePermissions';
 import { ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
+import { hasPermissions, PERMISSIONS } from '../../../../../config/permissions';
 import { PaymentPlanGroupDetail } from '../types';
 import { isGroupBackgroundActionBusy } from '../utils';
 import { GroupExportXlsxDialog } from './GroupExportXlsxDialog';
@@ -10,8 +12,19 @@ interface DeliveryExportXlsxWithAuthCodeGroupButtonProps {
 
 export function DeliveryExportXlsxWithAuthCodeGroupButton({
   group,
-}: DeliveryExportXlsxWithAuthCodeGroupButtonProps): ReactElement {
+}: DeliveryExportXlsxWithAuthCodeGroupButtonProps): ReactElement | null {
   const { t } = useTranslation();
+  const permissions = usePermissions();
+
+  if (
+    !hasPermissions(
+      PERMISSIONS.PM_PAYMENT_PLAN_GROUP_EXPORT_XLSX,
+      permissions,
+    ) ||
+    !hasPermissions(PERMISSIONS.PM_DOWNLOAD_FSP_AUTH_CODE, permissions)
+  )
+    return null;
+
   return (
     <GroupExportXlsxDialog
       groupId={group?.id ?? ''}

--- a/src/frontend/src/containers/pages/paymentmodule/Groups/actions/DeliveryImportXlsxGroupButton.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/Groups/actions/DeliveryImportXlsxGroupButton.tsx
@@ -1,9 +1,11 @@
 import { XlsxImportDialog } from '@core/XlsxImportDialog';
 import { useBaseUrl } from '@hooks/useBaseUrl';
+import { usePermissions } from '@hooks/usePermissions';
 import { PaymentPlanImportFile } from '@restgenerated/models/PaymentPlanImportFile';
 import { RestService } from '@restgenerated/services/RestService';
 import { ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
+import { hasPermissions, PERMISSIONS } from '../../../../../config/permissions';
 import { PaymentPlanGroupDetail } from '../types';
 import { isGroupBackgroundActionBusy } from '../utils';
 
@@ -13,9 +15,15 @@ interface DeliveryImportXlsxGroupButtonProps {
 
 export function DeliveryImportXlsxGroupButton({
   group,
-}: DeliveryImportXlsxGroupButtonProps): ReactElement {
+}: DeliveryImportXlsxGroupButtonProps): ReactElement | null {
   const { t } = useTranslation();
   const { businessArea, programId } = useBaseUrl();
+  const permissions = usePermissions();
+
+  if (
+    !hasPermissions(PERMISSIONS.PM_PAYMENT_PLAN_GROUP_IMPORT_XLSX, permissions)
+  )
+    return null;
 
   return (
     <XlsxImportDialog

--- a/src/frontend/src/containers/pages/paymentmodule/Groups/actions/DownloadBatchButton.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/Groups/actions/DownloadBatchButton.tsx
@@ -1,7 +1,9 @@
+import { usePermissions } from '@hooks/usePermissions';
 import { GetApp } from '@mui/icons-material';
 import { Box, Button } from '@mui/material';
 import { ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
+import { hasPermissions, PERMISSIONS } from '../../../../../config/permissions';
 
 interface DownloadBatchButtonProps {
   groupId: string;
@@ -11,8 +13,14 @@ interface DownloadBatchButtonProps {
 export function DownloadBatchButton({
   groupId,
   tag,
-}: DownloadBatchButtonProps): ReactElement {
+}: DownloadBatchButtonProps): ReactElement | null {
   const { t } = useTranslation();
+  const permissions = usePermissions();
+
+  if (
+    !hasPermissions(PERMISSIONS.PM_PAYMENT_PLAN_GROUP_EXPORT_XLSX, permissions)
+  )
+    return null;
 
   const href = `/api/download-payment-plan-group-batch/${groupId}/${tag}`;
 

--- a/src/frontend/src/containers/pages/paymentmodule/Groups/actions/ExportBatchButton.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/Groups/actions/ExportBatchButton.tsx
@@ -1,5 +1,7 @@
+import { usePermissions } from '@hooks/usePermissions';
 import { ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
+import { hasPermissions, PERMISSIONS } from '../../../../../config/permissions';
 import { GroupExportXlsxDialog } from './GroupExportXlsxDialog';
 
 interface ExportBatchButtonProps {
@@ -12,8 +14,15 @@ export function ExportBatchButton({
   groupId,
   tag,
   isBusy = false,
-}: ExportBatchButtonProps): ReactElement {
+}: ExportBatchButtonProps): ReactElement | null {
   const { t } = useTranslation();
+  const permissions = usePermissions();
+
+  if (
+    !hasPermissions(PERMISSIONS.PM_PAYMENT_PLAN_GROUP_EXPORT_XLSX, permissions)
+  )
+    return null;
+
   return (
     <GroupExportXlsxDialog
       groupId={groupId}

--- a/src/frontend/src/containers/pages/paymentmodule/Groups/actions/SendToPaymentGatewayGroupButton.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/Groups/actions/SendToPaymentGatewayGroupButton.tsx
@@ -1,10 +1,12 @@
 import { LoadingButton } from '@core/LoadingButton';
 import { useBaseUrl } from '@hooks/useBaseUrl';
+import { usePermissions } from '@hooks/usePermissions';
 import { useSnackbar } from '@hooks/useSnackBar';
 import { Box } from '@mui/material';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
+import { hasPermissions, PERMISSIONS } from '../../../../../config/permissions';
 import { PaymentPlanGroupDetail } from '../types';
 import { RestService } from '@restgenerated/services/RestService';
 import { showApiErrorMessages } from '@utils/utils';
@@ -20,6 +22,7 @@ export function SendToPaymentGatewayGroupButton({
   const { businessArea, programId } = useBaseUrl();
   const { showMessage } = useSnackbar();
   const queryClient = useQueryClient();
+  const permissions = usePermissions();
 
   const {
     mutateAsync: sendToPaymentGateway,
@@ -43,6 +46,13 @@ export function SendToPaymentGatewayGroupButton({
   });
 
   if (!group) return null;
+  if (
+    !hasPermissions(
+      PERMISSIONS.PM_PAYMENT_PLAN_GROUP_SEND_TO_PAYMENT_GATEWAY,
+      permissions,
+    )
+  )
+    return null;
 
   return (
     <Box m={2}>

--- a/src/frontend/src/containers/pages/paymentmodule/Groups/actions/SendXlsxPasswordBatchButton.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/Groups/actions/SendXlsxPasswordBatchButton.tsx
@@ -1,5 +1,6 @@
 import { LoadingButton } from '@core/LoadingButton';
 import { useBaseUrl } from '@hooks/useBaseUrl';
+import { usePermissions } from '@hooks/usePermissions';
 import { useSnackbar } from '@hooks/useSnackBar';
 import { Lock } from '@mui/icons-material';
 import { Box } from '@mui/material';
@@ -8,6 +9,7 @@ import { useMutation } from '@tanstack/react-query';
 import { showApiErrorMessages } from '@utils/utils';
 import { ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
+import { hasPermissions, PERMISSIONS } from '../../../../../config/permissions';
 
 interface SendXlsxPasswordBatchButtonProps {
   groupId: string;
@@ -17,10 +19,11 @@ interface SendXlsxPasswordBatchButtonProps {
 export function SendXlsxPasswordBatchButton({
   groupId,
   tag,
-}: SendXlsxPasswordBatchButtonProps): ReactElement {
+}: SendXlsxPasswordBatchButtonProps): ReactElement | null {
   const { t } = useTranslation();
   const { businessArea, programId } = useBaseUrl();
   const { showMessage } = useSnackbar();
+  const permissions = usePermissions();
 
   const { mutateAsync: sendPassword, isPending: loadingSend } = useMutation({
     mutationFn: () =>
@@ -39,6 +42,9 @@ export function SendXlsxPasswordBatchButton({
       showApiErrorMessages(error, showMessage, t('Failed to send password'));
     },
   });
+
+  if (!hasPermissions(PERMISSIONS.PM_SEND_XLSX_PASSWORD, permissions))
+    return null;
 
   return (
     <Box m={2}>

--- a/src/frontend/src/containers/pages/targeting/CreateTargetPopulationPage.tsx
+++ b/src/frontend/src/containers/pages/targeting/CreateTargetPopulationPage.tsx
@@ -207,16 +207,21 @@ const CreateTargetPopulationPage = (): ReactElement => {
                       // @ts-ignore
                       error={errors.paymentPlanGroupId?.value}
                     />
-                    <Button
-                      variant="outlined"
-                      color="primary"
-                      onClick={() => setCreateGroupModalOpen(true)}
-                      disabled={!values.programCycleId?.value}
-                      data-cy="button-create-group"
-                      sx={{ whiteSpace: 'nowrap', flexShrink: 0, mt: 1 }}
-                    >
-                      {t('Create Group')}
-                    </Button>
+                    {hasPermissions(
+                      PERMISSIONS.PM_PAYMENT_PLAN_GROUP_CREATE,
+                      permissions,
+                    ) && (
+                      <Button
+                        variant="outlined"
+                        color="primary"
+                        onClick={() => setCreateGroupModalOpen(true)}
+                        disabled={!values.programCycleId?.value}
+                        data-cy="button-create-group"
+                        sx={{ whiteSpace: 'nowrap', flexShrink: 0, mt: 1 }}
+                      >
+                        {t('Create Group')}
+                      </Button>
+                    )}
                   </Box>
                 </Grid>
               </Grid>

--- a/tests/e2e/new_selenium/payment_module/test_payment_plan_group.py
+++ b/tests/e2e/new_selenium/payment_module/test_payment_plan_group.py
@@ -475,6 +475,7 @@ def test_group_payment_plan_list_export_tag_links_to_batch(
         Permissions.PROGRAMME_VIEW_LIST_AND_DETAILS,
         Permissions.PM_VIEW_LIST,
         Permissions.PM_PAYMENT_PLAN_GROUP_VIEW_DETAIL,
+        Permissions.PM_PAYMENT_PLAN_GROUP_EXPORT_XLSX,
     ):
         browser.login(username="noperm_user", password="testtest2")
         browser.open(f"/{business_area.slug}/programs/{program.code}/payment-module/groups/{group.id}")
@@ -501,6 +502,7 @@ def test_batch_detail_shows_download_button_when_file_present(
         Permissions.PROGRAMME_VIEW_LIST_AND_DETAILS,
         Permissions.PM_VIEW_LIST,
         Permissions.PM_PAYMENT_PLAN_GROUP_VIEW_DETAIL,
+        Permissions.PM_PAYMENT_PLAN_GROUP_EXPORT_XLSX,
     ):
         browser.login(username="noperm_user", password="testtest2")
         browser.open(f"/{business_area.slug}/programs/{program.code}/payment-module/groups/{group.id}/batches/1")
@@ -524,6 +526,7 @@ def test_batch_detail_shows_reexport_button_when_file_missing(
         Permissions.PROGRAMME_VIEW_LIST_AND_DETAILS,
         Permissions.PM_VIEW_LIST,
         Permissions.PM_PAYMENT_PLAN_GROUP_VIEW_DETAIL,
+        Permissions.PM_PAYMENT_PLAN_GROUP_EXPORT_XLSX,
     ):
         browser.login(username="noperm_user", password="testtest2")
         browser.open(f"/{business_area.slug}/programs/{program.code}/payment-module/groups/{group.id}/batches/1")


### PR DESCRIPTION
[AB#330306](https://unicef.visualstudio.com/ICTD-HCT-MIS/_workitems/edit/330306)
## Summary
- Backend already enforced permissions on several Payment Plan Group actions (send to payment gateway, export/import XLSX, batch export/download/re-export, send XLSX password, create group), but the frontend rendered these buttons unconditionally — users without the permission would see a clickable button that 403s on the server.
- Added `hasPermissions`/`usePermissions` checks to hide each button when the user lacks the corresponding permission, following the existing pattern from `EditGroupName.tsx` / `DeletePaymentPlanGroup.tsx`.
- Fixed `PaymentPlanGroupsPage.tsx`, which gated the list page on `PM_PAYMENT_PLAN_GROUP_VIEW_DETAIL` instead of the backend's `PM_PAYMENT_PLAN_GROUP_VIEW_LIST`.