### PR TITLE
[HOTFIX] 331115&330996: email url and group import fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [ "setuptools", "wheel" ]
 
 [project]
 name = "hope"
-version = "4.17.0"
+version = "4.17.1"
 description = "HCT MIS is UNICEF's humanitarian cash transfer platform."
 readme = "README.md"
 license = { text = "None" }

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "4.17.0",
+  "version": "4.17.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/hope/apps/core/utils.py
+++ b/src/hope/apps/core/utils.py
@@ -250,9 +250,10 @@ raise_attribute_error = object()
 
 
 def nested_getattr(obj: Any, attr: Any, default: object = raise_attribute_error) -> Any:
+    # ObjectDoesNotExist: a FK may point at a row deleted earlier in the same transaction
     try:
         return functools.reduce(getattr, attr.split("."), obj)
-    except AttributeError as e:
+    except (AttributeError, ObjectDoesNotExist) as e:
         if default != raise_attribute_error:
             return default
         logger.warning(e)

--- a/src/hope/apps/payment/xlsx/xlsx_payment_plan_group_delivery_export_service.py
+++ b/src/hope/apps/payment/xlsx/xlsx_payment_plan_group_delivery_export_service.py
@@ -13,6 +13,7 @@ from django.utils.crypto import get_random_string
 import openpyxl
 import pyzipper
 
+from hope.apps.payment.utils import get_link
 from hope.apps.payment.xlsx.base_xlsx_export_service import XlsxExportBaseService
 from hope.apps.payment.xlsx.xlsx_payment_plan_delivery_export_service import XlsxPaymentPlanDeliveryExportService
 from hope.models import (
@@ -177,7 +178,7 @@ class XlsxPaymentPlanGroupDeliveryExportService(XlsxExportBaseService):
         group = self.payment_plan_group
         tag = self.applied_export_tag
         batch_name = self._batch_name(tag)
-        link = reverse("download-payment-plan-group-batch", args=[str(group.id), tag])
+        link = get_link(reverse("download-payment-plan-group-batch", args=[str(group.id), tag]))
         return {
             "first_name": getattr(user, "first_name", ""),
             "last_name": getattr(user, "last_name", ""),

--- a/src/hope/models/payment_plan.py
+++ b/src/hope/models/payment_plan.py
@@ -13,7 +13,7 @@ from django.core.validators import (
     MinValueValidator,
     ProhibitNullCharactersValidator,
 )
-from django.db import models
+from django.db import models, transaction
 from django.db.models import Count, Exists, OuterRef, Q, QuerySet, Sum, Value
 from django.db.models.functions import Coalesce
 from django.utils import timezone
@@ -774,9 +774,11 @@ class PaymentPlan(
             return ""
 
     def remove_export_file_entitlement(self) -> None:
-        self.export_file_entitlement.file.delete(save=False)
+        file_field = self.export_file_entitlement.file
         self.export_file_entitlement.delete()
         self.export_file_entitlement = None
+        # Storage delete is not transactional: delete the file only once the transaction commits,
+        transaction.on_commit(lambda: file_field.delete(save=False))
 
     def remove_export_file_delivery(self) -> None:
         # The batch export shares one FileTemp across every plan in the batch (same export_tag).
@@ -790,8 +792,10 @@ class PaymentPlan(
             return
         file_temp = FileTemp.objects.filter(pk=file_temp_id).first()
         if file_temp is not None:
-            file_temp.file.delete(save=False)
+            file_field = file_temp.file
             file_temp.delete()
+            # Storage delete is not transactional; defer it so a rollback can't leave the row
+            transaction.on_commit(lambda: file_field.delete(save=False))
 
     def remove_export_files(self) -> None:
         # remove export_file_entitlement

--- a/src/hope/models/payment_plan.py
+++ b/src/hope/models/payment_plan.py
@@ -777,7 +777,7 @@ class PaymentPlan(
         file_field = self.export_file_entitlement.file
         self.export_file_entitlement.delete()
         self.export_file_entitlement = None
-        # Storage delete is not transactional: delete the file only once the transaction commits,
+        # Storage delete is not transactional: delete the file when the transaction commits
         transaction.on_commit(lambda: file_field.delete(save=False))
 
     def remove_export_file_delivery(self) -> None:
@@ -794,7 +794,7 @@ class PaymentPlan(
         if file_temp is not None:
             file_field = file_temp.file
             file_temp.delete()
-            # Storage delete is not transactional; defer it so a rollback can't leave the row
+            # Storage delete is not transactional: delete the file when the transaction commits
             transaction.on_commit(lambda: file_field.delete(save=False))
 
     def remove_export_files(self) -> None:

--- a/tests/unit/apps/core/test_utils.py
+++ b/tests/unit/apps/core/test_utils.py
@@ -15,10 +15,13 @@ from extras.test_utils.factories import (
     ProgramFactory,
 )
 from extras.test_utils.factories.core import (
+    FileTempFactory,
     FlexibleAttributeChoiceFactory,
     FlexibleAttributeFactory,
     FlexibleAttributeForPDUFactory,
 )
+from extras.test_utils.factories.payment import PaymentPlanFactory
+from hope.apps.activity_log.utils import copy_model_object
 from hope.apps.core.utils import (
     AutoCompleteFilterTemp,
     CaseInsensitiveTuple,
@@ -58,7 +61,7 @@ from hope.apps.core.utils import (
     unique_slugify,
 )
 from hope.apps.payment.utils import get_payment_delivered_quantity_status_and_value
-from hope.models import BusinessArea, FlexibleAttribute, Household, Individual, Payment
+from hope.models import BusinessArea, FileTemp, FlexibleAttribute, Household, Individual, Payment
 
 # ============================================================================
 # Pure function tests (no DB needed)
@@ -370,6 +373,16 @@ def test_nested_getattr_raises_when_no_default():
     obj = MagicMock(spec=[])
     with pytest.raises(AttributeError):
         nested_getattr(obj, "missing")
+
+
+@pytest.mark.django_db
+def test_nested_getattr_returns_default_when_related_object_deleted():
+    file_temp = FileTempFactory()
+    payment_plan = PaymentPlanFactory(export_file_delivery=file_temp)
+    snapshot = copy_model_object(payment_plan)
+    FileTemp.objects.filter(pk=file_temp.pk).delete()
+
+    assert nested_getattr(snapshot, "export_file_delivery", None) is None
 
 
 def test_build_arg_dict_from_dict_maps_keys():

--- a/tests/unit/apps/payment/test_xlsx_payment_plan_group_delivery_export_service.py
+++ b/tests/unit/apps/payment/test_xlsx_payment_plan_group_delivery_export_service.py
@@ -18,6 +18,7 @@ from extras.test_utils.factories.payment import (
     PaymentPlanGroupFactory,
 )
 from extras.test_utils.factories.program import ProgramCycleFactory, ProgramFactory
+from hope.apps.payment.utils import get_link
 from hope.apps.payment.xlsx.xlsx_payment_plan_delivery_export_service import XlsxPaymentPlanDeliveryExportService
 from hope.apps.payment.xlsx.xlsx_payment_plan_group_delivery_export_service import (
     EmptyDeliveryExportError,
@@ -983,8 +984,11 @@ def test_get_email_context_link_points_to_batch_download(group_with_one_accepted
 
     context = service.get_email_context(user)
 
-    expected_link = reverse("download-payment-plan-group-batch", args=[str(group_with_one_accepted_plan.id), 1])
+    expected_link = get_link(
+        reverse("download-payment-plan-group-batch", args=[str(group_with_one_accepted_plan.id), 1])
+    )
     assert context["link"] == expected_link
+    assert context["link"].startswith("http")
 
 
 def test_get_email_context_message_and_title_carry_group_and_batch(group_with_one_accepted_plan, user):

--- a/tests/unit/apps/payment/test_xlsx_payment_plan_group_delivery_import_service.py
+++ b/tests/unit/apps/payment/test_xlsx_payment_plan_group_delivery_import_service.py
@@ -2,6 +2,8 @@ from decimal import Decimal
 from io import BytesIO
 from unittest.mock import patch
 
+from django.contrib.contenttypes.models import ContentType
+from django.core.files.base import ContentFile
 from django.db import connection
 from django.test.utils import CaptureQueriesContext
 import openpyxl
@@ -24,7 +26,7 @@ from hope.apps.payment.xlsx.xlsx_payment_plan_delivery_import_service import Xls
 from hope.apps.payment.xlsx.xlsx_payment_plan_group_delivery_import_service import (
     XlsxPaymentPlanGroupDeliveryImportService,
 )
-from hope.models import FinancialServiceProvider, Payment, PaymentPlan, ProgramCycle
+from hope.models import FileTemp, FinancialServiceProvider, Payment, PaymentPlan, ProgramCycle
 
 pytestmark = pytest.mark.django_db
 
@@ -113,6 +115,22 @@ def group_two_plans_one_fsp(program_cycle, business_area, fsp, delivery_mechanis
         "payment_one": payment_one,
         "payment_two": payment_two,
     }
+
+
+@pytest.fixture
+def group_two_plans_with_shared_export_file(group_two_plans_one_fsp):
+    ctx = group_two_plans_one_fsp
+    file_temp = FileTemp.objects.create(
+        object_id=str(ctx["group"].pk),
+        content_type=ContentType.objects.get_for_model(ctx["group"]),
+    )
+    file_temp.file.save("export.xlsx", ContentFile(b"exported-bytes"))
+    PaymentPlan.objects.filter(id__in=[ctx["plan_one"].id, ctx["plan_two"].id]).update(
+        export_tag=1, export_file_delivery=file_temp
+    )
+    ctx["plan_one"].refresh_from_db()
+    ctx["plan_two"].refresh_from_db()
+    return {**ctx, "file_temp": file_temp, "file_name": file_temp.file.name}
 
 
 @pytest.fixture
@@ -489,6 +507,55 @@ def test_import_rolls_back_all_plans_when_any_plan_fails(group_two_plans_one_fsp
     ctx["payment_two"].refresh_from_db()
     assert ctx["payment_one"].delivered_quantity == before_one
     assert ctx["payment_two"].delivered_quantity == before_two
+
+
+def test_import_deletes_whole_shared_export_filetemp(
+    group_two_plans_with_shared_export_file, django_capture_on_commit_callbacks
+):
+    ctx = group_two_plans_with_shared_export_file
+    file_temp = ctx["file_temp"]
+    storage = file_temp.file.storage
+    file_name = ctx["file_name"]
+    file = _make_workbook(
+        ["payment_id", "delivered_quantity", "currency"],
+        [
+            [str(ctx["payment_one"].unicef_id), Decimal("50.00"), "USD"],
+            [str(ctx["payment_two"].unicef_id), Decimal("75.00"), "USD"],
+        ],
+    )
+    service = XlsxPaymentPlanGroupDeliveryImportService(ctx["group"], file)
+    service.open_workbook()
+
+    # file delete is deferred to transaction.on_commit, so execute the captured callbacks
+    with django_capture_on_commit_callbacks(execute=True):
+        service.import_payment_list()
+
+    assert not FileTemp.objects.filter(pk=file_temp.pk).exists()
+    assert not storage.exists(file_name)
+
+
+def test_import_does_not_crash_logging_change_after_removing_shared_export_file(
+    group_two_plans_with_shared_export_file,
+):
+    ctx = group_two_plans_with_shared_export_file
+    file = _make_workbook(
+        ["payment_id", "delivered_quantity", "currency"],
+        [
+            [str(ctx["payment_one"].unicef_id), Decimal("50.00"), "USD"],
+            [str(ctx["payment_two"].unicef_id), Decimal("75.00"), "USD"],
+        ],
+    )
+    service = XlsxPaymentPlanGroupDeliveryImportService(ctx["group"], file)
+    service.open_workbook()
+
+    # log_payment_plan_change diffs a pre-remove snapshot whose export_file_delivery FK now
+    # points at a deleted FileTemp: this must not raise FileTemp.DoesNotExist.
+    service.import_payment_list()
+
+    ctx["payment_one"].refresh_from_db()
+    ctx["payment_two"].refresh_from_db()
+    assert ctx["payment_one"].delivered_quantity == Decimal("50.00")
+    assert ctx["payment_two"].delivered_quantity == Decimal("75.00")
 
 
 def test_import_payment_list_builds_services_when_validate_not_called(group_two_plans_one_fsp):

--- a/uv.lock
+++ b/uv.lock
@@ -1928,7 +1928,7 @@ wheels = [
 
 [[package]]
 name = "hope"
-version = "4.17.0"
+version = "4.17.1"
 source = { editable = "." }
 dependencies = [
     { name = "black" },


### PR DESCRIPTION
[AB#331115](https://unicef.visualstudio.com/4e044e8d-bc28-4768-8074-f80ff6e4a0e5/_workitems/edit/331115)
[AB#330996](https://unicef.visualstudio.com/4e044e8d-bc28-4768-8074-f80ff6e4a0e5/_workitems/edit/330996)
Fix Payment Plan Group emails now have full path url instead of relative path.

Import on payment plan group delivery was crashing and rolling back, leaving the export file deleted but the FileTemp row orphaned.
Real cause: after we delete the shared export FileTemp, the activity-log diff reads the old snapshot that still points at it, and nested_getattr only caught AttributeError — so the DoesNotExist killed the import. File delete isn't transactional, so it was already gone by then.
Fix: nested_getattr now treats a deleted relation as absent, and file deletes are deferred to on_commit so row and file stay in sync on rollback.

