### PR TITLE
[HOTFIX] fix Kobo RDI identity import Partner instance + number field

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [ "setuptools", "wheel" ]
 
 [project]
 name = "hope"
-version = "4.16.1"
+version = "4.16.2"
 description = "HCT MIS is UNICEF's humanitarian cash transfer platform."
 readme = "README.md"
 license = { text = "None" }

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "4.16.1",
+  "version": "4.16.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/hope/apps/registration_data/tasks/rdi_kobo_create.py
+++ b/src/hope/apps/registration_data/tasks/rdi_kobo_create.py
@@ -41,6 +41,7 @@ from hope.models import (
     Facility,
     ImportData,
     KoboImportedSubmission,
+    Partner,
     PendingDocument,
     PendingHousehold,
     PendingIndividual,
@@ -165,12 +166,12 @@ class RdiKoboCreateTask(RdiBaseCreateTask):
                     data["country"] = GeoCountry.objects.get(iso_code2=Country(country).code)
 
                 if is_identity:
-                    partner = "WFP" if document_name == "scope_id" else "UNHCR"
+                    partner, _ = Partner.objects.get_or_create(name="WFP" if document_name == "scope_id" else "UNHCR")
                     identities.append(
                         PendingIndividualIdentity(
                             partner=partner,
                             individual=data["individual"],
-                            document_number=data.get("number", ""),
+                            number=data.get("number", ""),
                             country=data.get("country"),
                         )
                     )

--- a/src/hope/apps/registration_data/tasks/rdi_kobo_create.py
+++ b/src/hope/apps/registration_data/tasks/rdi_kobo_create.py
@@ -22,6 +22,8 @@ from hope.apps.household.const import (
     NON_BENEFICIARY,
     ROLE_ALTERNATE,
     ROLE_PRIMARY,
+    UNHCR,
+    WFP,
 )
 from hope.apps.periodic_data_update.utils import populate_pdu_with_null_values
 from hope.apps.registration_data.tasks.deduplicate import DeduplicateTask
@@ -166,7 +168,7 @@ class RdiKoboCreateTask(RdiBaseCreateTask):
                     data["country"] = GeoCountry.objects.get(iso_code2=Country(country).code)
 
                 if is_identity:
-                    partner, _ = Partner.objects.get_or_create(name="WFP" if document_name == "scope_id" else "UNHCR")
+                    partner, _ = Partner.objects.get_or_create(name=WFP if document_name == "scope_id" else UNHCR)
                     identities.append(
                         PendingIndividualIdentity(
                             partner=partner,

--- a/tests/unit/apps/registration_data/test_rdi_kobo_create.py
+++ b/tests/unit/apps/registration_data/test_rdi_kobo_create.py
@@ -32,6 +32,7 @@ from hope.models import (
     PendingDocument,
     PendingHousehold,
     PendingIndividual,
+    PendingIndividualIdentity,
     RegistrationDataImport,
 )
 from hope.models.financial_institution import FinancialInstitution
@@ -455,6 +456,58 @@ def test_handle_documents_and_identities(
 
     assert birth_certificate == "birth_certificate"
     assert national_passport == "national_passport"
+
+
+def test_handle_documents_and_identities_creates_identities_with_resolved_partner(
+    business_area: object,
+    registration_data_import: object,
+    program: object,
+) -> None:
+    task = RdiKoboCreateTask(registration_data_import.id, business_area.id)
+    individual = IndividualFactory(
+        program=program,
+        business_area=business_area,
+        registration_data_import=registration_data_import,
+        rdi_merge_status=MergeStatusModel.PENDING,
+    )
+    documents_and_identities = [
+        {
+            "scope_id": {
+                "number": "WFP-123",
+                "individual": individual,
+                "issuing_country": Country("AFG"),
+            }
+        },
+        {
+            "unhcr_id": {
+                "number": "UNHCR-456",
+                "individual": individual,
+                "issuing_country": Country("AFG"),
+            }
+        },
+    ]
+
+    task._handle_documents_and_identities(documents_and_identities)
+
+    assert PendingIndividualIdentity.objects.count() == 2
+    assert (
+        PendingIndividualIdentity.objects.filter(
+            number="WFP-123",
+            partner__name="WFP",
+            country__iso_code2="AF",
+            individual=individual,
+        ).count()
+        == 1
+    )
+    assert (
+        PendingIndividualIdentity.objects.filter(
+            number="UNHCR-456",
+            partner__name="UNHCR",
+            country__iso_code2="AF",
+            individual=individual,
+        ).count()
+        == 1
+    )
 
 
 def test_handle_household_dict(

--- a/uv.lock
+++ b/uv.lock
@@ -1928,7 +1928,7 @@ wheels = [
 
 [[package]]
 name = "hope"
-version = "4.16.1"
+version = "4.16.2"
 source = { editable = "." }
 dependencies = [
     { name = "black" },


### PR DESCRIPTION
[AB#330548](https://unicef.visualstudio.com/4e044e8d-bc28-4768-8074-f80ff6e4a0e5/_workitems/edit/330548)

KOBO import consisted of old code where partner was assumed to be a string instead of Partner object, and instead of number there was document_number field. It was not used till today, so it was never discovered. It was also not tested till now.
