### PR TITLE
[329150] Email notification for new step: ready for closure + send back

### DIFF
--- a/src/hope/apps/payment/api/views.py
+++ b/src/hope/apps/payment/api/views.py
@@ -1529,7 +1529,7 @@ class PaymentPlanViewSet(
     def ready_for_closure(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         payment_plan = self.get_object()
         old_payment_plan = copy_model_object(payment_plan)
-        payment_plan = PaymentPlanService(payment_plan).ready_for_closure()
+        payment_plan = PaymentPlanService(payment_plan).ready_for_closure(user=cast("User", request.user))
         log_create(
             mapping=PaymentPlan.ACTIVITY_LOG_MAPPING,
             business_area_field="business_area",
@@ -1545,7 +1545,7 @@ class PaymentPlanViewSet(
     def send_back_to_finished(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         payment_plan = self.get_object()
         old_payment_plan = copy_model_object(payment_plan)
-        payment_plan = PaymentPlanService(payment_plan).send_back_to_finished()
+        payment_plan = PaymentPlanService(payment_plan).send_back_to_finished(user=cast("User", request.user))
         log_create(
             mapping=PaymentPlan.ACTIVITY_LOG_MAPPING,
             business_area_field="business_area",

--- a/src/hope/apps/payment/notifications.py
+++ b/src/hope/apps/payment/notifications.py
@@ -18,12 +18,16 @@ class PaymentNotification:
     ACTION_APPROVE = PaymentPlan.Action.APPROVE.name
     ACTION_AUTHORIZE = PaymentPlan.Action.AUTHORIZE.name
     ACTION_REVIEW = PaymentPlan.Action.REVIEW.name  # payment plan release
+    ACTION_MARK_READY_FOR_CLOSURE = PaymentPlan.Action.MARK_READY_FOR_CLOSURE.name
+    ACTION_SEND_BACK_TO_FINISHED = PaymentPlan.Action.SEND_BACK_TO_FINISHED.name
 
     ACTION_TO_RECIPIENTS_PERMISSIONS_MAP = {
         ACTION_SEND_FOR_APPROVAL: Permissions.PM_ACCEPTANCE_PROCESS_APPROVE.name,
         ACTION_APPROVE: Permissions.PM_ACCEPTANCE_PROCESS_AUTHORIZE.name,
         ACTION_AUTHORIZE: Permissions.PM_ACCEPTANCE_PROCESS_FINANCIAL_REVIEW.name,
         ACTION_REVIEW: Permissions.PM_DOWNLOAD_XLSX_FOR_FSP.name,
+        ACTION_MARK_READY_FOR_CLOSURE: Permissions.PM_CLOSE_FINISHED.name,
+        ACTION_SEND_BACK_TO_FINISHED: Permissions.PM_MARK_READY_FOR_CLOSURE.name,
     }
 
     ACTION_PREPARE_EMAIL_BODIES_MAP = {
@@ -45,6 +49,16 @@ class PaymentNotification:
         ACTION_REVIEW: {
             "action_name": "released",
             "subject": "Payment is Released",
+            "recipient_title": "Reviewer",
+        },
+        ACTION_MARK_READY_FOR_CLOSURE: {
+            "action_name": "marked as ready for closure",
+            "subject": "Payment pending for Closure",
+            "recipient_title": "Reviewer",
+        },
+        ACTION_SEND_BACK_TO_FINISHED: {
+            "action_name": "sent back to finished",
+            "subject": "Payment sent back to Finished",
             "recipient_title": "Reviewer",
         },
     }

--- a/src/hope/apps/payment/services/follow_up_instruction_service.py
+++ b/src/hope/apps/payment/services/follow_up_instruction_service.py
@@ -211,7 +211,9 @@ class FollowUpInstructionService:
         for payment_plan in self._get_child_payment_plans():
             old_payment_plan = cast("PaymentPlan", copy_model_object(payment_plan))
             service = PaymentPlanService(payment_plan)
-            service.ready_for_closure()
+            # Bulk close auto-advances FINISHED → READY_FOR_CLOSURE → CLOSED with no manual pause,
+            # so suppress the "ready for closure" email.
+            service.ready_for_closure(user, notify=False)
             updated_payment_plan = service.close(
                 closure_comment="Comment",
                 user_id=str(user.pk),

--- a/src/hope/apps/payment/services/payment_plan_services.py
+++ b/src/hope/apps/payment/services/payment_plan_services.py
@@ -1313,7 +1313,7 @@ class PaymentPlanService:
                     ind_filter.individuals_filters_block = ind_filter_block_copy
                     ind_filter.save()
 
-    def ready_for_closure(self) -> PaymentPlan:
+    def ready_for_closure(self, user: "User", *, notify: bool = True) -> PaymentPlan:
         if self.payment_plan.status != PaymentPlan.Status.FINISHED:
             raise ValidationError(
                 f"Mark as Ready for Closure is possible only within Status {PaymentPlan.Status.FINISHED}"
@@ -1322,15 +1322,28 @@ class PaymentPlanService:
         flow.status_ready_for_closure()
         self.payment_plan.save(update_fields=("status", "status_date", "updated_at"))
         self.payment_plan.refresh_from_db(fields=["status", "status_date", "updated_at"])
+        if notify:
+            send_payment_notification_emails_async_task(
+                self.payment_plan,
+                PaymentPlan.Action.MARK_READY_FOR_CLOSURE.value,
+                str(user.pk),
+                f"{timezone.now():%-d %B %Y}",
+            )
         return self.payment_plan
 
-    def send_back_to_finished(self) -> PaymentPlan:
+    def send_back_to_finished(self, user: "User") -> PaymentPlan:
         if self.payment_plan.status != PaymentPlan.Status.READY_FOR_CLOSURE:
             raise ValidationError(f"Send Back is possible only within Status {PaymentPlan.Status.READY_FOR_CLOSURE}")
         flow = PaymentPlanFlow(self.payment_plan)
         flow.status_finished()
         self.payment_plan.save(update_fields=("status", "status_date", "updated_at"))
         self.payment_plan.refresh_from_db(fields=["status", "status_date", "updated_at"])
+        send_payment_notification_emails_async_task(
+            self.payment_plan,
+            PaymentPlan.Action.SEND_BACK_TO_FINISHED.value,
+            str(user.pk),
+            f"{timezone.now():%-d %B %Y}",
+        )
         return self.payment_plan
 
     def close(self, closure_comment: str | None = None, user_id: str | None = None) -> PaymentPlan:

--- a/src/hope/models/payment_plan.py
+++ b/src/hope/models/payment_plan.py
@@ -274,6 +274,8 @@ class PaymentPlan(
         REVIEW = "REVIEW", "Review"
         REJECT = "REJECT", "Reject"
         FINISH = "FINISH", "Finish"
+        MARK_READY_FOR_CLOSURE = "MARK_READY_FOR_CLOSURE", "Mark Ready for Closure"
+        SEND_BACK_TO_FINISHED = "SEND_BACK_TO_FINISHED", "Send Back to Finished"
         SEND_TO_PAYMENT_GATEWAY = "SEND_TO_PAYMENT_GATEWAY", "Send to Payment Gateway"
         SEND_XLSX_PASSWORD = "SEND_XLSX_PASSWORD", "Send XLSX Password"
 

--- a/tests/unit/apps/payment/test_follow_up_instruction_service.py
+++ b/tests/unit/apps/payment/test_follow_up_instruction_service.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 from decimal import Decimal
 from typing import Any
+from unittest.mock import patch
 import uuid
 
 import pytest
@@ -11,6 +12,7 @@ from extras.test_utils.factories import (
     CurrencyFactory,
     DeliveryMechanismFactory,
     FinancialServiceProviderFactory,
+    FollowUpInstructionFactory,
     PaymentFactory,
     PaymentPlanFactory,
     PaymentPlanGroupFactory,
@@ -750,6 +752,36 @@ def test_reactivate_abort_transitions_child_payment_plans_to_open(
     child_plan.refresh_from_db()
     assert result == instruction
     assert child_plan.status == PaymentPlan.Status.OPEN
+
+
+@patch("hope.apps.payment.services.payment_plan_services.send_payment_notification_emails_async_task")
+def test_close_transitions_child_payment_plans_to_closed_without_notification(
+    mock_notify: Any,
+    user: Any,
+    program: Any,
+    cycle: Any,
+    business_area: Any,
+    currency: Any,
+    delivery_mechanism: Any,
+    fsp: Any,
+) -> None:
+    instruction = FollowUpInstructionFactory(program=program, created_by=user)
+    child_plan = _create_instruction_child_payment_plan(
+        instruction=instruction,
+        cycle=cycle,
+        business_area=business_area,
+        currency=currency,
+        delivery_mechanism=delivery_mechanism,
+        fsp=fsp,
+        status=PaymentPlan.Status.FINISHED,
+    )
+
+    result = FollowUpInstructionService(instruction=instruction).close(user=user)
+
+    child_plan.refresh_from_db()
+    assert result == instruction
+    assert child_plan.status == PaymentPlan.Status.CLOSED
+    mock_notify.assert_not_called()
 
 
 def test_status_returns_first_status_when_no_precedence_match(user, program, business_area, cycle) -> None:

--- a/tests/unit/apps/payment/test_payment_notification.py
+++ b/tests/unit/apps/payment/test_payment_notification.py
@@ -24,6 +24,8 @@ def action_permissions_list():
         Permissions.PM_ACCEPTANCE_PROCESS_AUTHORIZE,
         Permissions.PM_ACCEPTANCE_PROCESS_FINANCIAL_REVIEW,
         Permissions.PM_DOWNLOAD_XLSX_FOR_FSP,
+        Permissions.PM_CLOSE_FINISHED,
+        Permissions.PM_MARK_READY_FOR_CLOSURE,
     ]
 
 
@@ -392,6 +394,24 @@ def notification_setup(
         name="Role with download xlsx permission",
     )
 
+    users["user_with_close_permission"] = UserFactory(partner=partner_empty)
+    create_user_role_with_permissions(
+        users["user_with_close_permission"],
+        [Permissions.PM_CLOSE_FINISHED],
+        business_area,
+        whole_business_area_access=True,
+        name="Role with close permission",
+    )
+
+    users["user_with_mark_ready_permission"] = UserFactory(partner=partner_empty)
+    create_user_role_with_permissions(
+        users["user_with_mark_ready_permission"],
+        [Permissions.PM_MARK_READY_FOR_CLOSURE],
+        business_area,
+        whole_business_area_access=True,
+        name="Role with mark ready for closure permission",
+    )
+
     users["user_with_action_permissions"] = UserFactory(partner=partner_empty)
     create_user_role_with_permissions(
         users["user_with_action_permissions"],
@@ -455,6 +475,8 @@ def test_prepare_user_recipients_for_send_for_approval(notification_setup: dict)
         "user_with_authorize_permission",
         "user_with_review_permission",
         "user_with_download_xlsx_permission",
+        "user_with_close_permission",
+        "user_with_mark_ready_permission",
     ]:
         assert users[key] not in payment_notification.user_recipients.all()
 
@@ -505,6 +527,8 @@ def test_prepare_user_recipients_for_approve(notification_setup: dict) -> None:
         "user_with_approval_permission_wrong_program_partner_empty",
         "user_with_review_permission",
         "user_with_download_xlsx_permission",
+        "user_with_close_permission",
+        "user_with_mark_ready_permission",
     ]:
         assert users[key] not in payment_notification.user_recipients.all()
 
@@ -555,6 +579,8 @@ def test_prepare_user_recipients_for_authorize(notification_setup: dict) -> None
         "user_with_approval_permission_wrong_program_partner_empty",
         "user_with_authorize_permission",
         "user_with_download_xlsx_permission",
+        "user_with_close_permission",
+        "user_with_mark_ready_permission",
     ]:
         assert users[key] not in payment_notification.user_recipients.all()
 
@@ -605,8 +631,156 @@ def test_prepare_user_recipients_for_release(notification_setup: dict) -> None:
         "user_with_approval_permission_wrong_program_partner_empty",
         "user_with_authorize_permission",
         "user_with_review_permission",
+        "user_with_close_permission",
+        "user_with_mark_ready_permission",
     ]:
         assert users[key] not in payment_notification.user_recipients.all()
+
+
+def test_prepare_user_recipients_for_mark_ready_for_closure(notification_setup: dict) -> None:
+    payment_notification = PaymentNotification(
+        notification_setup["payment_plan"],
+        PaymentPlan.Action.MARK_READY_FOR_CLOSURE.name,
+        notification_setup["user_action_user"],
+        f"{timezone.now():%-d %B %Y}",
+    )
+
+    users = notification_setup["users"]
+    assert payment_notification.user_recipients.count() == 11
+
+    for key in [
+        "user_with_partner_unicef_hq",
+        "user_with_action_permissions",
+        "user_with_close_permission",
+        "user_with_no_permissions_partner_with_action_permissions",
+        "user_with_no_permissions_partner_with_action_permissions_in_whole_ba",
+        "user_with_approval_permission_partner_with_action_permissions",
+        "user_with_approval_permission_partner_with_action_permissions_in_whole_ba",
+        "user_with_approval_permission_in_ba_partner_with_action_permissions",
+        "user_with_approval_permission_in_ba_partner_with_action_permissions_in_whole_ba",
+        "user_with_approval_permission_wrong_program_partner_with_action_permissions",
+        "user_with_approval_permission_wrong_program_partner_with_action_permissions_in_whole_ba",
+    ]:
+        assert users[key] in payment_notification.user_recipients.all()
+
+    assert notification_setup["user_action_user"] not in payment_notification.user_recipients.all()
+
+    for key in [
+        "user_with_mark_ready_permission",
+        "user_with_partner_unicef_in_ba",
+        "user_with_no_permissions",
+        "user_with_authorize_permission",
+        "user_with_review_permission",
+        "user_with_download_xlsx_permission",
+    ]:
+        assert users[key] not in payment_notification.user_recipients.all()
+
+
+def test_prepare_user_recipients_for_send_back_to_finished(notification_setup: dict) -> None:
+    payment_notification = PaymentNotification(
+        notification_setup["payment_plan"],
+        PaymentPlan.Action.SEND_BACK_TO_FINISHED.name,
+        notification_setup["user_action_user"],
+        f"{timezone.now():%-d %B %Y}",
+    )
+
+    users = notification_setup["users"]
+    assert payment_notification.user_recipients.count() == 11
+
+    for key in [
+        "user_with_partner_unicef_hq",
+        "user_with_action_permissions",
+        "user_with_mark_ready_permission",
+        "user_with_no_permissions_partner_with_action_permissions",
+        "user_with_no_permissions_partner_with_action_permissions_in_whole_ba",
+        "user_with_approval_permission_partner_with_action_permissions",
+        "user_with_approval_permission_partner_with_action_permissions_in_whole_ba",
+        "user_with_approval_permission_in_ba_partner_with_action_permissions",
+        "user_with_approval_permission_in_ba_partner_with_action_permissions_in_whole_ba",
+        "user_with_approval_permission_wrong_program_partner_with_action_permissions",
+        "user_with_approval_permission_wrong_program_partner_with_action_permissions_in_whole_ba",
+    ]:
+        assert users[key] in payment_notification.user_recipients.all()
+
+    assert notification_setup["user_action_user"] not in payment_notification.user_recipients.all()
+
+    for key in [
+        "user_with_close_permission",
+        "user_with_partner_unicef_in_ba",
+        "user_with_no_permissions",
+        "user_with_authorize_permission",
+        "user_with_review_permission",
+        "user_with_download_xlsx_permission",
+    ]:
+        assert users[key] not in payment_notification.user_recipients.all()
+
+
+def test_action_user_is_ccd_and_excluded_from_recipients_for_mark_ready_for_closure(
+    notification_setup: dict,
+) -> None:
+    action_user = notification_setup["user_action_user"]
+    payment_notification = PaymentNotification(
+        notification_setup["payment_plan"],
+        PaymentPlan.Action.MARK_READY_FOR_CLOSURE.name,
+        action_user,
+        f"{timezone.now():%-d %B %Y}",
+    )
+
+    assert action_user not in payment_notification.user_recipients.all()
+    assert action_user.email not in payment_notification.email.recipients
+    assert action_user.email in payment_notification.email.ccs
+
+
+@override_config(SEND_PAYMENT_PLANS_NOTIFICATION=True)
+@override_settings(EMAIL_SUBJECT_PREFIX="")
+def test_send_email_notification_subject_mark_ready_for_closure(notification_setup: dict, mocker: Any) -> None:
+    mocker.patch("hope.apps.payment.notifications.MailjetClient.send_email")
+    payment_notification = PaymentNotification(
+        notification_setup["payment_plan"],
+        PaymentPlan.Action.MARK_READY_FOR_CLOSURE.name,
+        notification_setup["user_action_user"],
+        f"{timezone.now():%-d %B %Y}",
+    )
+    assert payment_notification.email.subject == "Payment pending for Closure"
+
+
+@override_config(SEND_PAYMENT_PLANS_NOTIFICATION=True)
+def test_send_email_notification_mark_ready_for_closure(notification_setup: dict, mocker: Any) -> None:
+    mock_send = mocker.patch("hope.apps.payment.notifications.MailjetClient.send_email")
+    payment_notification = PaymentNotification(
+        notification_setup["payment_plan"],
+        PaymentPlan.Action.MARK_READY_FOR_CLOSURE.name,
+        notification_setup["user_action_user"],
+        f"{timezone.now():%-d %B %Y}",
+    )
+    payment_notification.send_email_notification()
+    assert mock_send.call_count == 1
+
+
+@override_config(SEND_PAYMENT_PLANS_NOTIFICATION=True)
+@override_settings(EMAIL_SUBJECT_PREFIX="")
+def test_send_email_notification_subject_send_back_to_finished(notification_setup: dict, mocker: Any) -> None:
+    mocker.patch("hope.apps.payment.notifications.MailjetClient.send_email")
+    payment_notification = PaymentNotification(
+        notification_setup["payment_plan"],
+        PaymentPlan.Action.SEND_BACK_TO_FINISHED.name,
+        notification_setup["user_action_user"],
+        f"{timezone.now():%-d %B %Y}",
+    )
+    assert payment_notification.email.subject == "Payment sent back to Finished"
+
+
+@override_config(SEND_PAYMENT_PLANS_NOTIFICATION=True)
+def test_send_email_notification_send_back_to_finished(notification_setup: dict, mocker: Any) -> None:
+    mock_send = mocker.patch("hope.apps.payment.notifications.MailjetClient.send_email")
+    payment_notification = PaymentNotification(
+        notification_setup["payment_plan"],
+        PaymentPlan.Action.SEND_BACK_TO_FINISHED.name,
+        notification_setup["user_action_user"],
+        f"{timezone.now():%-d %B %Y}",
+    )
+    payment_notification.send_email_notification()
+    assert mock_send.call_count == 1
 
 
 @override_config(SEND_PAYMENT_PLANS_NOTIFICATION=True)

--- a/tests/unit/apps/payment/test_payment_plan_services.py
+++ b/tests/unit/apps/payment/test_payment_plan_services.py
@@ -1961,6 +1961,65 @@ def test_check_payment_plan_and_update_status_triggers_when_count_meets_required
     mock_flow_cls.return_value.status_approve.assert_called_once()
 
 
+@patch("hope.apps.payment.services.payment_plan_services.send_payment_notification_emails_async_task")
+def test_ready_for_closure_sends_notification(mock_notify, user: User, business_area: Any, cycle: ProgramCycle) -> None:
+    payment_plan = PaymentPlanFactory(
+        program_cycle=cycle,
+        business_area=business_area,
+        status=PaymentPlan.Status.FINISHED,
+    )
+
+    PaymentPlanService(payment_plan).ready_for_closure(user=user)
+
+    payment_plan.refresh_from_db()
+    assert payment_plan.status == PaymentPlan.Status.READY_FOR_CLOSURE
+    mock_notify.assert_called_once_with(
+        payment_plan,
+        PaymentPlan.Action.MARK_READY_FOR_CLOSURE.value,
+        str(user.pk),
+        mock.ANY,
+    )
+
+
+@patch("hope.apps.payment.services.payment_plan_services.send_payment_notification_emails_async_task")
+def test_ready_for_closure_suppresses_notification_when_notify_false(
+    mock_notify, user: User, business_area: Any, cycle: ProgramCycle
+) -> None:
+    payment_plan = PaymentPlanFactory(
+        program_cycle=cycle,
+        business_area=business_area,
+        status=PaymentPlan.Status.FINISHED,
+    )
+
+    PaymentPlanService(payment_plan).ready_for_closure(user, notify=False)
+
+    payment_plan.refresh_from_db()
+    assert payment_plan.status == PaymentPlan.Status.READY_FOR_CLOSURE
+    mock_notify.assert_not_called()
+
+
+@patch("hope.apps.payment.services.payment_plan_services.send_payment_notification_emails_async_task")
+def test_send_back_to_finished_sends_notification(
+    mock_notify, user: User, business_area: Any, cycle: ProgramCycle
+) -> None:
+    payment_plan = PaymentPlanFactory(
+        program_cycle=cycle,
+        business_area=business_area,
+        status=PaymentPlan.Status.READY_FOR_CLOSURE,
+    )
+
+    PaymentPlanService(payment_plan).send_back_to_finished(user=user)
+
+    payment_plan.refresh_from_db()
+    assert payment_plan.status == PaymentPlan.Status.FINISHED
+    mock_notify.assert_called_once_with(
+        payment_plan,
+        PaymentPlan.Action.SEND_BACK_TO_FINISHED.value,
+        str(user.pk),
+        mock.ANY,
+    )
+
+
 def test_build_payments_chunks_with_chunks_no_none_returns_single_chunk(locked_payment_plan_with_payments):
     service = PaymentPlanService(payment_plan=locked_payment_plan_with_payments)
     payments = locked_payment_plan_with_payments.eligible_payments.all()


### PR DESCRIPTION
[AB#329150](https://unicef.visualstudio.com/4e044e8d-bc28-4768-8074-f80ff6e4a0e5/_workitems/edit/329150)

Payment plans now send a notification email when they are marked ready for                                                                                                                                                                                                                                                 
  closure and when they are sent back to finished. In both cases the recipients                                                                                                                                                                                                                                              
  are the users holding the permission required for the next action in the flow - `PM_CLOSE_FINISHED`                                                                                                                                                                                                                                            
  are notified after mark-ready ("Payment pending for Closure"); users with                                                                                                                                                                                                                                                     
  `PM_MARK_READY_FOR_CLOSURE` are notified on send-back ("Payment sent back to                                                                                                                                                                                                                                               
  Finished").                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                             
  ### Changes                                                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                             
  - Added `MARK_READY_FOR_CLOSURE` and `SEND_BACK_TO_FINISHED` to                                                                                                                                                                                                                                                            
    `PaymentPlan.Action`, with recipient permissions, subjects and email bodies in                                                                                                                                                                                                                                           
    `PaymentNotification`.                                                                                                                                                                                                                                                   
  - `ready_for_closure(user, *, notify=True)` and `send_back_to_finished(user)`                                                                                                                                                                                                                                              
    queue the notification email.                                                                                                                                                                                                                                                                                            
  - Follow-up-instruction bulk close passes `notify=False`: it auto-advances                                                                                                                                                                                                                                                 
    `FINISHED → READY_FOR_CLOSURE → CLOSED` without pause, so the intermediate                                                                                                                                                                                                                                               
    email would reach every closer once per child plan.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               