### PR TITLE
Optimize React Query caching and refetch behavior

### DIFF
--- a/src/frontend/eslint.config.cjs
+++ b/src/frontend/eslint.config.cjs
@@ -137,6 +137,19 @@ module.exports = defineConfig([
       '@tanstack/query/no-rest-destructuring': 'warn',
       '@tanstack/query/stable-query-client': 'error',
 
+      // Query keys must be derived from the fetcher via restQueryKey (utils/queryKeys.ts)
+      // so reader and invalidator keys cannot drift. `warn` while readers are still being
+      // migrated (lint has no --max-warnings, so CI stays green); flip to `error` once the
+      // full migration lands.
+      'no-restricted-syntax': [
+        'warn',
+        {
+          selector: "Property[key.name='queryKey'] > ArrayExpression",
+          message:
+            'Derive query keys via restQueryKey(RestService.method[, params]) — see utils/queryKeys.ts — instead of a hand-written array literal.',
+        },
+      ],
+
       'react/jsx-filename-extension': [
         1,
         {

--- a/src/frontend/eslint.config.cjs
+++ b/src/frontend/eslint.config.cjs
@@ -138,11 +138,10 @@ module.exports = defineConfig([
       '@tanstack/query/stable-query-client': 'error',
 
       // Query keys must be derived from the fetcher via restQueryKey (utils/queryKeys.ts)
-      // so reader and invalidator keys cannot drift. `warn` while readers are still being
-      // migrated (lint has no --max-warnings, so CI stays green); flip to `error` once the
-      // full migration lands.
+      // so reader and invalidator keys cannot drift. The migration is complete, so this is
+      // an error — a hand-written key silently stops matching its invalidator.
       'no-restricted-syntax': [
-        'warn',
+        'error',
         {
           selector: "Property[key.name='queryKey'] > ArrayExpression",
           message:

--- a/src/frontend/src/components/accountability/Communication/LookUpsCommunication/LookUpSelectionCommunication.tsx
+++ b/src/frontend/src/components/accountability/Communication/LookUpsCommunication/LookUpSelectionCommunication.tsx
@@ -12,6 +12,7 @@ import { LookUpTargetPopulationFiltersCommunication } from './LookUpTargetPopula
 import { useProgramContext } from 'src/programContext';
 import { HouseholdChoices } from '@restgenerated/models/HouseholdChoices';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useQuery } from '@tanstack/react-query';
 import { RegistrationDataImportStatusEnum } from '@restgenerated/models/RegistrationDataImportStatusEnum';
 
@@ -79,7 +80,10 @@ export function LookUpSelectionCommunication({
 
   const { data: choicesData, isLoading: choicesLoading } =
     useQuery<HouseholdChoices>({
-      queryKey: ['householdChoices', businessArea],
+      queryKey: restQueryKey(
+        RestService.restBusinessAreasHouseholdsChoicesRetrieve,
+        { businessAreaSlug: businessArea },
+      ),
       queryFn: () =>
         RestService.restBusinessAreasHouseholdsChoicesRetrieve({
           businessAreaSlug: businessArea,

--- a/src/frontend/src/components/accountability/Feedback/FeedbackTable/FeedbackFilters.tsx
+++ b/src/frontend/src/components/accountability/Feedback/FeedbackTable/FeedbackFilters.tsx
@@ -8,6 +8,7 @@ import { useBaseUrl } from '@hooks/useBaseUrl';
 import { Grid, MenuItem } from '@mui/material';
 import { Choice } from '@restgenerated/models/Choice';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { CreatedByAutocompleteRestFilter } from '@shared/autocompletes/CreatedByAutocompleteRestFilter';
 import { ProgramAutocompleteRestFilter } from '@shared/autocompletes/ProgramAutocompleteRestFilter';
 import { useQuery } from '@tanstack/react-query';
@@ -39,7 +40,7 @@ const FeedbackFilters = ({
   const { data: issueTypeChoices, isLoading: choicesLoading } = useQuery<
     Choice[]
   >({
-    queryKey: ['choicesFeedbackIssueType'],
+    queryKey: restQueryKey(RestService.restChoicesFeedbackIssueTypeList),
     queryFn: () => RestService.restChoicesFeedbackIssueTypeList(),
   });
 

--- a/src/frontend/src/components/accountability/Feedback/HouseholdQuestionnaire/HouseholdQuestionnaire.tsx
+++ b/src/frontend/src/components/accountability/Feedback/HouseholdQuestionnaire/HouseholdQuestionnaire.tsx
@@ -11,6 +11,7 @@ import { LoadingComponent } from '@components/core/LoadingComponent';
 import { useQuery } from '@tanstack/react-query';
 import { HouseholdDetail } from '@restgenerated/models/HouseholdDetail';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 
 interface HouseholdQuestionnaireProps {
   values;
@@ -26,23 +27,23 @@ function HouseholdQuestionnaire({
 
   const householdId = values.selectedHousehold?.id;
 
+  const householdParams = {
+    businessAreaSlug: businessArea,
+    id: householdId,
+    programCode: values.selectedHousehold?.program?.code,
+  };
+
   const {
     data: household,
     isLoading,
     error,
   } = useQuery<HouseholdDetail>({
-    queryKey: [
-      'household',
-      businessArea,
-      householdId,
-      values.selectedHousehold?.program?.code,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsHouseholdsRetrieve,
+      householdParams,
+    ),
     queryFn: () =>
-      RestService.restBusinessAreasProgramsHouseholdsRetrieve({
-        businessAreaSlug: businessArea,
-        id: householdId,
-        programCode: values.selectedHousehold?.program?.code,
-      }),
+      RestService.restBusinessAreasProgramsHouseholdsRetrieve(householdParams),
     enabled: !!householdId && !isAllPrograms,
   });
 

--- a/src/frontend/src/components/accountability/Feedback/IndividualQuestionnnaire/IndividualQuestionnaire.tsx
+++ b/src/frontend/src/components/accountability/Feedback/IndividualQuestionnnaire/IndividualQuestionnaire.tsx
@@ -9,6 +9,7 @@ import { ReactElement } from 'react';
 import withErrorBoundary from '@components/core/withErrorBoundary';
 import { choicesToDict } from '@utils/utils';
 import { RestService } from '@restgenerated/index';
+import { restQueryKey } from '@utils/queryKeys';
 import { IndividualChoices } from '@restgenerated/models/IndividualChoices';
 import { useQuery } from '@tanstack/react-query';
 
@@ -26,7 +27,10 @@ const IndividualQuestionnaire = ({
   const { selectedProgram } = useProgramContext();
   const beneficiaryGroup = selectedProgram?.beneficiaryGroup;
   const { data: choicesData } = useQuery<IndividualChoices>({
-    queryKey: ['individualChoices', businessArea],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasIndividualsChoicesRetrieve,
+      { businessAreaSlug: businessArea },
+    ),
     queryFn: () =>
       RestService.restBusinessAreasIndividualsChoicesRetrieve({
         businessAreaSlug: businessArea,

--- a/src/frontend/src/components/accountability/Feedback/Messages/Messages.tsx
+++ b/src/frontend/src/components/accountability/Feedback/Messages/Messages.tsx
@@ -76,8 +76,17 @@ function Messages({ messages, canAddMessage }: MessagesProps): ReactElement {
         requestBody: { description },
       });
 
+      // Refresh both feedback detail readers: the details page keys via
+      // useHopeDetailsQuery (`restBusinessAreasFeedbacksRetrieve`), the edit page keys
+      // `['businessAreasFeedbacksRetrieve', businessArea, id]`.
       queryClient.invalidateQueries({
-        queryKey: ['businessAreasFeedbacksRetrieve', id],
+        queryKey: [
+          'restBusinessAreasFeedbacksRetrieve',
+          { id, programCode, businessAreaSlug },
+        ],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ['businessAreasFeedbacksRetrieve', businessAreaSlug, id],
       });
     } catch (error) {
       showApiErrorMessages(error, showMessage);

--- a/src/frontend/src/components/accountability/Feedback/Messages/Messages.tsx
+++ b/src/frontend/src/components/accountability/Feedback/Messages/Messages.tsx
@@ -80,9 +80,6 @@ function Messages({ messages, canAddMessage }: MessagesProps): ReactElement {
         requestBody: { description },
       });
 
-      // Refresh the feedback detail. Both the details page (via
-      // useHopeDetailsQuery) and the edit page derive their key from the same
-      // fetcher, so the bare prefix invalidates every cached variant.
       queryClient.invalidateQueries({
         queryKey: restQueryKey(RestService.restBusinessAreasFeedbacksRetrieve),
       });

--- a/src/frontend/src/components/accountability/Feedback/Messages/Messages.tsx
+++ b/src/frontend/src/components/accountability/Feedback/Messages/Messages.tsx
@@ -50,7 +50,10 @@ function Messages({ messages, canAddMessage }: MessagesProps): ReactElement {
   const { businessAreaSlug, programCode } = useBaseUrl();
   const { showMessage } = useSnackbar();
   const { data: meData, isLoading: meLoading } = useQuery({
-    queryKey: ['profile', businessAreaSlug, programCode],
+    queryKey: restQueryKey(RestService.restBusinessAreasUsersProfileRetrieve, {
+      businessAreaSlug,
+      program: programCode,
+    }),
     queryFn: () => {
       return RestService.restBusinessAreasUsersProfileRetrieve({
         businessAreaSlug,

--- a/src/frontend/src/components/accountability/Feedback/Messages/Messages.tsx
+++ b/src/frontend/src/components/accountability/Feedback/Messages/Messages.tsx
@@ -14,6 +14,7 @@ import { FeedbackDetail } from '@restgenerated/models/FeedbackDetail';
 import { RestService } from '@restgenerated/services/RestService';
 import { FormikTextField } from '@shared/Formik/FormikTextField';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { renderUserName, showApiErrorMessages } from '@utils/utils';
 import { Field, Form, Formik } from 'formik';
 import { ReactElement, useState } from 'react';
@@ -76,17 +77,11 @@ function Messages({ messages, canAddMessage }: MessagesProps): ReactElement {
         requestBody: { description },
       });
 
-      // Refresh both feedback detail readers: the details page keys via
-      // useHopeDetailsQuery (`restBusinessAreasFeedbacksRetrieve`), the edit page keys
-      // `['businessAreasFeedbacksRetrieve', businessArea, id]`.
+      // Refresh the feedback detail. Both the details page (via
+      // useHopeDetailsQuery) and the edit page derive their key from the same
+      // fetcher, so the bare prefix invalidates every cached variant.
       queryClient.invalidateQueries({
-        queryKey: [
-          'restBusinessAreasFeedbacksRetrieve',
-          { id, programCode, businessAreaSlug },
-        ],
-      });
-      queryClient.invalidateQueries({
-        queryKey: ['businessAreasFeedbacksRetrieve', businessAreaSlug, id],
+        queryKey: restQueryKey(RestService.restBusinessAreasFeedbacksRetrieve),
       });
     } catch (error) {
       showApiErrorMessages(error, showMessage);

--- a/src/frontend/src/components/core/AppBar.tsx
+++ b/src/frontend/src/components/core/AppBar.tsx
@@ -11,6 +11,7 @@ import { styled } from '@mui/system';
 import { ReactElement } from 'react';
 import { theme as muiTheme } from 'src/theme';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useQuery } from '@tanstack/react-query';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 
@@ -65,13 +66,18 @@ const StyledIconButton = styled(IconButton)<AppBarProps>(({ open }) => ({
 export const AppBar = ({ open, handleDrawerOpen }): ReactElement => {
   const { businessArea, programCode } = useBaseUrl();
 
+  const profileParams = {
+    businessAreaSlug: businessArea,
+    program: programCode === 'all' ? undefined : programCode,
+  };
+
   const { data: meData } = useQuery({
-    queryKey: ['profile', businessArea, programCode],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasUsersProfileRetrieve,
+      profileParams,
+    ),
     queryFn: () => {
-      return RestService.restBusinessAreasUsersProfileRetrieve({
-        businessAreaSlug: businessArea,
-        program: programCode === 'all' ? undefined : programCode,
-      });
+      return RestService.restBusinessAreasUsersProfileRetrieve(profileParams);
     },
     staleTime: 5 * 60 * 1000, // Data is considered fresh for 5 minutes
     gcTime: 30 * 60 * 1000, // Keep unused data in cache for 30 minutes

--- a/src/frontend/src/components/core/Drawer/DrawerItems.tsx
+++ b/src/frontend/src/components/core/Drawer/DrawerItems.tsx
@@ -24,6 +24,7 @@ import { useProgramContext } from 'src/programContext';
 import { BeneficiaryGroup } from '@restgenerated/models/BeneficiaryGroup';
 import { BusinessArea } from '@restgenerated/models/BusinessArea';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useQuery } from '@tanstack/react-query';
 
 const Text = styled(ListItemText)`
@@ -68,7 +69,9 @@ export const DrawerItems = ({
   const permissions = usePermissions();
 
   const { data: businessAreaData } = useQuery<BusinessArea>({
-    queryKey: ['businessArea', businessArea],
+    queryKey: restQueryKey(RestService.restBusinessAreasRetrieve, {
+      slug: businessArea,
+    }),
     queryFn: () =>
       RestService.restBusinessAreasRetrieve({
         slug: businessArea,

--- a/src/frontend/src/components/core/MockExampleProfile/MockExampleProfile.tsx
+++ b/src/frontend/src/components/core/MockExampleProfile/MockExampleProfile.tsx
@@ -1,13 +1,17 @@
 import React from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 
 const MockExampleProfile = () => {
   const { businessAreaSlug, programCode } = useBaseUrl();
 
   const { data: meData, isLoading: meLoading } = useQuery({
-    queryKey: ['profile', businessAreaSlug, programCode],
+    queryKey: restQueryKey(RestService.restBusinessAreasUsersProfileRetrieve, {
+      businessAreaSlug: businessAreaSlug,
+      program: programCode,
+    }),
     queryFn: () => {
       return RestService.restBusinessAreasUsersProfileRetrieve({
         businessAreaSlug: businessAreaSlug,

--- a/src/frontend/src/components/core/UsersListFilters.tsx
+++ b/src/frontend/src/components/core/UsersListFilters.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { createHandleApplyFilterChange } from '@utils/utils';
 import { FiltersSection } from './FiltersSection';
@@ -49,7 +50,9 @@ export function UsersListFilters({
   };
 
   const { data: choicesData, isLoading } = useQuery({
-    queryKey: ['userChoices', businessArea],
+    queryKey: restQueryKey(RestService.restBusinessAreasUsersChoicesRetrieve, {
+      businessAreaSlug: businessArea,
+    }),
     queryFn: () =>
       RestService.restBusinessAreasUsersChoicesRetrieve({
         businessAreaSlug: businessArea,

--- a/src/frontend/src/components/core/XlsxImportDialog.tsx
+++ b/src/frontend/src/components/core/XlsxImportDialog.tsx
@@ -6,7 +6,11 @@ import { useSnackbar } from '@hooks/useSnackBar';
 import { Publish } from '@mui/icons-material';
 import { Box, Button, Dialog, DialogActions, DialogTitle } from '@mui/material';
 import { PaymentPlanImportFile } from '@restgenerated/models/PaymentPlanImportFile';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  useMutation,
+  useQueryClient,
+  type QueryKey,
+} from '@tanstack/react-query';
 import { getApiErrorMessages } from '@utils/utils';
 import { ReactElement, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -17,7 +21,7 @@ interface XlsxImportDialogProps {
   /** Wires the actual import endpoint; receives the multipart form data. */
   mutationFn: (formData: PaymentPlanImportFile) => Promise<unknown>;
   /** Query key invalidated on a successful import. */
-  invalidateQueryKey: unknown[];
+  invalidateQueryKey: QueryKey;
   successMessage: string;
   /** Fallback message when the API error has no parsable body. */
   errorFallback?: string;

--- a/src/frontend/src/components/grievances/AddIndividualDataChange.tsx
+++ b/src/frontend/src/components/grievances/AddIndividualDataChange.tsx
@@ -20,6 +20,7 @@ import { ReactElement } from 'react';
 import withErrorBoundary from '@components/core/withErrorBoundary';
 import { useQuery } from '@tanstack/react-query';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 
 export interface AddIndividualDataChangeFieldProps {
@@ -128,7 +129,10 @@ function AddIndividualDataChange({
   const { businessAreaSlug } = useBaseUrl();
 
   const { data, isLoading: loading } = useQuery({
-    queryKey: ['addIndividualFieldsAttributes', businessAreaSlug],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasGrievanceTicketsAllAddIndividualsFieldsAttributesList,
+      { businessAreaSlug },
+    ),
     queryFn: () =>
       RestService.restBusinessAreasGrievanceTicketsAllAddIndividualsFieldsAttributesList(
         {
@@ -138,7 +142,10 @@ function AddIndividualDataChange({
   });
 
   const { data: choicesData, isLoading: choicesLoading } = useQuery({
-    queryKey: ['businessAreasGrievanceTicketsChoices', businessAreaSlug],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasGrievanceTicketsChoicesRetrieve,
+      { businessAreaSlug },
+    ),
     queryFn: () =>
       RestService.restBusinessAreasGrievanceTicketsChoicesRetrieve({
         businessAreaSlug,
@@ -147,7 +154,10 @@ function AddIndividualDataChange({
 
   const { data: individualChoicesData, isLoading: individualChoicesLoading } =
     useQuery({
-      queryKey: ['individualChoices', businessAreaSlug],
+      queryKey: restQueryKey(
+        RestService.restBusinessAreasIndividualsChoicesRetrieve,
+        { businessAreaSlug },
+      ),
       queryFn: () =>
         RestService.restBusinessAreasIndividualsChoicesRetrieve({
           businessAreaSlug,
@@ -155,7 +165,7 @@ function AddIndividualDataChange({
     });
 
   const { data: countriesData, isLoading: countriesLoading } = useQuery({
-    queryKey: ['countriesList'],
+    queryKey: restQueryKey(RestService.restChoicesCountriesList),
     queryFn: () => RestService.restChoicesCountriesList(),
   });
 

--- a/src/frontend/src/components/grievances/AddIndividualGrievanceDetails.tsx
+++ b/src/frontend/src/components/grievances/AddIndividualGrievanceDetails.tsx
@@ -38,7 +38,10 @@ function AddIndividualGrievanceDetails({
   const queryClient = useQueryClient();
 
   const { data, isLoading: loading } = useQuery({
-    queryKey: ['addIndividualFieldsAttributes', businessArea],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasGrievanceTicketsAllAddIndividualsFieldsAttributesList,
+      { businessAreaSlug: businessArea },
+    ),
     queryFn: () =>
       RestService.restBusinessAreasGrievanceTicketsAllAddIndividualsFieldsAttributesList(
         {

--- a/src/frontend/src/components/grievances/AddIndividualGrievanceDetails.tsx
+++ b/src/frontend/src/components/grievances/AddIndividualGrievanceDetails.tsx
@@ -21,6 +21,7 @@ import withErrorBoundary from '@components/core/withErrorBoundary';
 import { GrievanceTicketDetail } from '@restgenerated/models/GrievanceTicketDetail';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import camelCase from 'lodash/camelCase';
 import { PERMISSIONS } from 'src/config/permissions';
@@ -33,7 +34,7 @@ function AddIndividualGrievanceDetails({
   canApproveDataChange: boolean;
 }): ReactElement {
   const { t } = useTranslation();
-  const { businessArea, businessAreaSlug } = useBaseUrl();
+  const { businessArea } = useBaseUrl();
   const queryClient = useQueryClient();
 
   const { data, isLoading: loading } = useQuery({
@@ -64,11 +65,9 @@ function AddIndividualGrievanceDetails({
     onSuccess: () => {
       // Invalidate and refetch the grievance ticket details
       queryClient.invalidateQueries({
-        queryKey: [
-          'businessAreasGrievanceTicketsRetrieve',
-          businessAreaSlug,
-          ticket.id,
-        ],
+        queryKey: restQueryKey(
+          RestService.restBusinessAreasGrievanceTicketsRetrieve,
+        ),
       });
     },
   });

--- a/src/frontend/src/components/grievances/ApproveDeleteHouseholdGrievanceDetails.tsx
+++ b/src/frontend/src/components/grievances/ApproveDeleteHouseholdGrievanceDetails.tsx
@@ -25,6 +25,7 @@ import { FormikRadioGroup } from '@shared/Formik/FormikRadioGroup';
 import { FormikTextField } from '@shared/Formik/FormikTextField';
 import { GRIEVANCE_TICKET_STATES } from '@utils/constants';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useProgramContext } from 'src/programContext';
 import { GrievanceTicketDetail } from '@restgenerated/models/GrievanceTicketDetail';
 import { showApiErrorMessages } from '@utils/utils';
@@ -73,11 +74,9 @@ export const ApproveDeleteHouseholdGrievanceDetails = ({
     },
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: [
-          'businessAreasGrievanceTicketsRetrieve',
-          businessAreaSlug,
-          ticket.id,
-        ],
+        queryKey: restQueryKey(
+          RestService.restBusinessAreasGrievanceTicketsRetrieve,
+        ),
       });
     },
   });

--- a/src/frontend/src/components/grievances/CreateGrievance/Description/Description.tsx
+++ b/src/frontend/src/components/grievances/CreateGrievance/Description/Description.tsx
@@ -8,6 +8,7 @@ import { useBaseUrl } from '@hooks/useBaseUrl';
 import { Box, FormHelperText, Grid, GridSize, Typography } from '@mui/material';
 import { PaginatedProgramListList } from '@restgenerated/models/PaginatedProgramListList';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useQuery } from '@tanstack/react-query';
 import { FormikAdminAreaAutocomplete } from '@shared/Formik/FormikAdminAreaAutocomplete';
 import { FormikSelectField } from '@shared/Formik/FormikSelectField';
@@ -70,7 +71,10 @@ function Description({
   const { isAllPrograms, businessArea } = useBaseUrl();
 
   const { data: partnerChoicesData } = useQuery({
-    queryKey: ['partnerForGrievanceChoices', businessArea],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasUsersPartnerForGrievanceChoicesRetrieve,
+      { businessAreaSlug: businessArea },
+    ),
     queryFn: () =>
       RestService.restBusinessAreasUsersPartnerForGrievanceChoicesRetrieve({
         businessAreaSlug: businessArea,

--- a/src/frontend/src/components/grievances/DeleteHouseholdGrievanceDetails.tsx
+++ b/src/frontend/src/components/grievances/DeleteHouseholdGrievanceDetails.tsx
@@ -15,6 +15,7 @@ import { useProgramContext } from 'src/programContext';
 import { ReactElement } from 'react';
 import { HouseholdChoices } from '@restgenerated/models/HouseholdChoices';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useQuery } from '@tanstack/react-query';
 import { GrievanceTicketDetail } from '@restgenerated/models/GrievanceTicketDetail';
 
@@ -37,7 +38,10 @@ export function DeleteHouseholdGrievanceDetails({
 
   const { data: choicesData, isLoading: choicesLoading } =
     useQuery<HouseholdChoices>({
-      queryKey: ['householdChoices', businessArea],
+      queryKey: restQueryKey(
+        RestService.restBusinessAreasHouseholdsChoicesRetrieve,
+        { businessAreaSlug: businessArea },
+      ),
       queryFn: () =>
         RestService.restBusinessAreasHouseholdsChoicesRetrieve({
           businessAreaSlug: businessArea,

--- a/src/frontend/src/components/grievances/DeleteIndividualGrievanceDetails.tsx
+++ b/src/frontend/src/components/grievances/DeleteIndividualGrievanceDetails.tsx
@@ -70,7 +70,10 @@ export function DeleteIndividualGrievanceDetails({
   const queryClient = useQueryClient();
 
   const { data: addIndividualFieldsData, isLoading } = useQuery({
-    queryKey: ['allAddIndividualsFieldsAttributes', businessArea],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasGrievanceTicketsAllAddIndividualsFieldsAttributesList,
+      { businessAreaSlug: businessArea },
+    ),
     queryFn: () =>
       RestService.restBusinessAreasGrievanceTicketsAllAddIndividualsFieldsAttributesList(
         {

--- a/src/frontend/src/components/grievances/DeleteIndividualGrievanceDetails.tsx
+++ b/src/frontend/src/components/grievances/DeleteIndividualGrievanceDetails.tsx
@@ -5,6 +5,7 @@ import { useSnackbar } from '@hooks/useSnackBar';
 import { GRIEVANCE_TICKET_STATES } from '@utils/constants';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useConfirmation } from '@core/ConfirmationDialog';
 import { LabelizedField } from '@core/LabelizedField';
@@ -35,7 +36,6 @@ export function DeleteIndividualGrievanceDetails({
 }): ReactElement {
   const { t } = useTranslation();
   const { showMessage } = useSnackbar();
-  const { businessAreaSlug } = useBaseUrl();
   const confirm = useConfirmation();
   const { selectedProgram } = useProgramContext();
   const beneficiaryGroup = selectedProgram?.beneficiaryGroup;
@@ -97,11 +97,9 @@ export function DeleteIndividualGrievanceDetails({
     onSuccess: () => {
       // Invalidate and refetch the grievance ticket details
       queryClient.invalidateQueries({
-        queryKey: [
-          'businessAreasGrievanceTicketsRetrieve',
-          businessAreaSlug,
-          ticket.id,
-        ],
+        queryKey: restQueryKey(
+          RestService.restBusinessAreasGrievanceTicketsRetrieve,
+        ),
       });
     },
   });

--- a/src/frontend/src/components/grievances/EditHouseholdDataChange/EditHouseholdDataChange.tsx
+++ b/src/frontend/src/components/grievances/EditHouseholdDataChange/EditHouseholdDataChange.tsx
@@ -14,6 +14,7 @@ import withErrorBoundary from '@components/core/withErrorBoundary';
 import { DarkGrey } from '@components/grievances/LookUps/LookUpStyles';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { RestService } from '@restgenerated/index';
+import { restQueryKey } from '@utils/queryKeys';
 import { HouseholdDetail } from '@restgenerated/models/HouseholdDetail';
 import { useQuery } from '@tanstack/react-query';
 import { roleDisplayMap } from '@components/grievances/utils/createGrievanceUtils';
@@ -45,7 +46,10 @@ function EditHouseholdDataChange({
           values.selectedIndividual?.programCode));
 
   const { data: individualsChoices } = useQuery({
-    queryKey: ['individualsChoices', businessArea],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasIndividualsChoicesRetrieve,
+      { businessAreaSlug: businessArea },
+    ),
     queryFn: () =>
       RestService.restBusinessAreasIndividualsChoicesRetrieve({
         businessAreaSlug: businessArea,
@@ -62,7 +66,10 @@ function EditHouseholdDataChange({
 
   const { data: householdFieldsData, isLoading: householdFieldsLoading } =
     useQuery({
-      queryKey: ['householdFields', businessArea, programId],
+      queryKey: restQueryKey(
+        RestService.restBusinessAreasGrievanceTicketsAllEditHouseholdFieldsAttributesList,
+        { businessAreaSlug: businessArea },
+      ),
       queryFn: () =>
         RestService.restBusinessAreasGrievanceTicketsAllEditHouseholdFieldsAttributesList(
           {
@@ -72,35 +79,42 @@ function EditHouseholdDataChange({
       enabled: Boolean(businessArea),
     });
 
+  const fullHouseholdParams = {
+    businessAreaSlug: businessArea,
+    id: household.id,
+    programCode: dynamicProgramCode,
+  };
   const {
     data: fullHousehold,
     isLoading: fullHouseholdLoading,
     refetch: refetchHousehold,
   } = useQuery<HouseholdDetail>({
-    queryKey: [businessArea, household.id, dynamicProgramCode, programId],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsHouseholdsRetrieve,
+      fullHouseholdParams,
+    ),
     queryFn: () =>
-      RestService.restBusinessAreasProgramsHouseholdsRetrieve({
-        businessAreaSlug: businessArea,
-        id: household.id,
-        programCode: dynamicProgramCode,
-      }),
+      RestService.restBusinessAreasProgramsHouseholdsRetrieve(
+        fullHouseholdParams,
+      ),
     enabled: Boolean(household && businessArea && dynamicProgramCode),
   });
 
   // Fetch household members for roles logic
+  const householdMembersParams = {
+    businessAreaSlug: businessArea,
+    id: household.id,
+    programCode: dynamicProgramCode,
+  };
   const { data: householdMembers, isLoading: membersLoading } = useQuery({
-    queryKey: [
-      'householdMembers',
-      businessArea,
-      household.id,
-      dynamicProgramCode,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsHouseholdsMembersList,
+      householdMembersParams,
+    ),
     queryFn: () =>
-      RestService.restBusinessAreasProgramsHouseholdsMembersList({
-        businessAreaSlug: businessArea,
-        id: household.id,
-        programCode: dynamicProgramCode,
-      }),
+      RestService.restBusinessAreasProgramsHouseholdsMembersList(
+        householdMembersParams,
+      ),
     enabled: Boolean(household && businessArea && dynamicProgramCode),
   });
 

--- a/src/frontend/src/components/grievances/EditHouseholdDataChange/EditHouseholdDataChange.tsx
+++ b/src/frontend/src/components/grievances/EditHouseholdDataChange/EditHouseholdDataChange.tsx
@@ -317,21 +317,13 @@ function EditHouseholdDataChange({
                       onClick={() => {
                         if (availableIndividuals.length > 0) {
                           const defaultIndividual = availableIndividuals[0].id;
-                          // Find current role for this individual
-                          const currentRoleObj =
-                            fullHousehold.rolesInHousehold.find(
-                              (r) => r.individual.id === defaultIndividual,
-                            );
-                          // Only add if newRole is not equal to current role
-                          if (!currentRoleObj || '' !== currentRoleObj.role) {
-                            setFieldValue('roles', [
-                              ...(values.roles || []),
-                              {
-                                individual: defaultIndividual,
-                                newRole: '',
-                              },
-                            ]);
-                          }
+                          setFieldValue('roles', [
+                            ...(values.roles || []),
+                            {
+                              individual: defaultIndividual,
+                              newRole: '',
+                            },
+                          ]);
                         }
                       }}
                       data-cy="button-add-new-role"

--- a/src/frontend/src/components/grievances/EditIndividualDataChange/EditIndividualDataChange.tsx
+++ b/src/frontend/src/components/grievances/EditIndividualDataChange/EditIndividualDataChange.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 import { useQuery } from '@tanstack/react-query';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { LoadingComponent } from '@core/LoadingComponent';
 import { Title } from '@core/Title';
@@ -66,7 +67,10 @@ function EditIndividualDataChange({
     data: addIndividualFieldsData,
     isLoading: addIndividualFieldsLoading,
   } = useQuery({
-    queryKey: ['allAddIndividualsFieldsAttributes', businessArea],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasGrievanceTicketsAllAddIndividualsFieldsAttributesList,
+      { businessAreaSlug: businessArea },
+    ),
     queryFn: () =>
       RestService.restBusinessAreasGrievanceTicketsAllAddIndividualsFieldsAttributesList(
         {
@@ -77,7 +81,10 @@ function EditIndividualDataChange({
   });
 
   const { data: choicesData, isLoading: choicesLoading } = useQuery({
-    queryKey: ['grievanceTicketsChoices', businessArea],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasGrievanceTicketsChoicesRetrieve,
+      { businessAreaSlug: businessArea },
+    ),
     queryFn: () =>
       RestService.restBusinessAreasGrievanceTicketsChoicesRetrieve({
         businessAreaSlug: businessArea,
@@ -87,7 +94,10 @@ function EditIndividualDataChange({
 
   const { data: individualChoicesData, isLoading: individualChoicesLoading } =
     useQuery({
-      queryKey: ['individualsChoices', businessArea],
+      queryKey: restQueryKey(
+        RestService.restBusinessAreasIndividualsChoicesRetrieve,
+        { businessAreaSlug: businessArea },
+      ),
       queryFn: () =>
         RestService.restBusinessAreasIndividualsChoicesRetrieve({
           businessAreaSlug: businessArea,
@@ -96,25 +106,25 @@ function EditIndividualDataChange({
     });
 
   const { data: countriesData, isLoading: countriesLoading } = useQuery({
-    queryKey: ['countriesList'],
+    queryKey: restQueryKey(RestService.restChoicesCountriesList),
     queryFn: () => RestService.restChoicesCountriesList(),
   });
 
+  const fullIndividualParams = {
+    businessAreaSlug: businessArea,
+    id: individual?.id,
+    programCode: dynamicProgramCode,
+  };
   const { data: fullIndividual, isLoading: fullIndividualLoading } =
     useQuery<IndividualDetail>({
-      queryKey: [
-        'individual',
-        businessArea,
-        individual?.id,
-        dynamicProgramCode,
-        programId,
-      ],
+      queryKey: restQueryKey(
+        RestService.restBusinessAreasProgramsIndividualsRetrieve,
+        fullIndividualParams,
+      ),
       queryFn: () =>
-        RestService.restBusinessAreasProgramsIndividualsRetrieve({
-          businessAreaSlug: businessArea,
-          id: individual.id,
-          programCode: dynamicProgramCode,
-        }),
+        RestService.restBusinessAreasProgramsIndividualsRetrieve(
+          fullIndividualParams,
+        ),
       enabled: Boolean(individual && businessArea && dynamicProgramCode),
     });
 

--- a/src/frontend/src/components/grievances/EditPeopleDataChange/EditPeopleDataChange.tsx
+++ b/src/frontend/src/components/grievances/EditPeopleDataChange/EditPeopleDataChange.tsx
@@ -6,6 +6,7 @@ import { Box, Button, Grid, Typography } from '@mui/material';
 import { IndividualDetail } from '@restgenerated/models/IndividualDetail';
 import { IndividualList } from '@restgenerated/models/IndividualList';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useQuery } from '@tanstack/react-query';
 import { FieldArray } from 'formik';
 import { ReactElement, useEffect } from 'react';
@@ -57,7 +58,10 @@ function EditPeopleDataChange({
           values.selectedIndividual?.programCode));
   const { data: editPeopleFieldsData, isLoading: editPeopleFieldsLoading } =
     useQuery({
-      queryKey: ['allEditPeopleFieldsAttributes', businessArea],
+      queryKey: restQueryKey(
+        RestService.restBusinessAreasGrievanceTicketsAllEditPeopleFieldsAttributesList,
+        { businessAreaSlug: businessArea },
+      ),
       queryFn: () =>
         RestService.restBusinessAreasGrievanceTicketsAllEditPeopleFieldsAttributesList(
           {
@@ -67,7 +71,10 @@ function EditPeopleDataChange({
     });
 
   const { data: choicesData, isLoading: choicesLoading } = useQuery({
-    queryKey: ['grievanceTicketsChoices', businessArea],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasGrievanceTicketsChoicesRetrieve,
+      { businessAreaSlug: businessArea },
+    ),
     queryFn: () =>
       RestService.restBusinessAreasGrievanceTicketsChoicesRetrieve({
         businessAreaSlug: businessArea,
@@ -76,7 +83,10 @@ function EditPeopleDataChange({
 
   const { data: individualChoicesData, isLoading: individualChoicesLoading } =
     useQuery({
-      queryKey: ['individualsChoices', businessArea],
+      queryKey: restQueryKey(
+        RestService.restBusinessAreasIndividualsChoicesRetrieve,
+        { businessAreaSlug: businessArea },
+      ),
       queryFn: () =>
         RestService.restBusinessAreasIndividualsChoicesRetrieve({
           businessAreaSlug: businessArea,
@@ -84,25 +94,25 @@ function EditPeopleDataChange({
     });
 
   const { data: countriesData, isLoading: countriesLoading } = useQuery({
-    queryKey: ['countriesList'],
+    queryKey: restQueryKey(RestService.restChoicesCountriesList),
     queryFn: () => RestService.restChoicesCountriesList(),
   });
 
+  const fullIndividualParams = {
+    businessAreaSlug: businessArea,
+    programCode: dynamicProgramCode,
+    id: individual?.id,
+  };
   const { data: fullIndividual, isLoading: fullIndividualLoading } =
     useQuery<IndividualDetail>({
-      queryKey: [
-        'businessAreaProgramIndividual',
-        businessArea,
-        dynamicProgramCode,
-        individual?.id,
-        values.selectedIndividual,
-      ],
+      queryKey: restQueryKey(
+        RestService.restBusinessAreasProgramsIndividualsRetrieve,
+        fullIndividualParams,
+      ),
       queryFn: () =>
-        RestService.restBusinessAreasProgramsIndividualsRetrieve({
-          businessAreaSlug: businessArea,
-          programCode: dynamicProgramCode,
-          id: individual?.id,
-        }),
+        RestService.restBusinessAreasProgramsIndividualsRetrieve(
+          fullIndividualParams,
+        ),
       enabled: Boolean(individual && businessArea && dynamicProgramCode),
     });
 

--- a/src/frontend/src/components/grievances/FlagDetails.tsx
+++ b/src/frontend/src/components/grievances/FlagDetails.tsx
@@ -15,6 +15,7 @@ import { DATE_FORMAT } from '../../config';
 import { GRIEVANCE_TICKET_STATES } from '@utils/constants';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useConfirmation } from '@core/ConfirmationDialog';
 import { FlagTooltip } from '@core/FlagTooltip';
@@ -38,7 +39,7 @@ export const FlagDetails = ({
 }): ReactElement => {
   const { t } = useTranslation();
   const confirm = useConfirmation();
-  const { businessArea, businessAreaSlug } = useBaseUrl();
+  const { businessArea } = useBaseUrl();
   const queryClient = useQueryClient();
 
   const mutation = useMutation({
@@ -59,11 +60,9 @@ export const FlagDetails = ({
     onSuccess: () => {
       // Invalidate and refetch the grievance ticket details
       queryClient.invalidateQueries({
-        queryKey: [
-          'businessAreasGrievanceTicketsRetrieve',
-          businessAreaSlug,
-          ticket.id,
-        ],
+        queryKey: restQueryKey(
+          RestService.restBusinessAreasGrievanceTicketsRetrieve,
+        ),
       });
     },
   });

--- a/src/frontend/src/components/grievances/GrievanceDetailsToolbar.tsx
+++ b/src/frontend/src/components/grievances/GrievanceDetailsToolbar.tsx
@@ -10,6 +10,7 @@ import EditIcon from '@mui/icons-material/EditRounded';
 import { Box, Button, Tooltip } from '@mui/material';
 import { GrievanceTicketDetail } from '@restgenerated/models/GrievanceTicketDetail';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import {
   GRIEVANCE_CATEGORIES,
@@ -112,11 +113,9 @@ export const GrievanceDetailsToolbar = ({
     },
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: [
-          'businessAreasGrievanceTicketsRetrieve',
-          businessArea,
-          ticket.id,
-        ],
+        queryKey: restQueryKey(
+          RestService.restBusinessAreasGrievanceTicketsRetrieve,
+        ),
       });
     },
   });
@@ -304,11 +303,9 @@ export const GrievanceDetailsToolbar = ({
             { businessAreaSlug: businessArea, id: linkedId, formData: {} },
           );
           queryClient.invalidateQueries({
-            queryKey: [
-              'businessAreasGrievanceTicketsRetrieve',
-              businessArea,
-              linkedId,
-            ],
+            queryKey: restQueryKey(
+              RestService.restBusinessAreasGrievanceTicketsRetrieve,
+            ),
           });
         } catch (e) {
           showApiErrorMessages(e, showMessage);

--- a/src/frontend/src/components/grievances/GrievancesPhotoModals/GrievanceFlexFieldPhotoModal.tsx
+++ b/src/frontend/src/components/grievances/GrievancesPhotoModals/GrievanceFlexFieldPhotoModal.tsx
@@ -4,6 +4,7 @@ import PhotoModal from '@core/PhotoModal/PhotoModal';
 import { ReactElement } from 'react';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { RestService } from '@restgenerated/index';
+import { restQueryKey } from '@utils/queryKeys';
 import { GrievanceTicketDetail } from '@restgenerated/models/GrievanceTicketDetail';
 import { useQuery } from '@tanstack/react-query';
 
@@ -22,7 +23,10 @@ export function GrievanceFlexFieldPhotoModal({
   const { businessAreaSlug } = useBaseUrl();
 
   const { data } = useQuery<GrievanceTicketDetail>({
-    queryKey: ['businessAreasGrievanceTicketsRetrieve', businessAreaSlug, id],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasGrievanceTicketsRetrieve,
+      { businessAreaSlug, id },
+    ),
     queryFn: () =>
       RestService.restBusinessAreasGrievanceTicketsRetrieve({
         businessAreaSlug,

--- a/src/frontend/src/components/grievances/GrievancesPhotoModals/GrievanceFlexFieldPhotoModalEditable.tsx
+++ b/src/frontend/src/components/grievances/GrievancesPhotoModals/GrievanceFlexFieldPhotoModalEditable.tsx
@@ -4,6 +4,7 @@ import { useParams } from 'react-router-dom';
 import { FormikFileField } from '@shared/Formik/FormikFileField';
 import { useQuery } from '@tanstack/react-query';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import PhotoModal from '@core/PhotoModal/PhotoModal';
 
@@ -27,7 +28,10 @@ export function GrievanceFlexFieldPhotoModalEditable({
   const { businessArea } = useBaseUrl();
 
   const { data } = useQuery({
-    queryKey: ['grievanceTicket', id, businessArea],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasGrievanceTicketsRetrieve,
+      { businessAreaSlug: businessArea, id },
+    ),
     queryFn: () =>
       RestService.restBusinessAreasGrievanceTicketsRetrieve({
         businessAreaSlug: businessArea,

--- a/src/frontend/src/components/grievances/GrievancesPhotoModals/GrievanceFlexFieldPhotoModalNewHousehold.tsx
+++ b/src/frontend/src/components/grievances/GrievancesPhotoModals/GrievanceFlexFieldPhotoModalNewHousehold.tsx
@@ -3,6 +3,7 @@ import PhotoModal from '@core/PhotoModal/PhotoModal';
 import { ReactElement } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { HouseholdDetail } from '@restgenerated/models/HouseholdDetail';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { useProgramContext } from 'src/programContext';
@@ -22,20 +23,18 @@ export function GrievanceFlexFieldPhotoModalNewHousehold({
   const { businessArea, programId } = useBaseUrl();
   const { selectedProgram } = useProgramContext();
 
+  const householdParams = {
+    businessAreaSlug: businessArea,
+    id: householdId,
+    programCode: programId || selectedProgram?.code || '',
+  };
   const { data } = useQuery<HouseholdDetail>({
-    queryKey: [
-      'household',
-      businessArea,
-      householdId,
-      programId,
-      selectedProgram?.code,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsHouseholdsRetrieve,
+      householdParams,
+    ),
     queryFn: () =>
-      RestService.restBusinessAreasProgramsHouseholdsRetrieve({
-        businessAreaSlug: businessArea,
-        id: householdId,
-        programCode: programId || selectedProgram?.code || '',
-      }),
+      RestService.restBusinessAreasProgramsHouseholdsRetrieve(householdParams),
     enabled:
       !!businessArea &&
       !!householdId &&

--- a/src/frontend/src/components/grievances/GrievancesPhotoModals/GrievanceFlexFieldPhotoModalNewIndividual.tsx
+++ b/src/frontend/src/components/grievances/GrievancesPhotoModals/GrievanceFlexFieldPhotoModalNewIndividual.tsx
@@ -3,6 +3,7 @@ import PhotoModal from '@core/PhotoModal/PhotoModal';
 import { ReactElement } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { IndividualDetail } from '@restgenerated/models/IndividualDetail';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { useProgramContext } from 'src/programContext';
@@ -22,20 +23,18 @@ export function GrievanceFlexFieldPhotoModalNewIndividual({
   const { businessArea, programId } = useBaseUrl();
   const { selectedProgram } = useProgramContext();
 
+  const individualParams = {
+    businessAreaSlug: businessArea,
+    programCode: programId || selectedProgram?.code || '',
+    id: individualId,
+  };
   const { data } = useQuery<IndividualDetail>({
-    queryKey: [
-      'individual',
-      businessArea,
-      programId,
-      individualId,
-      selectedProgram?.code,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsIndividualsRetrieve,
+      individualParams,
+    ),
     queryFn: () =>
-      RestService.restBusinessAreasProgramsIndividualsRetrieve({
-        businessAreaSlug: businessArea,
-        programCode: programId || selectedProgram?.code || '',
-        id: individualId,
-      }),
+      RestService.restBusinessAreasProgramsIndividualsRetrieve(individualParams),
     enabled:
       !!businessArea &&
       !!individualId &&

--- a/src/frontend/src/components/grievances/GrievancesPhotoModals/GrievanceIndividualPhotoModal.tsx
+++ b/src/frontend/src/components/grievances/GrievancesPhotoModals/GrievanceIndividualPhotoModal.tsx
@@ -2,6 +2,7 @@ import PhotoModal from '@core/PhotoModal/PhotoModal';
 import { ReactElement } from 'react';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { RestService } from '@restgenerated/index';
+import { restQueryKey } from '@utils/queryKeys';
 import { IndividualPhotoDetail } from '@restgenerated/models/IndividualPhotoDetail';
 import { useQuery } from '@tanstack/react-query';
 import { useProgramContext } from 'src/programContext';
@@ -20,19 +21,20 @@ export function GrievanceIndividualPhotoModal({
   const { businessArea } = useBaseUrl();
   const { selectedProgram } = useProgramContext();
 
+  const individualPhotosParams = {
+    businessAreaSlug: businessArea,
+    programCode: selectedProgram?.code || '',
+    id: individualId || '',
+  };
   const { data } = useQuery<IndividualPhotoDetail>({
-    queryKey: [
-      'individualPhotos',
-      businessArea,
-      selectedProgram?.code,
-      individualId,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsIndividualsPhotosRetrieve,
+      individualPhotosParams,
+    ),
     queryFn: () =>
-      RestService.restBusinessAreasProgramsIndividualsPhotosRetrieve({
-        businessAreaSlug: businessArea,
-        programCode: selectedProgram?.code || '',
-        id: individualId || '',
-      }),
+      RestService.restBusinessAreasProgramsIndividualsPhotosRetrieve(
+        individualPhotosParams,
+      ),
     enabled:
       !!isCurrent &&
       !!businessArea &&

--- a/src/frontend/src/components/grievances/GrievancesTable/GrievancesTable.tsx
+++ b/src/frontend/src/components/grievances/GrievancesTable/GrievancesTable.tsx
@@ -11,7 +11,7 @@ import { GrievanceTicketList } from '@restgenerated/models/GrievanceTicketList';
 import { PaginatedGrievanceTicketListList } from '@restgenerated/models/PaginatedGrievanceTicketListList';
 import { PaginatedUserList } from '@restgenerated/models/PaginatedUserList';
 import { RestService } from '@restgenerated/services/RestService';
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { createApiParams } from '@utils/apiUtils';
 import {
   GRIEVANCE_CATEGORIES,
@@ -189,6 +189,7 @@ export const GrievancesTable = ({
         ),
       ),
     enabled: isAllPrograms,
+    placeholderData: keepPreviousData,
   });
 
   //ALL PROGRAMS COUNT
@@ -227,6 +228,7 @@ export const GrievancesTable = ({
         ),
       ),
     enabled: !isAllPrograms,
+    placeholderData: keepPreviousData,
   });
   //SELECTED PROGRAM COUNT
   const { data: selectedProgramGrievanceTicketsCount } =

--- a/src/frontend/src/components/grievances/GrievancesTable/GrievancesTable.tsx
+++ b/src/frontend/src/components/grievances/GrievancesTable/GrievancesTable.tsx
@@ -11,6 +11,7 @@ import { GrievanceTicketList } from '@restgenerated/models/GrievanceTicketList';
 import { PaginatedGrievanceTicketListList } from '@restgenerated/models/PaginatedGrievanceTicketListList';
 import { PaginatedUserList } from '@restgenerated/models/PaginatedUserList';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { createApiParams } from '@utils/apiUtils';
 import {
@@ -163,43 +164,36 @@ export const GrievancesTable = ({
   }, [usersListData]);
 
   //ALL PROGRAMS
+  const allGrievanceTicketsParams = createApiParams(
+    {
+      businessAreaSlug: businessArea,
+      program: programId === 'all' ? undefined : programId,
+    },
+    queryVariables,
+    { withPagination: true },
+  );
   const {
     data: allProgramsGrievanceTicketsData,
     isLoading: isLoadingAll,
     isFetching: isFetchingAll,
     error: errorAll,
   } = useQuery<PaginatedGrievanceTicketListList>({
-    queryKey: [
-      'businessAreasGrievanceTickets',
-      queryVariables,
-      businessArea,
-      filter.grievanceType,
-      programId,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasGrievanceTicketsList,
+      allGrievanceTicketsParams,
+    ),
     queryFn: () =>
-      RestService.restBusinessAreasGrievanceTicketsList(
-        createApiParams(
-          {
-            businessAreaSlug: businessArea,
-            program: programId === 'all' ? undefined : programId,
-          },
-          queryVariables,
-          {
-            withPagination: true,
-          },
-        ),
-      ),
+      RestService.restBusinessAreasGrievanceTicketsList(allGrievanceTicketsParams),
     enabled: isAllPrograms,
     placeholderData: keepPreviousData,
   });
 
   //ALL PROGRAMS COUNT
   const { data: allProgramsGrievanceTicketsCount } = useQuery<CountResponse>({
-    queryKey: [
-      'businessAreasGrievanceTicketsCount',
-      businessArea,
-      queryVariables,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasGrievanceTicketsCountRetrieve,
+      createApiParams({ businessAreaSlug: businessArea }, queryVariables),
+    ),
     queryFn: () =>
       RestService.restBusinessAreasGrievanceTicketsCountRetrieve(
         createApiParams({ businessAreaSlug: businessArea }, queryVariables),
@@ -208,45 +202,42 @@ export const GrievancesTable = ({
   });
 
   // SELECTED PROGRAM
+  const selectedProgramGrievanceTicketsParams = createApiParams(
+    { businessAreaSlug: businessArea, programCode: programId },
+    queryVariables,
+    { withPagination: true },
+  );
   const {
     data: selectedProgramGrievanceTicketsData,
     isLoading: isLoadingSelected,
     isFetching: isFetchingSelected,
     error: errorSelected,
   } = useQuery<PaginatedGrievanceTicketListList>({
-    queryKey: [
-      'businessAreasProgramsGrievanceTickets',
-      queryVariables,
-      programId,
-      businessArea,
-      filter.grievanceType,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsGrievanceTicketsList,
+      selectedProgramGrievanceTicketsParams,
+    ),
     queryFn: () =>
       RestService.restBusinessAreasProgramsGrievanceTicketsList(
-        createApiParams(
-          { businessAreaSlug: businessArea, programCode: programId },
-          queryVariables,
-          { withPagination: true },
-        ),
+        selectedProgramGrievanceTicketsParams,
       ),
     enabled: !isAllPrograms,
     placeholderData: keepPreviousData,
   });
   //SELECTED PROGRAM COUNT
+  const selectedProgramGrievanceTicketsCountParams = createApiParams(
+    { businessAreaSlug: businessArea, programCode: programId },
+    queryVariables,
+  );
   const { data: selectedProgramGrievanceTicketsCount } =
     useQuery<CountResponse>({
-      queryKey: [
-        'businessAreasProgramsGrievanceTicketsCount',
-        businessArea,
-        programId,
-        queryVariables,
-      ],
+      queryKey: restQueryKey(
+        RestService.restBusinessAreasProgramsGrievanceTicketsCountRetrieve,
+        selectedProgramGrievanceTicketsCountParams,
+      ),
       queryFn: () =>
         RestService.restBusinessAreasProgramsGrievanceTicketsCountRetrieve(
-          createApiParams(
-            { businessAreaSlug: businessArea, programCode: programId },
-            queryVariables,
-          ),
+          selectedProgramGrievanceTicketsCountParams,
         ),
       enabled: !isAllPrograms && page === 0,
     });

--- a/src/frontend/src/components/grievances/GrievancesTable/GrievancesTable.tsx
+++ b/src/frontend/src/components/grievances/GrievancesTable/GrievancesTable.tsx
@@ -137,15 +137,12 @@ export const GrievancesTable = ({
   const [page, setPage] = useState<number>(0);
 
   const { data: usersListData } = useQuery<PaginatedUserList>({
-    queryKey: [
-      'businessAreasUsersList',
-      {
-        businessAreaSlug: businessArea,
-        limit: 20,
-        ordering: 'first_name,last_name,email',
-        search: debouncedInputText || undefined,
-      },
-    ],
+    queryKey: restQueryKey(RestService.restBusinessAreasUsersList, {
+      businessAreaSlug: businessArea,
+      limit: 20,
+      ordering: 'first_name,last_name,email',
+      search: debouncedInputText || undefined,
+    }),
     queryFn: ({ queryKey }) => {
       const [, params] = queryKey;
       return RestService.restBusinessAreasUsersList(params as any);
@@ -273,21 +270,30 @@ export const GrievancesTable = ({
   };
 
   const { data: choicesData, isLoading: choicesLoading } = useQuery({
-    queryKey: ['businessAreasGrievanceTicketsChoices', businessAreaSlug],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasGrievanceTicketsChoicesRetrieve,
+      { businessAreaSlug },
+    ),
     queryFn: () =>
       RestService.restBusinessAreasGrievanceTicketsChoicesRetrieve({
         businessAreaSlug,
       }),
   });
 
+  const currentUserParams = {
+    businessAreaSlug,
+    program: programCode === 'all' ? undefined : programCode,
+  };
   const { data: currentUserData, isLoading: currentUserDataLoading } = useQuery(
     {
-      queryKey: ['profile', businessAreaSlug, programCode],
+      queryKey: restQueryKey(
+        RestService.restBusinessAreasUsersProfileRetrieve,
+        currentUserParams,
+      ),
       queryFn: () => {
-        return RestService.restBusinessAreasUsersProfileRetrieve({
-          businessAreaSlug,
-          program: programCode === 'all' ? undefined : programCode,
-        });
+        return RestService.restBusinessAreasUsersProfileRetrieve(
+          currentUserParams,
+        );
       },
       staleTime: 5 * 60 * 1000, // Data is considered fresh for 5 minutes
       gcTime: 30 * 60 * 1000, // Keep unused data in cache for 30 minutes

--- a/src/frontend/src/components/grievances/GrievancesTable/GrievancesTable.tsx
+++ b/src/frontend/src/components/grievances/GrievancesTable/GrievancesTable.tsx
@@ -166,6 +166,7 @@ export const GrievancesTable = ({
   const {
     data: allProgramsGrievanceTicketsData,
     isLoading: isLoadingAll,
+    isFetching: isFetchingAll,
     error: errorAll,
   } = useQuery<PaginatedGrievanceTicketListList>({
     queryKey: [
@@ -210,6 +211,7 @@ export const GrievancesTable = ({
   const {
     data: selectedProgramGrievanceTicketsData,
     isLoading: isLoadingSelected,
+    isFetching: isFetchingSelected,
     error: errorSelected,
   } = useQuery<PaginatedGrievanceTicketListList>({
     queryKey: [
@@ -440,6 +442,7 @@ export const GrievancesTable = ({
           }
           error={isAllPrograms ? errorAll : errorSelected}
           isLoading={isAllPrograms ? isLoadingAll : isLoadingSelected}
+          isFetching={isAllPrograms ? isFetchingAll : isFetchingSelected}
           queryVariables={queryVariables}
           setQueryVariables={setQueryVariables}
           defaultOrderBy="created_at"

--- a/src/frontend/src/components/grievances/GrievancesTable/GrievancesTableRow.tsx
+++ b/src/frontend/src/components/grievances/GrievancesTable/GrievancesTableRow.tsx
@@ -3,6 +3,7 @@ import TableCell from '@mui/material/TableCell';
 import { useNavigate } from 'react-router-dom';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { BulkUpdateGrievanceTicketsAssignees } from '@restgenerated/models/BulkUpdateGrievanceTicketsAssignees';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { useSnackbar } from '@hooks/useSnackBar';
@@ -78,7 +79,9 @@ export function GrievancesTableRow({
     },
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: ['businessAreasProgramsGrievanceTickets'],
+        queryKey: restQueryKey(
+          RestService.restBusinessAreasProgramsGrievanceTicketsList,
+        ),
       });
     },
     onError: (error: any) => {

--- a/src/frontend/src/components/grievances/GrievancesTable/GrievancesTableRow.tsx
+++ b/src/frontend/src/components/grievances/GrievancesTable/GrievancesTableRow.tsx
@@ -54,7 +54,7 @@ export function GrievancesTableRow({
   optionsData,
   setInputValue,
 }: GrievancesTableRowProps): ReactElement {
-  const { baseUrl, businessArea, isAllPrograms, programId } = useBaseUrl();
+  const { baseUrl, businessArea, isAllPrograms } = useBaseUrl();
   const { isSocialDctType } = useProgramContext();
   const navigate = useNavigate();
   const { showMessage } = useSnackbar();
@@ -79,12 +79,6 @@ export function GrievancesTableRow({
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: ['businessAreasProgramsGrievanceTickets'],
-      });
-      queryClient.invalidateQueries({
-        queryKey: [
-          'businessAreasProgramsGrievanceTickets',
-          { program: programId },
-        ],
       });
     },
     onError: (error: any) => {

--- a/src/frontend/src/components/grievances/GrievancesTable/bulk/BulkAddNoteModal.tsx
+++ b/src/frontend/src/components/grievances/GrievancesTable/bulk/BulkAddNoteModal.tsx
@@ -32,7 +32,7 @@ export function BulkAddNoteModal({
   const { t } = useTranslation();
   const { showMessage } = useSnackbar();
   const [value, setValue] = useState<string>('');
-  const { businessAreaSlug, isAllPrograms, programId } = useBaseUrl();
+  const { businessAreaSlug, isAllPrograms } = useBaseUrl();
   const queryClient = useQueryClient();
 
   const { mutateAsync } = useMutation({
@@ -49,10 +49,7 @@ export function BulkAddNoteModal({
         });
       } else {
         queryClient.invalidateQueries({
-          queryKey: [
-            'businessAreasProgramsGrievanceTickets',
-            { program: programId },
-          ],
+          queryKey: ['businessAreasProgramsGrievanceTickets'],
         });
       }
       setSelected([]);

--- a/src/frontend/src/components/grievances/GrievancesTable/bulk/BulkAddNoteModal.tsx
+++ b/src/frontend/src/components/grievances/GrievancesTable/bulk/BulkAddNoteModal.tsx
@@ -6,6 +6,7 @@ import { useSnackbar } from '@hooks/useSnackBar';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { BulkGrievanceTicketsAddNote } from '@restgenerated/models/BulkGrievanceTicketsAddNote';
 import { BulkBaseModal } from './BulkBaseModal';
 import { ReactElement, useState } from 'react';
@@ -45,11 +46,15 @@ export function BulkAddNoteModal({
     onSuccess: () => {
       if (isAllPrograms) {
         queryClient.invalidateQueries({
-          queryKey: ['businessAreasGrievanceTickets'],
+          queryKey: restQueryKey(
+            RestService.restBusinessAreasGrievanceTicketsList,
+          ),
         });
       } else {
         queryClient.invalidateQueries({
-          queryKey: ['businessAreasProgramsGrievanceTickets'],
+          queryKey: restQueryKey(
+            RestService.restBusinessAreasProgramsGrievanceTicketsList,
+          ),
         });
       }
       setSelected([]);

--- a/src/frontend/src/components/grievances/GrievancesTable/bulk/BulkAssignModal.tsx
+++ b/src/frontend/src/components/grievances/GrievancesTable/bulk/BulkAssignModal.tsx
@@ -8,6 +8,7 @@ import { BulkBaseModal } from './BulkBaseModal';
 import { GrievanceTicketList } from '@restgenerated/models/GrievanceTicketList';
 import { User } from '@restgenerated/models/User';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { BulkUpdateGrievanceTicketsAssignees } from '@restgenerated/models/BulkUpdateGrievanceTicketsAssignees';
 import { useBaseUrl } from '@hooks/useBaseUrl';
@@ -49,11 +50,15 @@ export function BulkAssignModal({
     onSuccess: () => {
       if (isAllPrograms) {
         queryClient.invalidateQueries({
-          queryKey: ['businessAreasGrievanceTickets'],
+          queryKey: restQueryKey(
+            RestService.restBusinessAreasGrievanceTicketsList,
+          ),
         });
       } else {
         queryClient.invalidateQueries({
-          queryKey: ['businessAreasProgramsGrievanceTickets'],
+          queryKey: restQueryKey(
+            RestService.restBusinessAreasProgramsGrievanceTicketsList,
+          ),
         });
       }
       setSelected([]);

--- a/src/frontend/src/components/grievances/GrievancesTable/bulk/BulkAssignModal.tsx
+++ b/src/frontend/src/components/grievances/GrievancesTable/bulk/BulkAssignModal.tsx
@@ -68,12 +68,14 @@ export function BulkAssignModal({
     },
   });
 
+  // `satisfies` keeps the orderBy string literals narrowed to the fetcher's enum, which a
+  // bare object literal loses once it is hoisted out of the call.
   const usersParams = {
     businessAreaSlug: businessAreaSlug,
     limit: 20,
     orderBy: ['first_name', 'last_name', 'email'],
     search: inputValue,
-  };
+  } satisfies Parameters<typeof RestService.restBusinessAreasUsersList>[0];
   const { data: usersData } = useQuery({
     queryKey: restQueryKey(RestService.restBusinessAreasUsersList, usersParams),
     queryFn: () => RestService.restBusinessAreasUsersList(usersParams),

--- a/src/frontend/src/components/grievances/GrievancesTable/bulk/BulkAssignModal.tsx
+++ b/src/frontend/src/components/grievances/GrievancesTable/bulk/BulkAssignModal.tsx
@@ -68,15 +68,15 @@ export function BulkAssignModal({
     },
   });
 
+  const usersParams = {
+    businessAreaSlug: businessAreaSlug,
+    limit: 20,
+    orderBy: ['first_name', 'last_name', 'email'],
+    search: inputValue,
+  };
   const { data: usersData } = useQuery({
-    queryKey: ['users', businessAreaSlug, inputValue],
-    queryFn: () =>
-      RestService.restBusinessAreasUsersList({
-        businessAreaSlug: businessAreaSlug,
-        limit: 20,
-        orderBy: ['first_name', 'last_name', 'email'],
-        search: inputValue,
-      }),
+    queryKey: restQueryKey(RestService.restBusinessAreasUsersList, usersParams),
+    queryFn: () => RestService.restBusinessAreasUsersList(usersParams),
   });
 
   const optionsData: User[] = usersData?.results || [];

--- a/src/frontend/src/components/grievances/GrievancesTable/bulk/BulkAssignModal.tsx
+++ b/src/frontend/src/components/grievances/GrievancesTable/bulk/BulkAssignModal.tsx
@@ -32,7 +32,7 @@ export function BulkAssignModal({
 }: BulkAssignModalProps): ReactElement {
   const { t } = useTranslation();
   const { showMessage } = useSnackbar();
-  const { businessAreaSlug, isAllPrograms, programId } = useBaseUrl();
+  const { businessAreaSlug, isAllPrograms } = useBaseUrl();
   const [value, setValue] = useState<User | null>(null);
   const [inputValue, setInputValue] = useState('');
   const queryClient = useQueryClient();
@@ -53,10 +53,7 @@ export function BulkAssignModal({
         });
       } else {
         queryClient.invalidateQueries({
-          queryKey: [
-            'businessAreasProgramsGrievanceTickets',
-            { program: programId },
-          ],
+          queryKey: ['businessAreasProgramsGrievanceTickets'],
         });
       }
       setSelected([]);

--- a/src/frontend/src/components/grievances/GrievancesTable/bulk/BulkSetPriorityModal.tsx
+++ b/src/frontend/src/components/grievances/GrievancesTable/bulk/BulkSetPriorityModal.tsx
@@ -37,7 +37,10 @@ export const BulkSetPriorityModal = ({
   const queryClient = useQueryClient();
 
   const { data: choices } = useQuery({
-    queryKey: ['businessAreasGrievanceTicketsChoices', businessAreaSlug],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasGrievanceTicketsChoicesRetrieve,
+      { businessAreaSlug },
+    ),
     queryFn: () =>
       RestService.restBusinessAreasGrievanceTicketsChoicesRetrieve({
         businessAreaSlug,

--- a/src/frontend/src/components/grievances/GrievancesTable/bulk/BulkSetPriorityModal.tsx
+++ b/src/frontend/src/components/grievances/GrievancesTable/bulk/BulkSetPriorityModal.tsx
@@ -31,7 +31,7 @@ export const BulkSetPriorityModal = ({
 }: BulkSetPriorityModalProps): ReactElement => {
   const { t } = useTranslation();
   const { showMessage } = useSnackbar();
-  const { businessAreaSlug, isAllPrograms, programId } = useBaseUrl();
+  const { businessAreaSlug, isAllPrograms } = useBaseUrl();
   const [value, setValue] = useState<number>(0);
   const queryClient = useQueryClient();
 
@@ -59,10 +59,7 @@ export const BulkSetPriorityModal = ({
         });
       } else {
         queryClient.invalidateQueries({
-          queryKey: [
-            'businessAreasProgramsGrievanceTickets',
-            { program: programId },
-          ],
+          queryKey: ['businessAreasProgramsGrievanceTickets'],
         });
       }
       setSelected([]);

--- a/src/frontend/src/components/grievances/GrievancesTable/bulk/BulkSetPriorityModal.tsx
+++ b/src/frontend/src/components/grievances/GrievancesTable/bulk/BulkSetPriorityModal.tsx
@@ -6,6 +6,7 @@ import { useSnackbar } from '@hooks/useSnackBar';
 import { useMutation, useQueryClient, useQuery } from '@tanstack/react-query';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { BulkUpdateGrievanceTicketsPriority } from '@restgenerated/models/BulkUpdateGrievanceTicketsPriority';
 import { BulkBaseModal } from './BulkBaseModal';
 import { ReactElement, useState } from 'react';
@@ -55,11 +56,15 @@ export const BulkSetPriorityModal = ({
     onSuccess: () => {
       if (isAllPrograms) {
         queryClient.invalidateQueries({
-          queryKey: ['businessAreasGrievanceTickets'],
+          queryKey: restQueryKey(
+            RestService.restBusinessAreasGrievanceTicketsList,
+          ),
         });
       } else {
         queryClient.invalidateQueries({
-          queryKey: ['businessAreasProgramsGrievanceTickets'],
+          queryKey: restQueryKey(
+            RestService.restBusinessAreasProgramsGrievanceTicketsList,
+          ),
         });
       }
       setSelected([]);

--- a/src/frontend/src/components/grievances/GrievancesTable/bulk/BulkSetUrgencyModal.tsx
+++ b/src/frontend/src/components/grievances/GrievancesTable/bulk/BulkSetUrgencyModal.tsx
@@ -66,7 +66,10 @@ export function BulkSetUrgencyModal({
     },
   });
   const { data: choices } = useQuery({
-    queryKey: ['businessAreasGrievanceTicketsChoices', businessAreaSlug],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasGrievanceTicketsChoicesRetrieve,
+      { businessAreaSlug },
+    ),
     queryFn: () =>
       RestService.restBusinessAreasGrievanceTicketsChoicesRetrieve({
         businessAreaSlug,

--- a/src/frontend/src/components/grievances/GrievancesTable/bulk/BulkSetUrgencyModal.tsx
+++ b/src/frontend/src/components/grievances/GrievancesTable/bulk/BulkSetUrgencyModal.tsx
@@ -31,7 +31,7 @@ export function BulkSetUrgencyModal({
 }: BulkSetUrgencyModalProps): ReactElement {
   const { t } = useTranslation();
   const { showMessage } = useSnackbar();
-  const { businessAreaSlug, isAllPrograms, programId } = useBaseUrl();
+  const { businessAreaSlug, isAllPrograms } = useBaseUrl();
   const [value, setValue] = useState<number>(0);
   const queryClient = useQueryClient();
 
@@ -51,10 +51,7 @@ export function BulkSetUrgencyModal({
         });
       } else {
         queryClient.invalidateQueries({
-          queryKey: [
-            'businessAreasProgramsGrievanceTickets',
-            { program: programId },
-          ],
+          queryKey: ['businessAreasProgramsGrievanceTickets'],
         });
       }
       setSelected([]);

--- a/src/frontend/src/components/grievances/GrievancesTable/bulk/BulkSetUrgencyModal.tsx
+++ b/src/frontend/src/components/grievances/GrievancesTable/bulk/BulkSetUrgencyModal.tsx
@@ -5,6 +5,7 @@ import { FormControl, InputLabel, MenuItem, Select } from '@mui/material';
 import { BulkUpdateGrievanceTicketsUrgency } from '@restgenerated/models/BulkUpdateGrievanceTicketsUrgency';
 import { GrievanceTicketList } from '@restgenerated/models/GrievanceTicketList';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { showApiErrorMessages } from '@utils/utils';
 import { ReactElement, useState } from 'react';
@@ -47,11 +48,15 @@ export function BulkSetUrgencyModal({
     onSuccess: () => {
       if (isAllPrograms) {
         queryClient.invalidateQueries({
-          queryKey: ['businessAreasGrievanceTickets'],
+          queryKey: restQueryKey(
+            RestService.restBusinessAreasGrievanceTicketsList,
+          ),
         });
       } else {
         queryClient.invalidateQueries({
-          queryKey: ['businessAreasProgramsGrievanceTickets'],
+          queryKey: restQueryKey(
+            RestService.restBusinessAreasProgramsGrievanceTicketsList,
+          ),
         });
       }
       setSelected([]);

--- a/src/frontend/src/components/grievances/HouseholdQuestionnaire/HouseholdQuestionnaire.tsx
+++ b/src/frontend/src/components/grievances/HouseholdQuestionnaire/HouseholdQuestionnaire.tsx
@@ -11,6 +11,7 @@ import withErrorBoundary from '@components/core/withErrorBoundary';
 import { HouseholdDetail } from '@restgenerated/models/HouseholdDetail';
 import { useQuery } from '@tanstack/react-query';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 
 interface HouseholdQuestionnaireProps {
   values;
@@ -21,7 +22,7 @@ function HouseholdQuestionnaire({
   values,
   programCode,
 }: HouseholdQuestionnaireProps): ReactElement {
-  const { baseUrl, businessArea, programId } = useBaseUrl();
+  const { baseUrl, businessArea } = useBaseUrl();
   const { t } = useTranslation();
   const { selectedProgram } = useProgramContext();
   const beneficiaryGroup = selectedProgram?.beneficiaryGroup;
@@ -31,24 +32,22 @@ function HouseholdQuestionnaire({
       ? values.selectedHousehold.id
       : values.selectedHousehold;
 
+  const householdParams = {
+    businessAreaSlug: businessArea,
+    id: householdId,
+    programCode: programCode,
+  };
   const {
     data: household,
     isLoading,
     error,
   } = useQuery<HouseholdDetail>({
-    queryKey: [
-      'household',
-      businessArea,
-      householdId,
-      programCode,
-      programId,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsHouseholdsRetrieve,
+      householdParams,
+    ),
     queryFn: () =>
-      RestService.restBusinessAreasProgramsHouseholdsRetrieve({
-        businessAreaSlug: businessArea,
-        id: householdId,
-        programCode: programCode,
-      }),
+      RestService.restBusinessAreasProgramsHouseholdsRetrieve(householdParams),
     enabled: !!householdId && !!programCode,
   });
 

--- a/src/frontend/src/components/grievances/IndividualQuestionnnaire/IndividualQuestionnaire.tsx
+++ b/src/frontend/src/components/grievances/IndividualQuestionnnaire/IndividualQuestionnaire.tsx
@@ -8,6 +8,7 @@ import { useProgramContext } from 'src/programContext';
 import { ReactElement } from 'react';
 import withErrorBoundary from '@components/core/withErrorBoundary';
 import { RestService } from '@restgenerated/index';
+import { restQueryKey } from '@utils/queryKeys';
 import { IndividualChoices } from '@restgenerated/models/IndividualChoices';
 import { useQuery } from '@tanstack/react-query';
 import { choicesToDict } from '@utils/utils';
@@ -26,7 +27,10 @@ const IndividualQuestionnaire = ({
     values.selectedIndividual || values.selectedHousehold.headOfHousehold;
   const beneficiaryGroup = selectedProgram?.beneficiaryGroup;
   const { data: choicesData } = useQuery<IndividualChoices>({
-    queryKey: ['individualChoices', businessArea],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasIndividualsChoicesRetrieve,
+      { businessAreaSlug: businessArea },
+    ),
     queryFn: () =>
       RestService.restBusinessAreasIndividualsChoicesRetrieve({
         businessAreaSlug: businessArea,

--- a/src/frontend/src/components/grievances/LinkedTicketsModal/LinkedTicketsModal.tsx
+++ b/src/frontend/src/components/grievances/LinkedTicketsModal/LinkedTicketsModal.tsx
@@ -24,6 +24,7 @@ import {
 import { GrievanceTicketList } from '@restgenerated/models/GrievanceTicketList';
 import { GrievanceTicketRelated } from '@restgenerated/models/GrievanceTicketRelated';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useQuery } from '@tanstack/react-query';
 import { grievanceTicketStatusToColor } from '@utils/utils';
 import { ReactElement, useState } from 'react';
@@ -71,11 +72,10 @@ function LinkedTicketsModal({
   const { data: relatedTickets = [], isLoading } = useQuery<
     GrievanceTicketRelated[]
   >({
-    queryKey: [
-      'businessAreasGrievanceTicketsRelatedTickets',
-      businessArea,
-      ticket.id,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasGrievanceTicketsRelatedTicketsList,
+      { businessAreaSlug: businessArea, id: ticket.id },
+    ),
     queryFn: () =>
       RestService.restBusinessAreasGrievanceTicketsRelatedTicketsList({
         businessAreaSlug: businessArea,

--- a/src/frontend/src/components/grievances/LookUps/LookUpHouseholdIndividual/LookUpHouseholdIndividualSelectionDetail.tsx
+++ b/src/frontend/src/components/grievances/LookUps/LookUpHouseholdIndividual/LookUpHouseholdIndividualSelectionDetail.tsx
@@ -8,6 +8,7 @@ import { HouseholdDetail } from '@restgenerated/models/HouseholdDetail';
 import { IndividualChoices } from '@restgenerated/models/IndividualChoices';
 import { PaginatedProgramListList } from '@restgenerated/models/PaginatedProgramListList';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useQuery } from '@tanstack/react-query';
 import { createApiParams } from '@utils/apiUtils';
 import { GRIEVANCE_ISSUE_TYPES, PROGRAM_STATE_FILTER } from '@utils/constants';
@@ -53,7 +54,10 @@ export function LookUpHouseholdIndividualSelectionDetail({
 
   const { data: householdChoicesData, isLoading: householdChoicesLoading } =
     useQuery<HouseholdChoices>({
-      queryKey: ['householdChoices', businessArea],
+      queryKey: restQueryKey(
+        RestService.restBusinessAreasHouseholdsChoicesRetrieve,
+        { businessAreaSlug: businessArea },
+      ),
       queryFn: () =>
         RestService.restBusinessAreasHouseholdsChoicesRetrieve({
           businessAreaSlug: businessArea,
@@ -62,7 +66,10 @@ export function LookUpHouseholdIndividualSelectionDetail({
 
   const { data: individualChoicesData, isLoading: individualChoicesLoading } =
     useQuery<IndividualChoices>({
-      queryKey: ['individualChoices', businessArea],
+      queryKey: restQueryKey(
+        RestService.restBusinessAreasIndividualsChoicesRetrieve,
+        { businessAreaSlug: businessArea },
+      ),
       queryFn: () =>
         RestService.restBusinessAreasIndividualsChoicesRetrieve({
           businessAreaSlug: businessArea,
@@ -115,18 +122,20 @@ export function LookUpHouseholdIndividualSelectionDetail({
   const { selectedProgram } = useProgramContext();
   const beneficiaryGroup = selectedProgram?.beneficiaryGroup;
 
+  const programsListParams = createApiParams(
+    { businessAreaSlug: businessArea, limit: 100 },
+    {
+      withPagination: false,
+    },
+  );
   const { data: programsData, isLoading: programsLoading } =
     useQuery<PaginatedProgramListList>({
-      queryKey: ['businessAreasProgramsList', { limit: 100 }, businessArea],
+      queryKey: restQueryKey(
+        RestService.restBusinessAreasProgramsList,
+        programsListParams,
+      ),
       queryFn: () =>
-        RestService.restBusinessAreasProgramsList(
-          createApiParams(
-            { businessAreaSlug: businessArea, limit: 100 },
-            {
-              withPagination: false,
-            },
-          ),
-        ),
+        RestService.restBusinessAreasProgramsList(programsListParams),
     });
 
   if (householdChoicesLoading || individualChoicesLoading || programsLoading)

--- a/src/frontend/src/components/grievances/LookUps/LookUpHouseholdTable/LookUpHouseholdTable.tsx
+++ b/src/frontend/src/components/grievances/LookUps/LookUpHouseholdTable/LookUpHouseholdTable.tsx
@@ -6,7 +6,7 @@ import { HouseholdChoices } from '@restgenerated/models/HouseholdChoices';
 import { PaginatedHouseholdListList } from '@restgenerated/models/PaginatedHouseholdListList';
 import { RdiMergeStatusEnum } from '@restgenerated/models/RdiMergeStatusEnum';
 import { RestService } from '@restgenerated/services/RestService';
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { createApiParams } from '@utils/apiUtils';
 import { adjustHeadCells } from '@utils/utils';
 import { MouseEvent, ReactElement, useEffect, useMemo, useState } from 'react';
@@ -124,6 +124,7 @@ export function LookUpHouseholdTable({
         ),
       ),
     enabled: !!businessArea && !isAllPrograms,
+    placeholderData: keepPreviousData,
   });
 
   //selectedProgram
@@ -161,6 +162,7 @@ export function LookUpHouseholdTable({
       );
     },
     enabled: isAllPrograms,
+    placeholderData: keepPreviousData,
   });
   //allPrograms
 

--- a/src/frontend/src/components/grievances/LookUps/LookUpHouseholdTable/LookUpHouseholdTable.tsx
+++ b/src/frontend/src/components/grievances/LookUps/LookUpHouseholdTable/LookUpHouseholdTable.tsx
@@ -6,6 +6,7 @@ import { HouseholdChoices } from '@restgenerated/models/HouseholdChoices';
 import { PaginatedHouseholdListList } from '@restgenerated/models/PaginatedHouseholdListList';
 import { RdiMergeStatusEnum } from '@restgenerated/models/RdiMergeStatusEnum';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { createApiParams } from '@utils/apiUtils';
 import { adjustHeadCells } from '@utils/utils';
@@ -103,6 +104,12 @@ export function LookUpHouseholdTable({
   // Add page state for pagination
   const [page, setPage] = useState(0);
 
+  const programsHouseholdsParams = createApiParams(
+    { businessAreaSlug: businessArea, programCode: programId },
+    queryVariables,
+    { withPagination: true },
+  );
+
   //selectedProgram
   const {
     data: dataHouseholdsProgram,
@@ -110,19 +117,13 @@ export function LookUpHouseholdTable({
     isFetching: isFetchingHouseholdsProgram,
     error: errorHouseholdsProgram,
   } = useQuery<PaginatedHouseholdListList>({
-    queryKey: [
-      'businessAreasProgramsHouseholdsList',
-      queryVariables,
-      programId,
-      businessArea,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsHouseholdsList,
+      programsHouseholdsParams,
+    ),
     queryFn: () =>
       RestService.restBusinessAreasProgramsHouseholdsList(
-        createApiParams(
-          { businessAreaSlug: businessArea, programCode: programId },
-          queryVariables,
-          { withPagination: true },
-        ),
+        programsHouseholdsParams,
       ),
     enabled: !!businessArea && !isAllPrograms,
     placeholderData: keepPreviousData,
@@ -130,11 +131,10 @@ export function LookUpHouseholdTable({
 
   //selectedProgram
   const { data: dataHouseholdsProgramCount } = useQuery<CountResponse>({
-    queryKey: [
-      'businessAreasProgramsHouseholdsCountRetrieve',
-      businessArea,
-      programId,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsHouseholdsCountRetrieve,
+      { businessAreaSlug: businessArea, programCode: programId },
+    ),
     queryFn: () =>
       RestService.restBusinessAreasProgramsHouseholdsCountRetrieve({
         businessAreaSlug: businessArea,
@@ -144,44 +144,44 @@ export function LookUpHouseholdTable({
   });
 
   //allPrograms
+  const restQueryVariables = Object.fromEntries(
+    Object.entries(queryVariables).filter(([key]) => key !== 'programCode'),
+  );
+  const allProgramsHouseholdsParams = createApiParams(
+    { businessAreaSlug: businessArea },
+    restQueryVariables,
+    { withPagination: true },
+  );
+  const allProgramsHouseholdsCountParams = createApiParams(
+    { businessAreaSlug: businessArea },
+    restQueryVariables,
+  );
   const {
     data: dataHouseholdsAllPrograms,
     isLoading: isLoadingHouseholdsAllPrograms,
     isFetching: isFetchingHouseholdsAllPrograms,
     error: errorHouseholdsAllPrograms,
   } = useQuery<PaginatedHouseholdListList>({
-    queryKey: ['businessAreasHouseholdsList', queryVariables, businessArea],
-    queryFn: () => {
-      const restQueryVariables = Object.fromEntries(
-        Object.entries(queryVariables).filter(([key]) => key !== 'programCode'),
-      );
-      return RestService.restBusinessAreasHouseholdsList(
-        createApiParams(
-          { businessAreaSlug: businessArea },
-          restQueryVariables,
-          { withPagination: true },
-        ),
-      );
-    },
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasHouseholdsList,
+      allProgramsHouseholdsParams,
+    ),
+    queryFn: () =>
+      RestService.restBusinessAreasHouseholdsList(allProgramsHouseholdsParams),
     enabled: isAllPrograms,
     placeholderData: keepPreviousData,
   });
   //allPrograms
 
   const { data: dataHouseholdsAllProgramsCount } = useQuery<CountResponse>({
-    queryKey: [
-      'businessAreasHouseholdsCountRetrieve',
-      businessArea,
-      queryVariables,
-    ],
-    queryFn: () => {
-      const restQueryVariables = Object.fromEntries(
-        Object.entries(queryVariables).filter(([key]) => key !== 'programCode'),
-      );
-      return RestService.restBusinessAreasHouseholdsCountRetrieve(
-        createApiParams({ businessAreaSlug: businessArea }, restQueryVariables),
-      );
-    },
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasHouseholdsCountRetrieve,
+      allProgramsHouseholdsCountParams,
+    ),
+    queryFn: () =>
+      RestService.restBusinessAreasHouseholdsCountRetrieve(
+        allProgramsHouseholdsCountParams,
+      ),
     enabled: isAllPrograms && page === 0,
   });
 

--- a/src/frontend/src/components/grievances/LookUps/LookUpHouseholdTable/LookUpHouseholdTable.tsx
+++ b/src/frontend/src/components/grievances/LookUps/LookUpHouseholdTable/LookUpHouseholdTable.tsx
@@ -107,6 +107,7 @@ export function LookUpHouseholdTable({
   const {
     data: dataHouseholdsProgram,
     isLoading: isLoadingHouseholdsProgram,
+    isFetching: isFetchingHouseholdsProgram,
     error: errorHouseholdsProgram,
   } = useQuery<PaginatedHouseholdListList>({
     queryKey: [
@@ -146,6 +147,7 @@ export function LookUpHouseholdTable({
   const {
     data: dataHouseholdsAllPrograms,
     isLoading: isLoadingHouseholdsAllPrograms,
+    isFetching: isFetchingHouseholdsAllPrograms,
     error: errorHouseholdsAllPrograms,
   } = useQuery<PaginatedHouseholdListList>({
     queryKey: ['businessAreasHouseholdsList', queryVariables, businessArea],
@@ -299,6 +301,11 @@ export function LookUpHouseholdTable({
         isAllPrograms
           ? isLoadingHouseholdsAllPrograms
           : isLoadingHouseholdsProgram
+      }
+      isFetching={
+        isAllPrograms
+          ? isFetchingHouseholdsAllPrograms
+          : isFetchingHouseholdsProgram
       }
       queryVariables={queryVariables}
       setQueryVariables={setQueryVariables}

--- a/src/frontend/src/components/grievances/LookUps/LookUpIndividualTable/LookUpIndividualTable.tsx
+++ b/src/frontend/src/components/grievances/LookUps/LookUpIndividualTable/LookUpIndividualTable.tsx
@@ -95,7 +95,8 @@ export function LookUpIndividualTable({
       householdId,
       excludedId: excludedId || ticket?.individual?.id || null,
       programId: isAllPrograms ? filter.program : programId,
-      isActiveProgram: filter.programState === PROGRAM_STATE_FILTER.ACTIVE ? true : null,
+      isActiveProgram:
+        filter.programState === PROGRAM_STATE_FILTER.ACTIVE ? true : null,
       withdrawn: false,
       rdiMergeStatus: RdiMergeStatusEnum.MERGED,
     }),
@@ -134,6 +135,7 @@ export function LookUpIndividualTable({
   const {
     data: selectedProgramIndividualsData,
     isLoading: isLoadingSelectedProgram,
+    isFetching: isFetchingSelectedProgram,
     error: errorSelectedProgram,
   } = useQuery<PaginatedIndividualListList>({
     queryKey: [
@@ -176,6 +178,7 @@ export function LookUpIndividualTable({
   const {
     data: allProgramsIndividualsData,
     isLoading: isLoadingAllPrograms,
+    isFetching: isFetchingAllPrograms,
     error: errorAllPrograms,
   } = useQuery<PaginatedIndividualListList>({
     queryKey: ['businessAreasIndividualsList', queryVariables, businessArea],
@@ -256,6 +259,9 @@ export function LookUpIndividualTable({
       error={isAllPrograms ? errorAllPrograms : errorSelectedProgram}
       isLoading={
         isAllPrograms ? isLoadingAllPrograms : isLoadingSelectedProgram
+      }
+      isFetching={
+        isAllPrograms ? isFetchingAllPrograms : isFetchingSelectedProgram
       }
       itemsCount={itemsCount}
       renderRow={(row: IndividualList) => (

--- a/src/frontend/src/components/grievances/LookUps/LookUpIndividualTable/LookUpIndividualTable.tsx
+++ b/src/frontend/src/components/grievances/LookUps/LookUpIndividualTable/LookUpIndividualTable.tsx
@@ -7,6 +7,7 @@ import { IndividualList } from '@restgenerated/models/IndividualList';
 import { PaginatedIndividualListList } from '@restgenerated/models/PaginatedIndividualListList';
 import { RdiMergeStatusEnum } from '@restgenerated/models/RdiMergeStatusEnum';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { createApiParams } from '@utils/apiUtils';
 import { PROGRAM_STATE_FILTER } from '@utils/constants';
@@ -132,77 +133,81 @@ export function LookUpIndividualTable({
   const [page, setPage] = useState(0);
 
   // Selected Program Individuals
+  const selectedProgramIndividualsParams = createApiParams(
+    { businessAreaSlug: businessArea, programCode: programId },
+    queryVariables,
+    { withPagination: true },
+  );
   const {
     data: selectedProgramIndividualsData,
     isLoading: isLoadingSelectedProgram,
     isFetching: isFetchingSelectedProgram,
     error: errorSelectedProgram,
   } = useQuery<PaginatedIndividualListList>({
-    queryKey: [
-      'businessAreasProgramsIndividualsList',
-      queryVariables,
-      programId,
-      businessArea,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsIndividualsList,
+      selectedProgramIndividualsParams,
+    ),
     queryFn: () =>
       RestService.restBusinessAreasProgramsIndividualsList(
-        createApiParams(
-          { businessAreaSlug: businessArea, programCode: programId },
-          queryVariables,
-          { withPagination: true },
-        ),
+        selectedProgramIndividualsParams,
       ),
     enabled: !!businessArea && !!programId && !isAllPrograms,
     placeholderData: keepPreviousData,
   });
 
   // Selected Program Count
+  const selectedProgramIndividualsCountParams = createApiParams(
+    { businessAreaSlug: businessArea, programCode: programId },
+    queryVariables,
+  );
   const { data: selectedProgramIndividualsCount } = useQuery<CountResponse>({
-    queryKey: [
-      'businessAreasProgramsIndividualsCountRetrieve',
-      businessArea,
-      programId,
-      queryVariables,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsIndividualsCountRetrieve,
+      selectedProgramIndividualsCountParams,
+    ),
     queryFn: () =>
       RestService.restBusinessAreasProgramsIndividualsCountRetrieve(
-        createApiParams(
-          { businessAreaSlug: businessArea, programCode: programId },
-          queryVariables,
-        ),
+        selectedProgramIndividualsCountParams,
       ),
     enabled: !!businessArea && !!programId && !isAllPrograms && page === 0,
   });
 
   // All Programs Individuals
+  const allProgramsIndividualsParams = createApiParams(
+    { businessAreaSlug: businessArea },
+    queryVariables,
+    { withPagination: true },
+  );
   const {
     data: allProgramsIndividualsData,
     isLoading: isLoadingAllPrograms,
     isFetching: isFetchingAllPrograms,
     error: errorAllPrograms,
   } = useQuery<PaginatedIndividualListList>({
-    queryKey: ['businessAreasIndividualsList', queryVariables, businessArea],
-    queryFn: () => {
-      return RestService.restBusinessAreasIndividualsList(
-        createApiParams({ businessAreaSlug: businessArea }, queryVariables, {
-          withPagination: true,
-        }),
-      );
-    },
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasIndividualsList,
+      allProgramsIndividualsParams,
+    ),
+    queryFn: () =>
+      RestService.restBusinessAreasIndividualsList(allProgramsIndividualsParams),
     enabled: !!businessArea && isAllPrograms,
     placeholderData: keepPreviousData,
   });
 
   // All Programs Count
+  const allProgramsIndividualsCountParams = createApiParams(
+    { businessAreaSlug: businessArea },
+    queryVariables,
+  );
   const { data: allProgramsIndividualsCount } = useQuery<CountResponse>({
-    queryKey: [
-      'businessAreasIndividualsCountRetrieve',
-      businessArea,
-      queryVariables,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasIndividualsCountRetrieve,
+      allProgramsIndividualsCountParams,
+    ),
     queryFn: () =>
       RestService.restBusinessAreasIndividualsCountRetrieve(
-        createApiParams({ businessAreaSlug: businessArea }, queryVariables),
+        allProgramsIndividualsCountParams,
       ),
     enabled: !!businessArea && isAllPrograms && page === 0,
   });

--- a/src/frontend/src/components/grievances/LookUps/LookUpIndividualTable/LookUpIndividualTable.tsx
+++ b/src/frontend/src/components/grievances/LookUps/LookUpIndividualTable/LookUpIndividualTable.tsx
@@ -7,7 +7,7 @@ import { IndividualList } from '@restgenerated/models/IndividualList';
 import { PaginatedIndividualListList } from '@restgenerated/models/PaginatedIndividualListList';
 import { RdiMergeStatusEnum } from '@restgenerated/models/RdiMergeStatusEnum';
 import { RestService } from '@restgenerated/services/RestService';
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { createApiParams } from '@utils/apiUtils';
 import { PROGRAM_STATE_FILTER } from '@utils/constants';
 import { adjustHeadCells } from '@utils/utils';
@@ -151,6 +151,7 @@ export function LookUpIndividualTable({
         ),
       ),
     enabled: !!businessArea && !!programId && !isAllPrograms,
+    placeholderData: keepPreviousData,
   });
 
   // Selected Program Count
@@ -186,6 +187,7 @@ export function LookUpIndividualTable({
       );
     },
     enabled: !!businessArea && isAllPrograms,
+    placeholderData: keepPreviousData,
   });
 
   // All Programs Count

--- a/src/frontend/src/components/grievances/LookUps/LookUpLinkedTickets/LinkedTicketIdDisplay.tsx
+++ b/src/frontend/src/components/grievances/LookUps/LookUpLinkedTickets/LinkedTicketIdDisplay.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { BlueText } from '../LookUpStyles';
 import { ReactElement } from 'react';
@@ -12,7 +13,10 @@ export function LinkedTicketIdDisplay({
   const { businessArea } = useBaseUrl();
 
   const { data } = useQuery({
-    queryKey: ['grievanceTicket', ticketId, businessArea],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasGrievanceTicketsRetrieve,
+      { businessAreaSlug: businessArea, id: ticketId },
+    ),
     queryFn: () =>
       RestService.restBusinessAreasGrievanceTicketsRetrieve({
         businessAreaSlug: businessArea,

--- a/src/frontend/src/components/grievances/LookUps/LookUpLinkedTickets/LookUpLinkedTicketsModal.tsx
+++ b/src/frontend/src/components/grievances/LookUps/LookUpLinkedTickets/LookUpLinkedTicketsModal.tsx
@@ -19,6 +19,7 @@ import { LoadingComponent } from '@core/LoadingComponent';
 import { LookUpLinkedTicketsFilters } from '../LookUpLinkedTicketsTable/LookUpLinkedTicketsFilters';
 import { LookUpLinkedTicketsTable } from '../LookUpLinkedTicketsTable/LookUpLinkedTicketsTable';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useQuery } from '@tanstack/react-query';
 
 export const LookUpLinkedTicketsModal = ({
@@ -31,7 +32,10 @@ export const LookUpLinkedTicketsModal = ({
   const { t } = useTranslation();
   const location = useLocation();
   const { data: choicesData, isLoading: choicesLoading } = useQuery({
-    queryKey: ['businessAreasGrievanceTicketsChoices', businessArea],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasGrievanceTicketsChoicesRetrieve,
+      { businessAreaSlug: businessArea },
+    ),
     queryFn: () =>
       RestService.restBusinessAreasGrievanceTicketsChoicesRetrieve({
         businessAreaSlug: businessArea,

--- a/src/frontend/src/components/grievances/LookUps/LookUpLinkedTicketsTable/LookUpLinkedTicketsTable.tsx
+++ b/src/frontend/src/components/grievances/LookUps/LookUpLinkedTicketsTable/LookUpLinkedTicketsTable.tsx
@@ -5,6 +5,7 @@ import { GrievanceTicketList } from '@restgenerated/models/GrievanceTicketList';
 import { PaginatedGrievanceTicketListList } from '@restgenerated/models/PaginatedGrievanceTicketListList';
 import { CountResponse } from '@restgenerated/models/CountResponse';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { choicesToDict, dateToIsoString } from '@utils/utils';
 import { createApiParams } from '@utils/apiUtils';
@@ -73,14 +74,23 @@ export function LookUpLinkedTicketsTable({
 
   const { data, isLoading, isFetching, error } =
     useQuery<PaginatedGrievanceTicketListList>({
-      queryKey: [
-        programId
-          ? 'businessAreasProgramsGrievanceTicketsList'
-          : 'businessAreasGrievanceTicketsList',
-        queryVariables,
-        businessArea,
-        programId,
-      ],
+      queryKey: programId
+        ? restQueryKey(
+            RestService.restBusinessAreasProgramsGrievanceTicketsList,
+            createApiParams(
+              { businessAreaSlug: businessArea, programCode: programId },
+              queryVariables,
+              { withPagination: true },
+            ),
+          )
+        : restQueryKey(
+            RestService.restBusinessAreasGrievanceTicketsList,
+            createApiParams(
+              { businessAreaSlug: businessArea },
+              queryVariables,
+              { withPagination: true },
+            ),
+          ),
       queryFn: () => {
         if (programId) {
           return RestService.restBusinessAreasProgramsGrievanceTicketsList(
@@ -105,14 +115,18 @@ export function LookUpLinkedTicketsTable({
     });
 
   const { data: countData } = useQuery<CountResponse>({
-    queryKey: [
-      programId
-        ? 'businessAreasProgramsGrievanceTicketsCount'
-        : 'businessAreasGrievanceTicketsCount',
-      businessArea,
-      programId,
-      queryVariables,
-    ],
+    queryKey: programId
+      ? restQueryKey(
+          RestService.restBusinessAreasProgramsGrievanceTicketsCountRetrieve,
+          createApiParams(
+            { businessAreaSlug: businessArea, programCode: programId },
+            queryVariables,
+          ),
+        )
+      : restQueryKey(
+          RestService.restBusinessAreasGrievanceTicketsCountRetrieve,
+          createApiParams({ businessAreaSlug: businessArea }, queryVariables),
+        ),
     queryFn: () => {
       if (programId) {
         return RestService.restBusinessAreasProgramsGrievanceTicketsCountRetrieve(

--- a/src/frontend/src/components/grievances/LookUps/LookUpLinkedTicketsTable/LookUpLinkedTicketsTable.tsx
+++ b/src/frontend/src/components/grievances/LookUps/LookUpLinkedTicketsTable/LookUpLinkedTicketsTable.tsx
@@ -30,7 +30,10 @@ export function LookUpLinkedTicketsTable({
 }: LookUpLinkedTicketsTableProps): ReactElement {
   const { data: choicesData, isLoading: choicesLoading } =
     useQuery<GrievanceChoices>({
-      queryKey: ['businessAreasGrievanceTicketsChoices', businessArea],
+      queryKey: restQueryKey(
+        RestService.restBusinessAreasGrievanceTicketsChoicesRetrieve,
+        { businessAreaSlug: businessArea },
+      ),
       queryFn: () =>
         RestService.restBusinessAreasGrievanceTicketsChoicesRetrieve({
           businessAreaSlug: businessArea,

--- a/src/frontend/src/components/grievances/LookUps/LookUpLinkedTicketsTable/LookUpLinkedTicketsTable.tsx
+++ b/src/frontend/src/components/grievances/LookUps/LookUpLinkedTicketsTable/LookUpLinkedTicketsTable.tsx
@@ -5,7 +5,7 @@ import { GrievanceTicketList } from '@restgenerated/models/GrievanceTicketList';
 import { PaginatedGrievanceTicketListList } from '@restgenerated/models/PaginatedGrievanceTicketListList';
 import { CountResponse } from '@restgenerated/models/CountResponse';
 import { RestService } from '@restgenerated/services/RestService';
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { choicesToDict, dateToIsoString } from '@utils/utils';
 import { createApiParams } from '@utils/apiUtils';
 import { MouseEvent, ReactElement, useState, useEffect, useMemo } from 'react';
@@ -100,6 +100,7 @@ export function LookUpLinkedTicketsTable({
           );
         }
       },
+      placeholderData: keepPreviousData,
       enabled: !choicesLoading && !!choicesData,
     },
   );

--- a/src/frontend/src/components/grievances/LookUps/LookUpLinkedTicketsTable/LookUpLinkedTicketsTable.tsx
+++ b/src/frontend/src/components/grievances/LookUps/LookUpLinkedTicketsTable/LookUpLinkedTicketsTable.tsx
@@ -71,8 +71,8 @@ export function LookUpLinkedTicketsTable({
 
   const [selected, setSelected] = useState(initialValues.selectedLinkedTickets);
 
-  const { data, isLoading, error } = useQuery<PaginatedGrievanceTicketListList>(
-    {
+  const { data, isLoading, isFetching, error } =
+    useQuery<PaginatedGrievanceTicketListList>({
       queryKey: [
         programId
           ? 'businessAreasProgramsGrievanceTicketsList'
@@ -102,8 +102,7 @@ export function LookUpLinkedTicketsTable({
       },
       placeholderData: keepPreviousData,
       enabled: !choicesLoading && !!choicesData,
-    },
-  );
+    });
 
   const { data: countData } = useQuery<CountResponse>({
     queryKey: [
@@ -193,6 +192,7 @@ export function LookUpLinkedTicketsTable({
         data={data}
         error={error}
         isLoading={isLoading}
+        isFetching={isFetching}
         queryVariables={queryVariables}
         setQueryVariables={setQueryVariables}
         itemsCount={countData?.count}

--- a/src/frontend/src/components/grievances/LookUps/LookUpPaymentRecordTable/LookUpPaymentRecordTable.tsx
+++ b/src/frontend/src/components/grievances/LookUps/LookUpPaymentRecordTable/LookUpPaymentRecordTable.tsx
@@ -50,6 +50,7 @@ export function LookUpPaymentRecordTable({
   const {
     data: paymentsData,
     isLoading,
+    isFetching,
     error,
   } = useQuery<PaginatedPaymentListList>({
     queryKey: [
@@ -175,6 +176,7 @@ export function LookUpPaymentRecordTable({
         headCells={headCells}
         data={paymentsData}
         isLoading={isLoading}
+        isFetching={isFetching}
         error={error}
         queryVariables={queryVariables}
         setQueryVariables={setQueryVariables}
@@ -206,6 +208,7 @@ export function LookUpPaymentRecordTable({
       numSelected={numSelected}
       data={paymentsData}
       isLoading={isLoading}
+      isFetching={isFetching}
       error={error}
       queryVariables={queryVariables}
       setQueryVariables={setQueryVariables}

--- a/src/frontend/src/components/grievances/LookUps/LookUpPaymentRecordTable/LookUpPaymentRecordTable.tsx
+++ b/src/frontend/src/components/grievances/LookUps/LookUpPaymentRecordTable/LookUpPaymentRecordTable.tsx
@@ -7,6 +7,7 @@ import { UniversalRestTable } from '@components/rest/UniversalRestTable/Universa
 import { PaginatedPaymentListList } from '@restgenerated/models/PaginatedPaymentListList';
 import { PaymentList } from '@restgenerated/models/PaymentList';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { createApiParams } from '@utils/apiUtils';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 
@@ -53,17 +54,32 @@ export function LookUpPaymentRecordTable({
     isFetching,
     error,
   } = useQuery<PaginatedPaymentListList>({
-    queryKey: [
+    queryKey:
       programId === 'all' || !programId
-        ? 'businessAreasPaymentsList'
-        : 'businessAreasProgramsPaymentsList',
-      queryVariables,
-      initialValues?.selectedHousehold?.unicefId,
-      initialValues?.selectedIndividual?.unicefId,
-      businessArea,
-      programId,
-      programId === 'all' || !programId ? globalPage : programPage,
-    ],
+        ? restQueryKey(
+            RestService.restBusinessAreasPaymentsList,
+            createApiParams(
+              {
+                businessAreaSlug: businessArea,
+              },
+              {},
+              { withPagination: true },
+            ),
+          )
+        : restQueryKey(
+            RestService.restBusinessAreasProgramsPaymentsList,
+            createApiParams(
+              {
+                householdUnicefId: initialValues?.selectedHousehold?.unicefId,
+                individualUnicefId:
+                  initialValues?.selectedIndividual?.unicefId,
+                businessAreaSlug: businessArea,
+                code: programId,
+              },
+              {},
+              { withPagination: true },
+            ),
+          ),
     queryFn: () => {
       // Use global payments API when programId is 'all' or not available
       if (programId === 'all' || !programId) {
@@ -95,46 +111,41 @@ export function LookUpPaymentRecordTable({
   });
 
   // Count queries for global and program payments
+  const globalPaymentsCountParams = createApiParams(
+    {
+      businessAreaSlug: businessArea,
+    },
+    {},
+  );
   const { data: globalCountData } = useQuery({
-    queryKey: [
-      'businessAreasPaymentsCount',
-      queryVariables,
-      businessArea,
-      globalPage,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasPaymentsCountRetrieve,
+      globalPaymentsCountParams,
+    ),
     queryFn: () =>
       RestService.restBusinessAreasPaymentsCountRetrieve(
-        createApiParams(
-          {
-            businessAreaSlug: businessArea,
-          },
-          {},
-        ),
+        globalPaymentsCountParams,
       ),
     enabled: (programId === 'all' || !programId) && globalPage === 0,
   });
 
+  const programPaymentsCountParams = createApiParams(
+    {
+      householdUnicefId: initialValues?.selectedHousehold?.unicefId,
+      individualUnicefId: initialValues?.selectedIndividual?.unicefId,
+      businessAreaSlug: businessArea,
+      code: programId,
+    },
+    {},
+  );
   const { data: programCountData } = useQuery({
-    queryKey: [
-      'businessAreasProgramsPaymentsCount',
-      queryVariables,
-      initialValues?.selectedHousehold?.unicefId,
-      initialValues?.selectedIndividual?.unicefId,
-      businessArea,
-      programId,
-      programPage,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsPaymentsCountRetrieve,
+      programPaymentsCountParams,
+    ),
     queryFn: () =>
       RestService.restBusinessAreasProgramsPaymentsCountRetrieve(
-        createApiParams(
-          {
-            householdUnicefId: initialValues?.selectedHousehold?.unicefId,
-            individualUnicefId: initialValues?.selectedIndividual?.unicefId,
-            businessAreaSlug: businessArea,
-            code: programId,
-          },
-          {},
-        ),
+        programPaymentsCountParams,
       ),
     enabled: programId !== 'all' && !!programId && programPage === 0,
   });

--- a/src/frontend/src/components/grievances/LookUps/LookUpPaymentRecordTable/LookUpPaymentRecordTable.tsx
+++ b/src/frontend/src/components/grievances/LookUps/LookUpPaymentRecordTable/LookUpPaymentRecordTable.tsx
@@ -8,7 +8,7 @@ import { PaginatedPaymentListList } from '@restgenerated/models/PaginatedPayment
 import { PaymentList } from '@restgenerated/models/PaymentList';
 import { RestService } from '@restgenerated/services/RestService';
 import { createApiParams } from '@utils/apiUtils';
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 
 interface LookUpPaymentRecordTableProps {
   openInNewTab?: boolean;
@@ -90,6 +90,7 @@ export function LookUpPaymentRecordTable({
         ),
       );
     },
+    placeholderData: keepPreviousData,
   });
 
   // Count queries for global and program payments

--- a/src/frontend/src/components/grievances/LookUps/LookUpReassignRole/LookUpReassignRole.tsx
+++ b/src/frontend/src/components/grievances/LookUps/LookUpReassignRole/LookUpReassignRole.tsx
@@ -2,6 +2,7 @@ import { LoadingComponent } from '@core/LoadingComponent';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { IndividualDetail } from '@restgenerated/models/IndividualDetail';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useQuery } from '@tanstack/react-query';
 import { GRIEVANCE_CATEGORIES, GRIEVANCE_ISSUE_TYPES } from '@utils/constants';
 import { Formik } from 'formik';
@@ -37,20 +38,21 @@ export function LookUpReassignRole({
   );
   const { businessArea, programId } = useBaseUrl();
 
+  const individualParams = {
+    businessAreaSlug: businessArea,
+    programCode: programId,
+    id: selectedIndividualId,
+  };
   const { data: individual, isLoading: loadingIndividual } =
     useQuery<IndividualDetail>({
-      queryKey: [
-        'businessAreaProgramIndividual',
-        businessArea,
-        programId,
-        selectedIndividualId,
-      ],
+      queryKey: restQueryKey(
+        RestService.restBusinessAreasProgramsIndividualsRetrieve,
+        individualParams,
+      ),
       queryFn: () =>
-        RestService.restBusinessAreasProgramsIndividualsRetrieve({
-          businessAreaSlug: businessArea,
-          programCode: programId,
-          id: selectedIndividualId,
-        }),
+        RestService.restBusinessAreasProgramsIndividualsRetrieve(
+          individualParams,
+        ),
       enabled: !!selectedIndividualId,
     });
   const [lookUpDialogOpen, setLookUpDialogOpen] = useState<boolean>(false);

--- a/src/frontend/src/components/grievances/LookUps/LookUpReassignRole/LookUpReassignRoleModal.tsx
+++ b/src/frontend/src/components/grievances/LookUps/LookUpReassignRole/LookUpReassignRoleModal.tsx
@@ -85,7 +85,10 @@ export function LookUpReassignRoleModal({
 
   const { data: individualChoicesData, isLoading: individualChoicesLoading } =
     useQuery<IndividualChoices>({
-      queryKey: ['individualChoices', businessArea],
+      queryKey: restQueryKey(
+        RestService.restBusinessAreasIndividualsChoicesRetrieve,
+        { businessAreaSlug: businessArea },
+      ),
       queryFn: () =>
         RestService.restBusinessAreasIndividualsChoicesRetrieve({
           businessAreaSlug: businessArea,

--- a/src/frontend/src/components/grievances/LookUps/LookUpReassignRole/LookUpReassignRoleModal.tsx
+++ b/src/frontend/src/components/grievances/LookUps/LookUpReassignRole/LookUpReassignRoleModal.tsx
@@ -15,6 +15,7 @@ import {
 import { IndividualChoices } from '@restgenerated/models/IndividualChoices';
 import { GrievanceReassignRole } from '@restgenerated/models/GrievanceReassignRole';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { FormikCheckboxField } from '@shared/Formik/FormikCheckboxField';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { getFilterFromQueryParams, showApiErrorMessages } from '@utils/utils';
@@ -71,7 +72,9 @@ export function LookUpReassignRoleModal({
     },
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: ['businessAreasGrievanceTicketsRetrieve', businessArea, id],
+        queryKey: restQueryKey(
+          RestService.restBusinessAreasGrievanceTicketsRetrieve,
+        ),
       });
       showMessage(t('Role Reassigned'));
     },

--- a/src/frontend/src/components/grievances/LookUps/LookUpReassignRole/ReassignRoleUnique.tsx
+++ b/src/frontend/src/components/grievances/LookUps/LookUpReassignRole/ReassignRoleUnique.tsx
@@ -8,6 +8,7 @@ import { useProgramContext } from 'src/programContext';
 import { ReactElement } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { GrievanceReassignRole } from '@restgenerated/models/GrievanceReassignRole';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { showApiErrorMessages } from '@utils/utils';
@@ -54,7 +55,9 @@ export function ReassignRoleUnique({
         }),
       onSuccess: () => {
         queryClient.invalidateQueries({
-          queryKey: ['businessAreasGrievanceTicketsRetrieve', businessArea, id],
+          queryKey: restQueryKey(
+            RestService.restBusinessAreasGrievanceTicketsRetrieve,
+          ),
         });
         showMessage(t('Role Reassigned'));
       },

--- a/src/frontend/src/components/grievances/NeedsAdjudication/NeedsAdjudicationDetailsOld.tsx
+++ b/src/frontend/src/components/grievances/NeedsAdjudication/NeedsAdjudicationDetailsOld.tsx
@@ -13,6 +13,7 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { GRIEVANCE_TICKET_STATES } from '@utils/constants';
 import { BlackLink } from '@core/BlackLink';
@@ -35,7 +36,7 @@ export const NeedsAdjudicationDetailsOld = ({
   canApprove: boolean;
 }): ReactElement => {
   const { t } = useTranslation();
-  const { businessAreaSlug, baseUrl, isAllPrograms } = useBaseUrl();
+  const { baseUrl, isAllPrograms } = useBaseUrl();
   const navigate = useNavigate();
   const confirm = useConfirmation();
   const { isActiveProgram } = useProgramContext();
@@ -62,11 +63,9 @@ export const NeedsAdjudicationDetailsOld = ({
     onSuccess: () => {
       // Invalidate and refetch the grievance ticket details
       queryClient.invalidateQueries({
-        queryKey: [
-          'businessAreasGrievanceTicketsRetrieve',
-          businessAreaSlug,
-          ticket.id,
-        ],
+        queryKey: restQueryKey(
+          RestService.restBusinessAreasGrievanceTicketsRetrieve,
+        ),
       });
     },
   });

--- a/src/frontend/src/components/grievances/Notes/Notes.tsx
+++ b/src/frontend/src/components/grievances/Notes/Notes.tsx
@@ -47,13 +47,17 @@ export function Notes({
   const { businessAreaSlug, programCode } = useBaseUrl();
   const { showMessage } = useSnackbar();
 
+  const profileParams = {
+    businessAreaSlug,
+    program: programCode === 'all' ? undefined : programCode,
+  };
   const { data: meData, isLoading: meLoading } = useQuery({
-    queryKey: ['profile', businessAreaSlug, programCode],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasUsersProfileRetrieve,
+      profileParams,
+    ),
     queryFn: () => {
-      return RestService.restBusinessAreasUsersProfileRetrieve({
-        businessAreaSlug,
-        program: programCode === 'all' ? undefined : programCode,
-      });
+      return RestService.restBusinessAreasUsersProfileRetrieve(profileParams);
     },
     staleTime: 5 * 60 * 1000, // Data is considered fresh for 5 minutes
     gcTime: 30 * 60 * 1000, // Keep unused data in cache for 30 minutes

--- a/src/frontend/src/components/grievances/Notes/Notes.tsx
+++ b/src/frontend/src/components/grievances/Notes/Notes.tsx
@@ -13,6 +13,7 @@ import { useProgramContext } from '../../../programContext';
 import { ReactElement } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { GrievanceTicketDetail } from '@restgenerated/models/GrievanceTicketDetail';
 import { GrievanceCreateNote } from '@restgenerated/models/GrievanceCreateNote';
@@ -73,11 +74,9 @@ export function Notes({
     },
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: [
-          'businessAreasGrievanceTicketsRetrieve',
-          businessAreaSlug,
-          id,
-        ],
+        queryKey: restQueryKey(
+          RestService.restBusinessAreasGrievanceTicketsRetrieve,
+        ),
       });
     },
     onError: (error: any) => {

--- a/src/frontend/src/components/grievances/OtherRelatedTicketsCreate.tsx
+++ b/src/frontend/src/components/grievances/OtherRelatedTicketsCreate.tsx
@@ -3,6 +3,7 @@ import { ReactElement, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useQuery } from '@tanstack/react-query';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { GRIEVANCE_TICKET_STATES } from '@utils/constants';
 import { decodeIdString } from '@utils/utils';
@@ -24,19 +25,19 @@ export function OtherRelatedTicketsCreate({ values }): ReactElement {
   const beneficiaryGroup = selectedProgram?.beneficiaryGroup;
   const [show, setShow] = useState(false);
 
+  const grievanceTicketsParams = {
+    businessAreaSlug,
+    household:
+      decodeIdString(values?.selectedHousehold?.id) ||
+      '294cfa7e-b16f-4331-8014-a22ffb2b8b3c',
+  };
   const { data, isLoading } = useQuery({
-    queryKey: [
-      'grievanceTickets',
-      businessAreaSlug,
-      values?.selectedHousehold?.id,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasGrievanceTicketsList,
+      grievanceTicketsParams,
+    ),
     queryFn: () =>
-      RestService.restBusinessAreasGrievanceTicketsList({
-        businessAreaSlug,
-        household:
-          decodeIdString(values?.selectedHousehold?.id) ||
-          '294cfa7e-b16f-4331-8014-a22ffb2b8b3c',
-      }),
+      RestService.restBusinessAreasGrievanceTicketsList(grievanceTicketsParams),
     enabled: !!businessAreaSlug,
   });
   if (isLoading) return <LoadingComponent />;

--- a/src/frontend/src/components/grievances/PaymentGrievance/PaymentGrievanceDetails/PaymentGrievanceDetails.tsx
+++ b/src/frontend/src/components/grievances/PaymentGrievance/PaymentGrievanceDetails/PaymentGrievanceDetails.tsx
@@ -22,6 +22,7 @@ import { ReactElement } from 'react';
 import { GrievanceTicketDetail } from '@restgenerated/models/GrievanceTicketDetail';
 import { GrievanceUpdateApproveStatus } from '@restgenerated/models/GrievanceUpdateApproveStatus';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { formatFigure, showApiErrorMessages } from '@utils/utils';
 
@@ -73,11 +74,9 @@ export function PaymentGrievanceDetails({
     },
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: [
-          'businessAreasGrievanceTicketsRetrieve',
-          businessArea,
-          ticket.id,
-        ],
+        queryKey: restQueryKey(
+          RestService.restBusinessAreasGrievanceTicketsRetrieve,
+        ),
       });
     },
     onError: (error: any) => {

--- a/src/frontend/src/components/grievances/PaymentGrievance/VerifyPaymentGrievance/VerifyPaymentGrievance.tsx
+++ b/src/frontend/src/components/grievances/PaymentGrievance/VerifyPaymentGrievance/VerifyPaymentGrievance.tsx
@@ -16,6 +16,7 @@ import { AutoSubmitFormOnEnter } from '@core/AutoSubmitFormOnEnter';
 import { GrievanceTicketDetail } from '@restgenerated/models/GrievanceTicketDetail';
 import { PatchedUpdateGrievanceTicket } from '@restgenerated/models/PatchedUpdateGrievanceTicket';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { showApiErrorMessages } from '@utils/utils';
 
 export interface VerifyPaymentGrievanceProps {
@@ -51,7 +52,9 @@ export function VerifyPaymentGrievance({
       setVerifyManualDialogOpen(false);
       showMessage(t('Payment has been verified.'));
       queryClient.invalidateQueries({
-        queryKey: ['businessAreasGrievanceTicketsRetrieve', businessArea, ticket.id],
+        queryKey: restQueryKey(
+          RestService.restBusinessAreasGrievanceTicketsRetrieve,
+        ),
       });
     },
     onError: (error: any) => {

--- a/src/frontend/src/components/grievances/PaymentGrievance/VerifyPaymentGrievance/VerifyPaymentGrievance.tsx
+++ b/src/frontend/src/components/grievances/PaymentGrievance/VerifyPaymentGrievance/VerifyPaymentGrievance.tsx
@@ -51,7 +51,7 @@ export function VerifyPaymentGrievance({
       setVerifyManualDialogOpen(false);
       showMessage(t('Payment has been verified.'));
       queryClient.invalidateQueries({
-        queryKey: ['GrievanceTicketDetail', ticket.id],
+        queryKey: ['businessAreasGrievanceTicketsRetrieve', businessArea, ticket.id],
       });
     },
     onError: (error: any) => {

--- a/src/frontend/src/components/grievances/RequestedHouseholdDataChange.tsx
+++ b/src/frontend/src/components/grievances/RequestedHouseholdDataChange.tsx
@@ -5,6 +5,7 @@ import { useBaseUrl } from '@hooks/useBaseUrl';
 import { GrievanceTicketDetail } from '@restgenerated/models/GrievanceTicketDetail';
 import { GrievanceHouseholdDataChangeApprove } from '@restgenerated/models/GrievanceHouseholdDataChangeApprove';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { GRIEVANCE_TICKET_STATES } from '@utils/constants';
 import { ApproveBox } from './GrievancesApproveSection/ApproveSectionStyles';
 import { Title } from '@core/Title';
@@ -65,11 +66,9 @@ export function RequestedHouseholdDataChange({
     onSuccess: () => {
       showMessage('Changes Approved');
       queryClient.invalidateQueries({
-        queryKey: [
-          'businessAreasGrievanceTicketsRetrieve',
-          businessArea,
-          ticket.id,
-        ],
+        queryKey: restQueryKey(
+          RestService.restBusinessAreasGrievanceTicketsRetrieve,
+        ),
       });
     },
     onError: (error: any) => {

--- a/src/frontend/src/components/grievances/RequestedHouseholdDataChangeTable/CurrentValue.tsx
+++ b/src/frontend/src/components/grievances/RequestedHouseholdDataChangeTable/CurrentValue.tsx
@@ -2,6 +2,7 @@ import { GrievanceFlexFieldPhotoModal } from '../GrievancesPhotoModals/Grievance
 import { ReactElement } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 
 export interface CurrentValueProps {
@@ -23,7 +24,9 @@ export function CurrentValue({
   const { businessArea } = useBaseUrl();
 
   const { data: areasData } = useQuery({
-    queryKey: ['adminAreas', businessArea],
+    queryKey: restQueryKey(RestService.restBusinessAreasGeoAreasList, {
+      businessAreaSlug: businessArea,
+    }),
     queryFn: () =>
       RestService.restBusinessAreasGeoAreasList({
         businessAreaSlug: businessArea,

--- a/src/frontend/src/components/grievances/RequestedHouseholdDataChangeTable/NewValue.tsx
+++ b/src/frontend/src/components/grievances/RequestedHouseholdDataChangeTable/NewValue.tsx
@@ -2,6 +2,7 @@ import { GrievanceFlexFieldPhotoModal } from '../GrievancesPhotoModals/Grievance
 import { ReactElement } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 
 export interface NewValueProps {
@@ -20,7 +21,9 @@ export function NewValue({ field, value }: NewValueProps): ReactElement {
   const { businessArea } = useBaseUrl();
 
   const { data: areasData } = useQuery({
-    queryKey: ['adminAreas', businessArea],
+    queryKey: restQueryKey(RestService.restBusinessAreasGeoAreasList, {
+      businessAreaSlug: businessArea,
+    }),
     queryFn: () =>
       RestService.restBusinessAreasGeoAreasList({
         businessAreaSlug: businessArea,

--- a/src/frontend/src/components/grievances/RequestedHouseholdDataChangeTable/RequestedHouseholdDataChangeTable.tsx
+++ b/src/frontend/src/components/grievances/RequestedHouseholdDataChangeTable/RequestedHouseholdDataChangeTable.tsx
@@ -2,6 +2,7 @@ import withErrorBoundary from '@components/core/withErrorBoundary';
 import { useArrayToDict } from '@hooks/useArrayToDict';
 import React, { ReactElement } from 'react';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import { Checkbox } from '@mui/material';
 import Table from '@mui/material/Table';
@@ -40,25 +41,23 @@ function RequestedHouseholdDataChangeTable(
   const { setFieldValue, ticket, isEdit, values } = props;
   const householdId = ticket.household?.id;
 
+  const householdParams = {
+    businessAreaSlug: businessArea,
+    id: householdId,
+    //@ts-ignore
+    programCode: ticket.household.programCode,
+  };
   const {
     data: household,
     isLoading: householdLoading,
     error,
   } = useQuery<HouseholdDetail>({
-    queryKey: [
-      'household',
-      businessArea,
-      householdId,
-      //@ts-ignore
-      ticket.household.programCode,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsHouseholdsRetrieve,
+      householdParams,
+    ),
     queryFn: () =>
-      RestService.restBusinessAreasProgramsHouseholdsRetrieve({
-        businessAreaSlug: businessArea,
-        id: householdId,
-        //@ts-ignore
-        programCode: ticket.household.programCode,
-      }),
+      RestService.restBusinessAreasProgramsHouseholdsRetrieve(householdParams),
     enabled: Boolean(householdId && businessArea),
   });
   const selectedBioData = values.selected;
@@ -85,7 +84,10 @@ function RequestedHouseholdDataChangeTable(
   );
 
   const { data: allEditHouseholdFieldsData } = useQuery({
-    queryKey: ['allEditHouseholdFieldsAttributes', businessArea],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasGrievanceTicketsAllEditHouseholdFieldsAttributesList,
+      { businessAreaSlug: businessArea },
+    ),
     queryFn: () =>
       RestService.restBusinessAreasGrievanceTicketsAllEditHouseholdFieldsAttributesList(
         { businessAreaSlug: businessArea },
@@ -101,7 +103,7 @@ function RequestedHouseholdDataChangeTable(
   );
 
   const { data: countriesChoicesData } = useQuery({
-    queryKey: ['restChoicesCountriesList'],
+    queryKey: restQueryKey(RestService.restChoicesCountriesList),
     queryFn: () => RestService.restChoicesCountriesList(),
     enabled: true,
   });

--- a/src/frontend/src/components/grievances/RequestedIndividualDataChange.tsx
+++ b/src/frontend/src/components/grievances/RequestedIndividualDataChange.tsx
@@ -17,6 +17,7 @@ import { RequestedIndividualDataChangeTable } from './RequestedIndividualDataCha
 import { GrievanceTicketDetail } from '@restgenerated/models/GrievanceTicketDetail';
 import { GrievanceIndividualDataChangeApprove } from '@restgenerated/models/GrievanceIndividualDataChangeApprove';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { IndividualDetail } from '@restgenerated/models/IndividualDetail';
 import { HouseholdDetail } from '@restgenerated/models/HouseholdDetail';
 import { ApproveBox } from '@components/grievances/GrievancesApproveSection/ApproveSectionStyles';
@@ -37,7 +38,6 @@ export function RequestedIndividualDataChange({
   canApproveDataChange: boolean;
 }): ReactElement {
   const { t } = useTranslation();
-  const { businessAreaSlug } = useBaseUrl();
   const { showMessage } = useSnackbar();
   const confirm = useConfirmation();
   const queryClient = useQueryClient();
@@ -144,11 +144,9 @@ export function RequestedIndividualDataChange({
     onSuccess: () => {
       showMessage('Changes Approved');
       queryClient.invalidateQueries({
-        queryKey: [
-          'businessAreasGrievanceTicketsRetrieve',
-          businessAreaSlug,
-          ticket.id,
-        ],
+        queryKey: restQueryKey(
+          RestService.restBusinessAreasGrievanceTicketsRetrieve,
+        ),
       });
     },
     onError: (error: any) => {

--- a/src/frontend/src/components/grievances/RequestedIndividualDataChangeTable/RequestedIndividualDataChangeTable.tsx
+++ b/src/frontend/src/components/grievances/RequestedIndividualDataChangeTable/RequestedIndividualDataChangeTable.tsx
@@ -13,6 +13,7 @@ import { AccountTable } from './AccountTable';
 import { GrievanceTicketDetail } from '@restgenerated/models/GrievanceTicketDetail';
 import { useQuery } from '@tanstack/react-query';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 
 interface RequestedIndividualDataChangeTableProps {
@@ -31,7 +32,10 @@ export function RequestedIndividualDataChangeTable({
   const { businessAreaSlug } = useBaseUrl();
 
   const { data: addIndividualFieldsData, isLoading: loading } = useQuery({
-    queryKey: ['addIndividualFieldsAttributes', businessAreaSlug],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasGrievanceTicketsAllAddIndividualsFieldsAttributesList,
+      { businessAreaSlug },
+    ),
     queryFn: () =>
       RestService.restBusinessAreasGrievanceTicketsAllAddIndividualsFieldsAttributesList(
         {
@@ -42,7 +46,10 @@ export function RequestedIndividualDataChangeTable({
 
   const { data: individualChoicesData, isLoading: individualChoicesLoading } =
     useQuery({
-      queryKey: ['individualChoices', businessAreaSlug],
+      queryKey: restQueryKey(
+        RestService.restBusinessAreasIndividualsChoicesRetrieve,
+        { businessAreaSlug },
+      ),
       queryFn: () =>
         RestService.restBusinessAreasIndividualsChoicesRetrieve({
           businessAreaSlug,
@@ -50,24 +57,25 @@ export function RequestedIndividualDataChangeTable({
     });
 
   const { data: countriesData, isLoading: countriesLoading } = useQuery({
-    queryKey: ['countriesList'],
+    queryKey: restQueryKey(RestService.restChoicesCountriesList),
     queryFn: () => RestService.restChoicesCountriesList(),
   });
 
+  const individualParams = {
+    businessAreaSlug,
+    programCode: ticket.individual.programCode,
+    id: ticket.individual.id,
+  };
   const { data: individual, isLoading: individualLoading } = useQuery({
-    queryKey: [
-      'individualChoices',
-      businessAreaSlug,
-      ticket.individual.id,
-      ticket.individual.programCode,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsIndividualsRetrieve,
+      individualParams,
+    ),
     queryFn: () => {
-      if (!ticket.individual.id) return null;
-      return RestService.restBusinessAreasProgramsIndividualsRetrieve({
-        businessAreaSlug,
-        programCode: ticket.individual.programCode,
-        id: ticket.individual.id,
-      });
+      if (!individualParams.id) return null;
+      return RestService.restBusinessAreasProgramsIndividualsRetrieve(
+        individualParams,
+      );
     },
   });
 

--- a/src/frontend/src/components/grievances/SanctionListIndividualsTable/SanctionListIndividualsTable.tsx
+++ b/src/frontend/src/components/grievances/SanctionListIndividualsTable/SanctionListIndividualsTable.tsx
@@ -1,5 +1,6 @@
 import { UniversalRestTable } from '@components/rest/UniversalRestTable/UniversalRestTable';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useQuery } from '@tanstack/react-query';
 import { SanctionListIndividualsTableRow } from './SanctionListIndividualsTableRow';
 import { headCells } from './SanctionListIndividualsHeadCells';
@@ -38,7 +39,10 @@ export function SanctionListIndividualsTable({
 
   const { data, isLoading, error } =
     useQuery<PaginatedSanctionListIndividualList>({
-      queryKey: ['restSanctionListList', queryVariables],
+      queryKey: restQueryKey(
+        RestService.restBusinessAreasSanctionListList,
+        queryVariables,
+      ),
       queryFn: () =>
         RestService.restBusinessAreasSanctionListList({ ...queryVariables }),
     });

--- a/src/frontend/src/components/grievances/TicketsAlreadyExist.tsx
+++ b/src/frontend/src/components/grievances/TicketsAlreadyExist.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 import { useQuery } from '@tanstack/react-query';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { decodeIdString } from '@utils/utils';
 import { ContentLink } from '@core/ContentLink';
@@ -34,27 +35,25 @@ export function TicketsAlreadyExist({ values }): ReactElement {
   const { baseUrl, businessAreaSlug } = useBaseUrl();
   const { t } = useTranslation();
 
+  const existingGrievanceTicketsParams = {
+    businessAreaSlug,
+    category: values.category,
+    issueType: values.issueType,
+    household: decodeIdString(values.selectedHousehold?.id),
+    individualId: decodeIdString(values.selectedIndividual?.id),
+    paymentRecordIds: Array.isArray(values.selectedPaymentRecords)
+      ? values.selectedPaymentRecords.map((r) => r.id).join(',')
+      : values.selectedPaymentRecords,
+  };
   const { data, isLoading: loading } = useQuery({
-    queryKey: [
-      'existingGrievanceTickets',
-      businessAreaSlug,
-      values.category,
-      values.issueType,
-      values.selectedHousehold?.id,
-      values.selectedIndividual?.id,
-      values.selectedPaymentRecords,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasGrievanceTicketsList,
+      existingGrievanceTicketsParams,
+    ),
     queryFn: () =>
-      RestService.restBusinessAreasGrievanceTicketsList({
-        businessAreaSlug,
-        category: values.category,
-        issueType: values.issueType,
-        household: decodeIdString(values.selectedHousehold?.id),
-        individualId: decodeIdString(values.selectedIndividual?.id),
-        paymentRecordIds: Array.isArray(values.selectedPaymentRecords)
-          ? values.selectedPaymentRecords.map((r) => r.id).join(',')
-          : values.selectedPaymentRecords,
-      }),
+      RestService.restBusinessAreasGrievanceTicketsList(
+        existingGrievanceTicketsParams,
+      ),
     enabled: !!(businessAreaSlug && values.category),
   });
 

--- a/src/frontend/src/components/paymentmodule/CreatePaymentPlan/CreatePaymentPlanHeader/CreatePaymentPlanHeader.tsx
+++ b/src/frontend/src/components/paymentmodule/CreatePaymentPlan/CreatePaymentPlanHeader/CreatePaymentPlanHeader.tsx
@@ -5,6 +5,7 @@ import { useBaseUrl } from '@hooks/useBaseUrl';
 import { Box, Button } from '@mui/material';
 import { ProgramCycleList } from '@restgenerated/models/ProgramCycleList';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useQuery } from '@tanstack/react-query';
 import { ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -26,20 +27,21 @@ export function CreatePaymentPlanHeader({
   const { businessArea, programId } = useBaseUrl();
   const { programCycleId } = useParams();
 
+  const programCycleParams = {
+    businessAreaSlug: businessArea,
+    id: programCycleId,
+    programCode: programId,
+  };
   const { data: programCycleData, isLoading: isLoadingProgramCycle } =
     useQuery<ProgramCycleList>({
-      queryKey: [
-        'programCyclesDetails',
-        businessArea,
-        programCycleId,
-        programId,
-      ],
+      queryKey: restQueryKey(
+        RestService.restBusinessAreasProgramsCyclesRetrieve,
+        programCycleParams,
+      ),
       queryFn: () => {
-        return RestService.restBusinessAreasProgramsCyclesRetrieve({
-          businessAreaSlug: businessArea,
-          id: programCycleId,
-          programCode: programId,
-        });
+        return RestService.restBusinessAreasProgramsCyclesRetrieve(
+          programCycleParams,
+        );
       },
     });
 

--- a/src/frontend/src/components/paymentmodule/CreatePaymentPlanGroupModal.tsx
+++ b/src/frontend/src/components/paymentmodule/CreatePaymentPlanGroupModal.tsx
@@ -13,6 +13,7 @@ import {
 import { PaymentPlanGroupCreate } from '@restgenerated/models/PaymentPlanGroupCreate';
 import { RestService } from '@restgenerated/index';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { showApiErrorMessages } from '@utils/utils';
 import { ReactElement, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -52,7 +53,9 @@ export const CreatePaymentPlanGroupModal = ({
       }),
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: ['paymentPlanGroupsList', businessArea, programId],
+        queryKey: restQueryKey(
+          RestService.restBusinessAreasProgramsPaymentPlanGroupsList,
+        ),
       });
     },
   });

--- a/src/frontend/src/components/paymentmodule/PaymentPlanDetails/ConversionToUsd/ConversionToUsd.test.tsx
+++ b/src/frontend/src/components/paymentmodule/PaymentPlanDetails/ConversionToUsd/ConversionToUsd.test.tsx
@@ -30,6 +30,7 @@ vi.mock('@restgenerated/services/RestService', () => ({
     restBusinessAreasProgramsPaymentPlansCustomExchangeRateCreate: vi.fn(() =>
       Promise.resolve({}),
     ),
+    restBusinessAreasProgramsPaymentPlansRetrieve: vi.fn(),
   },
 }));
 

--- a/src/frontend/src/components/paymentmodule/PaymentPlanDetails/ConversionToUsd/ConversionToUsd.tsx
+++ b/src/frontend/src/components/paymentmodule/PaymentPlanDetails/ConversionToUsd/ConversionToUsd.tsx
@@ -18,6 +18,7 @@ import { PaymentPlanDetail } from '@restgenerated/models/PaymentPlanDetail';
 import { PaymentPlanStatusEnum } from '@restgenerated/models/PaymentPlanStatusEnum';
 import { RestService } from '@restgenerated/services/RestService';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { showApiErrorMessages } from '@utils/utils';
 import { ReactElement, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -93,7 +94,7 @@ function ConversionToUsd({
         t('Exchange rate is being applied, please wait until completed'),
       );
       queryClient.invalidateQueries({
-        queryKey: ['paymentPlan', businessArea, paymentPlan.id, programId],
+        queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansRetrieve),
       });
     },
     onError: (error: any) => {

--- a/src/frontend/src/components/paymentmodule/PaymentPlanDetails/Entitlement/Entitlement.tsx
+++ b/src/frontend/src/components/paymentmodule/PaymentPlanDetails/Entitlement/Entitlement.tsx
@@ -28,6 +28,7 @@ import { PaymentPlanDetail } from '@restgenerated/models/PaymentPlanDetail';
 import { PaymentPlanStatusEnum } from '@restgenerated/models/PaymentPlanStatusEnum';
 import { RestService } from '@restgenerated/services/RestService';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { formatFigure, showApiErrorMessages } from '@utils/utils';
 import { ReactElement, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -139,7 +140,7 @@ function Entitlement({
       onSuccess: () => {
         showMessage(t('Formula is executing, please wait until completed'));
         queryClient.invalidateQueries({
-          queryKey: ['paymentPlan', businessArea, paymentPlan.id, programId],
+          queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansRetrieve),
         });
       },
       onError: (error: any) => {
@@ -173,7 +174,7 @@ function Entitlement({
           t('Flat amount is being applied, please wait until completed'),
         );
         queryClient.invalidateQueries({
-          queryKey: ['paymentPlan', businessArea, paymentPlan.id, programId],
+          queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansRetrieve),
         });
       },
       onError: (error: any) => {
@@ -213,7 +214,7 @@ function Entitlement({
     onSuccess: async () => {
       showMessage(t('Exporting XLSX started. Please check your email.'));
       await queryClient.invalidateQueries({
-        queryKey: ['paymentPlan', businessArea, paymentPlan.id, programId],
+        queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansRetrieve),
       });
     },
     onError: (error: any) => {

--- a/src/frontend/src/components/paymentmodule/PaymentPlanDetails/Entitlement/Entitlement.tsx
+++ b/src/frontend/src/components/paymentmodule/PaymentPlanDetails/Entitlement/Entitlement.tsx
@@ -182,16 +182,16 @@ function Entitlement({
       },
     });
 
+  const engineRulesParams = {
+    type: 'PAYMENT_PLAN' as const,
+    deprecated: false,
+    enabled: true,
+    businessArea: businessArea,
+  };
   const { data: steficonData, isLoading: loading } =
     useQuery<PaginatedRuleList>({
-      queryKey: ['engineRules', businessArea],
-      queryFn: () =>
-        RestService.restEngineRulesList({
-          type: 'PAYMENT_PLAN',
-          deprecated: false,
-          enabled: true,
-          businessArea: businessArea,
-        }),
+      queryKey: restQueryKey(RestService.restEngineRulesList, engineRulesParams),
+      queryFn: () => RestService.restEngineRulesList(engineRulesParams),
     });
 
   const { mutateAsync: mutateExport, isPending: loadingExport } = useMutation({

--- a/src/frontend/src/components/paymentmodule/PaymentPlanDetails/ExcludeSection/ExcludeSection.tsx
+++ b/src/frontend/src/components/paymentmodule/PaymentPlanDetails/ExcludeSection/ExcludeSection.tsx
@@ -27,6 +27,7 @@ import { RestService } from '@restgenerated/services/RestService';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { showApiErrorMessages } from '@utils/utils';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import type { PaymentPlanExcludeBeneficiaries } from '@restgenerated/models/PaymentPlanExcludeBeneficiaries';
 
 interface ExcludeSectionProps {
@@ -78,7 +79,7 @@ function ExcludeSection({
     },
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: ['paymentPlan', businessArea, paymentPlan.id, programId],
+        queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansRetrieve),
       });
     },
     onError: (error) => {

--- a/src/frontend/src/components/paymentmodule/PaymentPlanDetails/FundsCommitment/FundsCommitmentSection.tsx
+++ b/src/frontend/src/components/paymentmodule/PaymentPlanDetails/FundsCommitment/FundsCommitmentSection.tsx
@@ -76,7 +76,12 @@ const FundsCommitmentSection: React.FC<FundsCommitmentSectionProps> = ({
       },
       onSuccess: () => {
         queryClient.invalidateQueries({
-          queryKey: ['paymentPlan', paymentPlan.id],
+          queryKey: [
+            'paymentPlan',
+            businessArea,
+            paymentPlan.id,
+            paymentPlan.program.code,
+          ],
         });
       },
     });

--- a/src/frontend/src/components/paymentmodule/PaymentPlanDetails/FundsCommitment/FundsCommitmentSection.tsx
+++ b/src/frontend/src/components/paymentmodule/PaymentPlanDetails/FundsCommitment/FundsCommitmentSection.tsx
@@ -27,6 +27,7 @@ import { PaymentPlanStatusEnum } from '@restgenerated/models/PaymentPlanStatusEn
 import { useSnackbar } from '@hooks/useSnackBar';
 import { RestService } from '@restgenerated/services/RestService';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { WarningTooltip } from '@core/WarningTooltip';
 
 const EndInputAdornment = styled(InputAdornment)`
@@ -76,12 +77,9 @@ const FundsCommitmentSection: React.FC<FundsCommitmentSectionProps> = ({
       },
       onSuccess: () => {
         queryClient.invalidateQueries({
-          queryKey: [
-            'paymentPlan',
-            businessArea,
-            paymentPlan.id,
-            paymentPlan.program.code,
-          ],
+          queryKey: restQueryKey(
+            RestService.restBusinessAreasProgramsPaymentPlansRetrieve,
+          ),
         });
       },
     });
@@ -149,7 +147,9 @@ const FundsCommitmentSection: React.FC<FundsCommitmentSectionProps> = ({
         });
         showMessage(t('Funds commitment items assigned successfully'));
         await queryClient.invalidateQueries({
-          queryKey: ['paymentPlan'],
+          queryKey: restQueryKey(
+            RestService.restBusinessAreasProgramsPaymentPlansRetrieve,
+          ),
         });
       } catch (e) {
         showApiErrorMessages(e, showMessage);

--- a/src/frontend/src/components/paymentmodule/PaymentPlanDetails/ImportXlsxPaymentPlanPaymentList/ImportXlsxPaymentPlanPaymentList.tsx
+++ b/src/frontend/src/components/paymentmodule/PaymentPlanDetails/ImportXlsxPaymentPlanPaymentList/ImportXlsxPaymentPlanPaymentList.tsx
@@ -60,7 +60,7 @@ export function ImportXlsxPaymentPlanPaymentList({
       showMessage(t('Your import was successful!'));
       setXlsxError(null);
       queryClient.invalidateQueries({
-        queryKey: ['paymentPlan', paymentPlan.id],
+        queryKey: ['paymentPlan', businessArea, paymentPlan.id, programId],
       });
     },
     onError: (error: any) => {

--- a/src/frontend/src/components/paymentmodule/PaymentPlanDetails/ImportXlsxPaymentPlanPaymentList/ImportXlsxPaymentPlanPaymentList.tsx
+++ b/src/frontend/src/components/paymentmodule/PaymentPlanDetails/ImportXlsxPaymentPlanPaymentList/ImportXlsxPaymentPlanPaymentList.tsx
@@ -11,6 +11,7 @@ import { PaymentPlanImportFile } from '@restgenerated/models/PaymentPlanImportFi
 import { PaymentPlanStatusEnum } from '@restgenerated/models/PaymentPlanStatusEnum';
 import { RestService } from '@restgenerated/services/RestService';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { getApiErrorMessages } from '@utils/utils';
 import { ReactElement, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -60,7 +61,7 @@ export function ImportXlsxPaymentPlanPaymentList({
       showMessage(t('Your import was successful!'));
       setXlsxError(null);
       queryClient.invalidateQueries({
-        queryKey: ['paymentPlan', businessArea, paymentPlan.id, programId],
+        queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansRetrieve),
       });
     },
     onError: (error: any) => {

--- a/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/AbortPaymentPlan.tsx
+++ b/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/AbortPaymentPlan.tsx
@@ -63,6 +63,12 @@ export function AbortPaymentPlan({
       queryClient.invalidateQueries({
         queryKey: ['paymentPlan', businessArea, paymentPlan.id, programId],
       });
+      queryClient.invalidateQueries({
+        queryKey: ['businessAreasProgramsPaymentPlansList'],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ['businessAreasPaymentPlans'],
+      });
     },
   });
   const initialValues = {

--- a/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/AbortPaymentPlan.tsx
+++ b/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/AbortPaymentPlan.tsx
@@ -17,6 +17,7 @@ import { PaymentPlanDetail } from '@restgenerated/models/PaymentPlanDetail';
 import { RestService } from '@restgenerated/services/RestService';
 import { FormikTextField } from '@shared/Formik/FormikTextField/FormikTextField';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { Field, Form, Formik } from 'formik';
 import { ReactElement, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -61,10 +62,10 @@ export function AbortPaymentPlan({
       showMessage(t('Payment Plan has been aborted.'));
       setAbortDialogOpen(false);
       queryClient.invalidateQueries({
-        queryKey: ['paymentPlan', businessArea, paymentPlan.id, programId],
+        queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansRetrieve),
       });
       queryClient.invalidateQueries({
-        queryKey: ['businessAreasProgramsPaymentPlansList'],
+        queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansList),
       });
       queryClient.invalidateQueries({
         queryKey: ['businessAreasPaymentPlans'],

--- a/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/AbortPaymentPlan.tsx
+++ b/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/AbortPaymentPlan.tsx
@@ -67,9 +67,6 @@ export function AbortPaymentPlan({
       queryClient.invalidateQueries({
         queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansList),
       });
-      queryClient.invalidateQueries({
-        queryKey: ['businessAreasPaymentPlans'],
-      });
     },
   });
   const initialValues = {

--- a/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/ApprovePaymentPlan.tsx
+++ b/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/ApprovePaymentPlan.tsx
@@ -69,9 +69,6 @@ export function ApprovePaymentPlan({
       queryClient.invalidateQueries({
         queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansList),
       });
-      queryClient.invalidateQueries({
-        queryKey: ['businessAreasPaymentPlans'],
-      });
     },
   });
   const initialValues = {

--- a/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/ApprovePaymentPlan.tsx
+++ b/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/ApprovePaymentPlan.tsx
@@ -19,6 +19,7 @@ import { PaymentPlanDetail } from '@restgenerated/models/PaymentPlanDetail';
 import { RestService } from '@restgenerated/services/RestService';
 import { FormikTextField } from '@shared/Formik/FormikTextField/FormikTextField';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { Field, Form, Formik } from 'formik';
 import { ReactElement, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -63,10 +64,10 @@ export function ApprovePaymentPlan({
       showMessage(t('Payment Plan has been approved.'));
       setApproveDialogOpen(false);
       queryClient.invalidateQueries({
-        queryKey: ['paymentPlan', businessArea, paymentPlan.id, programId],
+        queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansRetrieve),
       });
       queryClient.invalidateQueries({
-        queryKey: ['businessAreasProgramsPaymentPlansList'],
+        queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansList),
       });
       queryClient.invalidateQueries({
         queryKey: ['businessAreasPaymentPlans'],

--- a/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/ApprovePaymentPlan.tsx
+++ b/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/ApprovePaymentPlan.tsx
@@ -65,6 +65,12 @@ export function ApprovePaymentPlan({
       queryClient.invalidateQueries({
         queryKey: ['paymentPlan', businessArea, paymentPlan.id, programId],
       });
+      queryClient.invalidateQueries({
+        queryKey: ['businessAreasProgramsPaymentPlansList'],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ['businessAreasPaymentPlans'],
+      });
     },
   });
   const initialValues = {

--- a/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/AuthorizePaymentPlan.tsx
+++ b/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/AuthorizePaymentPlan.tsx
@@ -19,6 +19,7 @@ import { PaymentPlanDetail } from '@restgenerated/models/PaymentPlanDetail';
 import { RestService } from '@restgenerated/services/RestService';
 import { FormikTextField } from '@shared/Formik/FormikTextField/FormikTextField';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { Field, Form, Formik } from 'formik';
 import { ReactElement, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -62,10 +63,10 @@ export function AuthorizePaymentPlan({
       showMessage(t('Payment Plan has been authorized.'));
       setAuthorizeDialogOpen(false);
       queryClient.invalidateQueries({
-        queryKey: ['paymentPlan', businessArea, paymentPlan.id, programId],
+        queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansRetrieve),
       });
       queryClient.invalidateQueries({
-        queryKey: ['businessAreasProgramsPaymentPlansList'],
+        queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansList),
       });
       queryClient.invalidateQueries({
         queryKey: ['businessAreasPaymentPlans'],

--- a/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/AuthorizePaymentPlan.tsx
+++ b/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/AuthorizePaymentPlan.tsx
@@ -64,6 +64,12 @@ export function AuthorizePaymentPlan({
       queryClient.invalidateQueries({
         queryKey: ['paymentPlan', businessArea, paymentPlan.id, programId],
       });
+      queryClient.invalidateQueries({
+        queryKey: ['businessAreasProgramsPaymentPlansList'],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ['businessAreasPaymentPlans'],
+      });
     },
   });
   const initialValues = {

--- a/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/AuthorizePaymentPlan.tsx
+++ b/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/AuthorizePaymentPlan.tsx
@@ -68,9 +68,6 @@ export function AuthorizePaymentPlan({
       queryClient.invalidateQueries({
         queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansList),
       });
-      queryClient.invalidateQueries({
-        queryKey: ['businessAreasPaymentPlans'],
-      });
     },
   });
   const initialValues = {

--- a/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/ClosePaymentPlanDialog.tsx
+++ b/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/ClosePaymentPlanDialog.tsx
@@ -75,6 +75,12 @@ export function ClosePaymentPlanDialog({
       queryClient.invalidateQueries({
         queryKey: ['paymentPlan', businessArea, paymentPlan.id, programId],
       });
+      queryClient.invalidateQueries({
+        queryKey: ['businessAreasProgramsPaymentPlansList'],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ['businessAreasPaymentPlans'],
+      });
     },
     onError: (error: any) => {
       showApiErrorMessages(error, showMessage);

--- a/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/ClosePaymentPlanDialog.tsx
+++ b/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/ClosePaymentPlanDialog.tsx
@@ -21,6 +21,7 @@ import { RestService } from '@restgenerated/services/RestService';
 import { FormikTextField } from '@shared/Formik/FormikTextField/FormikTextField';
 import { showApiErrorMessages } from '@utils/utils';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { Field, Form, Formik } from 'formik';
 import { ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -73,10 +74,10 @@ export function ClosePaymentPlanDialog({
       showMessage(t('Payment Plan has been closed.'));
       onClose();
       queryClient.invalidateQueries({
-        queryKey: ['paymentPlan', businessArea, paymentPlan.id, programId],
+        queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansRetrieve),
       });
       queryClient.invalidateQueries({
-        queryKey: ['businessAreasProgramsPaymentPlansList'],
+        queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansList),
       });
       queryClient.invalidateQueries({
         queryKey: ['businessAreasPaymentPlans'],

--- a/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/ClosePaymentPlanDialog.tsx
+++ b/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/ClosePaymentPlanDialog.tsx
@@ -79,9 +79,6 @@ export function ClosePaymentPlanDialog({
       queryClient.invalidateQueries({
         queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansList),
       });
-      queryClient.invalidateQueries({
-        queryKey: ['businessAreasPaymentPlans'],
-      });
     },
     onError: (error: any) => {
       showApiErrorMessages(error, showMessage);

--- a/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/DeletePaymentPlan.tsx
+++ b/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/DeletePaymentPlan.tsx
@@ -17,6 +17,7 @@ import {
 import { PaymentPlanDetail } from '@restgenerated/models/PaymentPlanDetail';
 import { RestService } from '@restgenerated/services/RestService';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { ReactElement, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
@@ -54,7 +55,7 @@ export function DeletePaymentPlan({
         }),
       onSuccess: () => {
         queryClient.invalidateQueries({
-          queryKey: ['businessAreasProgramsPaymentPlansList'],
+          queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansList),
         });
         queryClient.invalidateQueries({
           queryKey: ['businessAreasPaymentPlans'],

--- a/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/DeletePaymentPlan.tsx
+++ b/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/DeletePaymentPlan.tsx
@@ -57,9 +57,6 @@ export function DeletePaymentPlan({
         queryClient.invalidateQueries({
           queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansList),
         });
-        queryClient.invalidateQueries({
-          queryKey: ['businessAreasPaymentPlans'],
-        });
       },
     });
   const { id } = paymentPlan;

--- a/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/DeletePaymentPlan.tsx
+++ b/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/DeletePaymentPlan.tsx
@@ -16,7 +16,7 @@ import {
 } from '@mui/material';
 import { PaymentPlanDetail } from '@restgenerated/models/PaymentPlanDetail';
 import { RestService } from '@restgenerated/services/RestService';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { ReactElement, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
@@ -35,6 +35,7 @@ export function DeletePaymentPlan({
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const { baseUrl } = useBaseUrl();
   const { showMessage } = useSnackbar();
+  const queryClient = useQueryClient();
   const { mutateAsync: deletePaymentPlan, isPending: loadingDelete } =
     useMutation({
       mutationFn: ({
@@ -51,6 +52,14 @@ export function DeletePaymentPlan({
           id,
           programCode,
         }),
+      onSuccess: () => {
+        queryClient.invalidateQueries({
+          queryKey: ['businessAreasProgramsPaymentPlansList'],
+        });
+        queryClient.invalidateQueries({
+          queryKey: ['businessAreasPaymentPlans'],
+        });
+      },
     });
   const { id } = paymentPlan;
   const { isActiveProgram } = useProgramContext();

--- a/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/HeaderButtons/AbortedPaymentPlanHeaderButtons.tsx
+++ b/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/HeaderButtons/AbortedPaymentPlanHeaderButtons.tsx
@@ -46,9 +46,6 @@ export function AbortedPaymentPlanHeaderButtons({
       queryClient.invalidateQueries({
         queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansList),
       });
-      queryClient.invalidateQueries({
-        queryKey: ['businessAreasPaymentPlans'],
-      });
     },
     onError: () => {
       setLoading(false);

--- a/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/HeaderButtons/AbortedPaymentPlanHeaderButtons.tsx
+++ b/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/HeaderButtons/AbortedPaymentPlanHeaderButtons.tsx
@@ -42,6 +42,12 @@ export function AbortedPaymentPlanHeaderButtons({
       queryClient.invalidateQueries({
         queryKey: ['paymentPlan', businessArea, paymentPlan.id, programId],
       });
+      queryClient.invalidateQueries({
+        queryKey: ['businessAreasProgramsPaymentPlansList'],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ['businessAreasPaymentPlans'],
+      });
     },
     onError: () => {
       setLoading(false);

--- a/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/HeaderButtons/AbortedPaymentPlanHeaderButtons.tsx
+++ b/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/HeaderButtons/AbortedPaymentPlanHeaderButtons.tsx
@@ -6,6 +6,7 @@ import { PaymentPlanDetail } from '@restgenerated/models/PaymentPlanDetail';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { useSnackbar } from '@hooks/useSnackBar';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { RestService } from '@restgenerated/services/RestService';
 import { PERMISSIONS } from 'src/config/permissions';
 
@@ -40,10 +41,10 @@ export function AbortedPaymentPlanHeaderButtons({
     onSuccess: () => {
       showMessage(t('Payment Plan has been reactivated.'));
       queryClient.invalidateQueries({
-        queryKey: ['paymentPlan', businessArea, paymentPlan.id, programId],
+        queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansRetrieve),
       });
       queryClient.invalidateQueries({
-        queryKey: ['businessAreasProgramsPaymentPlansList'],
+        queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansList),
       });
       queryClient.invalidateQueries({
         queryKey: ['businessAreasPaymentPlans'],

--- a/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/HeaderButtons/FinishedPaymentPlanHeaderButtons.tsx
+++ b/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/HeaderButtons/FinishedPaymentPlanHeaderButtons.tsx
@@ -49,9 +49,6 @@ export function FinishedPaymentPlanHeaderButtons({
       queryClient.invalidateQueries({
         queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansList),
       });
-      queryClient.invalidateQueries({
-        queryKey: ['businessAreasPaymentPlans'],
-      });
     },
     onError: (error: any) => {
       showApiErrorMessages(error, showMessage);
@@ -77,9 +74,6 @@ export function FinishedPaymentPlanHeaderButtons({
       });
       queryClient.invalidateQueries({
         queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansList),
-      });
-      queryClient.invalidateQueries({
-        queryKey: ['businessAreasPaymentPlans'],
       });
     },
     onError: (error: any) => {

--- a/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/HeaderButtons/FinishedPaymentPlanHeaderButtons.tsx
+++ b/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/HeaderButtons/FinishedPaymentPlanHeaderButtons.tsx
@@ -6,6 +6,7 @@ import { LoadingButton } from '../../../../core/LoadingButton';
 import { CreateChildPaymentPlan } from '../../../CreateChildPaymentPlan';
 import { RestService } from '@restgenerated/services/RestService';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { SplitIntoPaymentLists } from '../SplitIntoPaymentLists';
 import { ReactElement } from 'react';
 import { PaymentPlanDetail } from '@restgenerated/models/PaymentPlanDetail';
@@ -43,10 +44,10 @@ export function FinishedPaymentPlanHeaderButtons({
     onSuccess: () => {
       showMessage(t('Payment Plan marked as ready for closure.'));
       queryClient.invalidateQueries({
-        queryKey: ['paymentPlan', businessArea, paymentPlan.id, programId],
+        queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansRetrieve),
       });
       queryClient.invalidateQueries({
-        queryKey: ['businessAreasProgramsPaymentPlansList'],
+        queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansList),
       });
       queryClient.invalidateQueries({
         queryKey: ['businessAreasPaymentPlans'],
@@ -72,10 +73,10 @@ export function FinishedPaymentPlanHeaderButtons({
     onSuccess: () => {
       showMessage(t('Sending to Payment Gateway started'));
       queryClient.invalidateQueries({
-        queryKey: ['paymentPlan', businessArea, paymentPlan.id, programId],
+        queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansRetrieve),
       });
       queryClient.invalidateQueries({
-        queryKey: ['businessAreasProgramsPaymentPlansList'],
+        queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansList),
       });
       queryClient.invalidateQueries({
         queryKey: ['businessAreasPaymentPlans'],

--- a/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/HeaderButtons/FinishedPaymentPlanHeaderButtons.tsx
+++ b/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/HeaderButtons/FinishedPaymentPlanHeaderButtons.tsx
@@ -45,6 +45,12 @@ export function FinishedPaymentPlanHeaderButtons({
       queryClient.invalidateQueries({
         queryKey: ['paymentPlan', businessArea, paymentPlan.id, programId],
       });
+      queryClient.invalidateQueries({
+        queryKey: ['businessAreasProgramsPaymentPlansList'],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ['businessAreasPaymentPlans'],
+      });
     },
     onError: (error: any) => {
       showApiErrorMessages(error, showMessage);
@@ -65,6 +71,15 @@ export function FinishedPaymentPlanHeaderButtons({
       ),
     onSuccess: () => {
       showMessage(t('Sending to Payment Gateway started'));
+      queryClient.invalidateQueries({
+        queryKey: ['paymentPlan', businessArea, paymentPlan.id, programId],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ['businessAreasProgramsPaymentPlansList'],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ['businessAreasPaymentPlans'],
+      });
     },
     onError: (error: any) => {
       showApiErrorMessages(error, showMessage);

--- a/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/HeaderButtons/LockedFspPaymentPlanHeaderButtons.tsx
+++ b/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/HeaderButtons/LockedFspPaymentPlanHeaderButtons.tsx
@@ -8,6 +8,7 @@ import { ReactElement } from 'react';
 import { PaymentPlanDetail } from '@restgenerated/models/PaymentPlanDetail';
 import { RestService } from '@restgenerated/services/RestService';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { showApiErrorMessages } from '@utils/utils';
 import { AbortPaymentPlan } from '@components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/AbortPaymentPlan';
 
@@ -40,11 +41,11 @@ export function LockedFspPaymentPlanHeaderButtons({
     onSuccess: async () => {
       showMessage(t('Payment Plan FSPs have been unlocked.'));
       await queryClient.invalidateQueries({
-        queryKey: ['paymentPlan', businessArea, paymentPlan.id, programId],
+        queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansRetrieve),
         exact: false,
       });
       queryClient.invalidateQueries({
-        queryKey: ['businessAreasProgramsPaymentPlansList'],
+        queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansList),
       });
       queryClient.invalidateQueries({
         queryKey: ['businessAreasPaymentPlans'],
@@ -68,11 +69,11 @@ export function LockedFspPaymentPlanHeaderButtons({
       onSuccess: async () => {
         showMessage(t('Payment Plan has been sent for approval.'));
         await queryClient.invalidateQueries({
-          queryKey: ['paymentPlan', businessArea, paymentPlan.id, programId],
+          queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansRetrieve),
           exact: false,
         });
         queryClient.invalidateQueries({
-          queryKey: ['businessAreasProgramsPaymentPlansList'],
+          queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansList),
         });
         queryClient.invalidateQueries({
           queryKey: ['businessAreasPaymentPlans'],

--- a/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/HeaderButtons/LockedFspPaymentPlanHeaderButtons.tsx
+++ b/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/HeaderButtons/LockedFspPaymentPlanHeaderButtons.tsx
@@ -43,6 +43,12 @@ export function LockedFspPaymentPlanHeaderButtons({
         queryKey: ['paymentPlan', businessArea, paymentPlan.id, programId],
         exact: false,
       });
+      queryClient.invalidateQueries({
+        queryKey: ['businessAreasProgramsPaymentPlansList'],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ['businessAreasPaymentPlans'],
+      });
     },
     onError: (error: any) => {
       showApiErrorMessages(error, showMessage);
@@ -64,6 +70,12 @@ export function LockedFspPaymentPlanHeaderButtons({
         await queryClient.invalidateQueries({
           queryKey: ['paymentPlan', businessArea, paymentPlan.id, programId],
           exact: false,
+        });
+        queryClient.invalidateQueries({
+          queryKey: ['businessAreasProgramsPaymentPlansList'],
+        });
+        queryClient.invalidateQueries({
+          queryKey: ['businessAreasPaymentPlans'],
         });
       },
       onError: (error: any) => {

--- a/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/HeaderButtons/LockedFspPaymentPlanHeaderButtons.tsx
+++ b/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/HeaderButtons/LockedFspPaymentPlanHeaderButtons.tsx
@@ -47,9 +47,6 @@ export function LockedFspPaymentPlanHeaderButtons({
       queryClient.invalidateQueries({
         queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansList),
       });
-      queryClient.invalidateQueries({
-        queryKey: ['businessAreasPaymentPlans'],
-      });
     },
     onError: (error: any) => {
       showApiErrorMessages(error, showMessage);
@@ -74,9 +71,6 @@ export function LockedFspPaymentPlanHeaderButtons({
         });
         queryClient.invalidateQueries({
           queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansList),
-        });
-        queryClient.invalidateQueries({
-          queryKey: ['businessAreasPaymentPlans'],
         });
       },
       onError: (error: any) => {

--- a/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/HeaderButtons/LockedPaymentPlanHeaderButtons.tsx
+++ b/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/HeaderButtons/LockedPaymentPlanHeaderButtons.tsx
@@ -45,6 +45,12 @@ export function LockedPaymentPlanHeaderButtons({
         queryKey: ['paymentPlan', businessArea, paymentPlan.id, programId],
         exact: false,
       });
+      queryClient.invalidateQueries({
+        queryKey: ['businessAreasProgramsPaymentPlansList'],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ['businessAreasPaymentPlans'],
+      });
     },
     onError: (error: any) => {
       showApiErrorMessages(error, showMessage);

--- a/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/HeaderButtons/LockedPaymentPlanHeaderButtons.tsx
+++ b/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/HeaderButtons/LockedPaymentPlanHeaderButtons.tsx
@@ -49,9 +49,6 @@ export function LockedPaymentPlanHeaderButtons({
       queryClient.invalidateQueries({
         queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansList),
       });
-      queryClient.invalidateQueries({
-        queryKey: ['businessAreasPaymentPlans'],
-      });
     },
     onError: (error: any) => {
       showApiErrorMessages(error, showMessage);

--- a/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/HeaderButtons/LockedPaymentPlanHeaderButtons.tsx
+++ b/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/HeaderButtons/LockedPaymentPlanHeaderButtons.tsx
@@ -9,6 +9,7 @@ import { ReactElement } from 'react';
 import { PaymentPlanDetail } from '@restgenerated/models/PaymentPlanDetail';
 import { RestService } from '@restgenerated/services/RestService';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { showApiErrorMessages } from '@utils/utils';
 import { AbortPaymentPlan } from '@components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/AbortPaymentPlan';
 import { PERMISSIONS } from 'src/config/permissions';
@@ -42,11 +43,11 @@ export function LockedPaymentPlanHeaderButtons({
     onSuccess: async () => {
       showMessage(t('Payment Plan has been unlocked.'));
       await queryClient.invalidateQueries({
-        queryKey: ['paymentPlan', businessArea, paymentPlan.id, programId],
+        queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansRetrieve),
         exact: false,
       });
       queryClient.invalidateQueries({
-        queryKey: ['businessAreasProgramsPaymentPlansList'],
+        queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansList),
       });
       queryClient.invalidateQueries({
         queryKey: ['businessAreasPaymentPlans'],

--- a/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/HeaderButtons/ReadyForClosurePaymentPlanHeaderButtons.tsx
+++ b/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/HeaderButtons/ReadyForClosurePaymentPlanHeaderButtons.tsx
@@ -46,9 +46,6 @@ export function ReadyForClosurePaymentPlanHeaderButtons({
       queryClient.invalidateQueries({
         queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansList),
       });
-      queryClient.invalidateQueries({
-        queryKey: ['businessAreasPaymentPlans'],
-      });
     },
     onError: (error: any) => {
       showApiErrorMessages(error, showMessage);

--- a/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/HeaderButtons/ReadyForClosurePaymentPlanHeaderButtons.tsx
+++ b/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/HeaderButtons/ReadyForClosurePaymentPlanHeaderButtons.tsx
@@ -42,6 +42,12 @@ export function ReadyForClosurePaymentPlanHeaderButtons({
       queryClient.invalidateQueries({
         queryKey: ['paymentPlan', businessArea, paymentPlan.id, programId],
       });
+      queryClient.invalidateQueries({
+        queryKey: ['businessAreasProgramsPaymentPlansList'],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ['businessAreasPaymentPlans'],
+      });
     },
     onError: (error: any) => {
       showApiErrorMessages(error, showMessage);

--- a/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/HeaderButtons/ReadyForClosurePaymentPlanHeaderButtons.tsx
+++ b/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/HeaderButtons/ReadyForClosurePaymentPlanHeaderButtons.tsx
@@ -5,6 +5,7 @@ import { useBaseUrl } from '@hooks/useBaseUrl';
 import { LoadingButton } from '../../../../core/LoadingButton';
 import { RestService } from '@restgenerated/services/RestService';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { ReactElement, useState } from 'react';
 import { PaymentPlanDetail } from '@restgenerated/models/PaymentPlanDetail';
 import { showApiErrorMessages } from '@utils/utils';
@@ -40,10 +41,10 @@ export function ReadyForClosurePaymentPlanHeaderButtons({
     onSuccess: () => {
       showMessage(t('Payment Plan has been sent back.'));
       queryClient.invalidateQueries({
-        queryKey: ['paymentPlan', businessArea, paymentPlan.id, programId],
+        queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansRetrieve),
       });
       queryClient.invalidateQueries({
-        queryKey: ['businessAreasProgramsPaymentPlansList'],
+        queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansList),
       });
       queryClient.invalidateQueries({
         queryKey: ['businessAreasPaymentPlans'],

--- a/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/LockFspPaymentPlan.tsx
+++ b/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/LockFspPaymentPlan.tsx
@@ -14,6 +14,7 @@ import {
 import { PaymentPlanDetail } from '@restgenerated/models/PaymentPlanDetail';
 import { RestService } from '@restgenerated/services/RestService';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { ReactElement, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { hasPermissions, PERMISSIONS } from '../../../../config/permissions';
@@ -56,11 +57,11 @@ export function LockFspPaymentPlan({
       showMessage(t('Payment Plan FSPs are locked.'));
       setLockDialogOpen(false);
       await queryClient.invalidateQueries({
-        queryKey: ['paymentPlan', businessArea, paymentPlan.id, programId],
+        queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansRetrieve),
         exact: false,
       });
       await queryClient.invalidateQueries({
-        queryKey: ['businessAreasProgramsPaymentPlansList'],
+        queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansList),
       });
       await queryClient.invalidateQueries({
         queryKey: ['businessAreasPaymentPlans'],

--- a/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/LockFspPaymentPlan.tsx
+++ b/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/LockFspPaymentPlan.tsx
@@ -63,9 +63,6 @@ export function LockFspPaymentPlan({
       await queryClient.invalidateQueries({
         queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansList),
       });
-      await queryClient.invalidateQueries({
-        queryKey: ['businessAreasPaymentPlans'],
-      });
     },
     onError: (error: any) => {
       showApiErrorMessages(error, showMessage);

--- a/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/LockFspPaymentPlan.tsx
+++ b/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/LockFspPaymentPlan.tsx
@@ -59,6 +59,12 @@ export function LockFspPaymentPlan({
         queryKey: ['paymentPlan', businessArea, paymentPlan.id, programId],
         exact: false,
       });
+      await queryClient.invalidateQueries({
+        queryKey: ['businessAreasProgramsPaymentPlansList'],
+      });
+      await queryClient.invalidateQueries({
+        queryKey: ['businessAreasPaymentPlans'],
+      });
     },
     onError: (error: any) => {
       showApiErrorMessages(error, showMessage);

--- a/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/LockPaymentPlan.tsx
+++ b/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/LockPaymentPlan.tsx
@@ -16,6 +16,7 @@ import {
 import { PaymentPlanDetail } from '@restgenerated/models/PaymentPlanDetail';
 import { RestService } from '@restgenerated/services/RestService';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { showApiErrorMessages } from '@utils/utils';
 import { ReactElement, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -56,11 +57,11 @@ export function LockPaymentPlan({
       showMessage(t('Payment Plan has been locked.'));
       setLockDialogOpen(false);
       await queryClient.invalidateQueries({
-        queryKey: ['paymentPlan', businessArea, paymentPlan.id, programId],
+        queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansRetrieve),
         exact: false,
       });
       await queryClient.invalidateQueries({
-        queryKey: ['businessAreasProgramsPaymentPlansList'],
+        queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansList),
       });
       await queryClient.invalidateQueries({
         queryKey: ['businessAreasPaymentPlans'],

--- a/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/LockPaymentPlan.tsx
+++ b/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/LockPaymentPlan.tsx
@@ -59,6 +59,12 @@ export function LockPaymentPlan({
         queryKey: ['paymentPlan', businessArea, paymentPlan.id, programId],
         exact: false,
       });
+      await queryClient.invalidateQueries({
+        queryKey: ['businessAreasProgramsPaymentPlansList'],
+      });
+      await queryClient.invalidateQueries({
+        queryKey: ['businessAreasPaymentPlans'],
+      });
     },
     onError: (error: any) => {
       showApiErrorMessages(error, showMessage);

--- a/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/LockPaymentPlan.tsx
+++ b/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/LockPaymentPlan.tsx
@@ -63,9 +63,6 @@ export function LockPaymentPlan({
       await queryClient.invalidateQueries({
         queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansList),
       });
-      await queryClient.invalidateQueries({
-        queryKey: ['businessAreasPaymentPlans'],
-      });
     },
     onError: (error: any) => {
       showApiErrorMessages(error, showMessage);

--- a/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/MarkAsReleasedPaymentPlan.tsx
+++ b/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/MarkAsReleasedPaymentPlan.tsx
@@ -68,9 +68,6 @@ export function MarkAsReleasedPaymentPlan({
         queryClient.invalidateQueries({
           queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansList),
         });
-        queryClient.invalidateQueries({
-          queryKey: ['businessAreasPaymentPlans'],
-        });
       },
     });
 

--- a/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/MarkAsReleasedPaymentPlan.tsx
+++ b/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/MarkAsReleasedPaymentPlan.tsx
@@ -19,6 +19,7 @@ import { PaymentPlanDetail } from '@restgenerated/models/PaymentPlanDetail';
 import { RestService } from '@restgenerated/services/RestService';
 import { FormikTextField } from '@shared/Formik/FormikTextField/FormikTextField';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { Field, Form, Formik } from 'formik';
 import { ReactElement, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -62,10 +63,10 @@ export function MarkAsReleasedPaymentPlan({
         showMessage(t('Payment Plan has been marked as released.'));
         setMarkAsReleasedDialogOpen(false);
         queryClient.invalidateQueries({
-          queryKey: ['paymentPlan', businessArea, paymentPlan.id, programId],
+          queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansRetrieve),
         });
         queryClient.invalidateQueries({
-          queryKey: ['businessAreasProgramsPaymentPlansList'],
+          queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansList),
         });
         queryClient.invalidateQueries({
           queryKey: ['businessAreasPaymentPlans'],

--- a/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/MarkAsReleasedPaymentPlan.tsx
+++ b/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/MarkAsReleasedPaymentPlan.tsx
@@ -64,6 +64,12 @@ export function MarkAsReleasedPaymentPlan({
         queryClient.invalidateQueries({
           queryKey: ['paymentPlan', businessArea, paymentPlan.id, programId],
         });
+        queryClient.invalidateQueries({
+          queryKey: ['businessAreasProgramsPaymentPlansList'],
+        });
+        queryClient.invalidateQueries({
+          queryKey: ['businessAreasPaymentPlans'],
+        });
       },
     });
 

--- a/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/RejectPaymentPlan.tsx
+++ b/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/RejectPaymentPlan.tsx
@@ -64,6 +64,12 @@ export function RejectPaymentPlan({
       queryClient.invalidateQueries({
         queryKey: ['paymentPlan', businessArea, paymentPlanId, programId],
       });
+      queryClient.invalidateQueries({
+        queryKey: ['businessAreasProgramsPaymentPlansList'],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ['businessAreasPaymentPlans'],
+      });
     },
   });
 

--- a/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/RejectPaymentPlan.tsx
+++ b/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/RejectPaymentPlan.tsx
@@ -19,6 +19,7 @@ import { AcceptanceProcess } from '@restgenerated/models/AcceptanceProcess';
 import { RestService } from '@restgenerated/services/RestService';
 import { FormikTextField } from '@shared/Formik/FormikTextField/FormikTextField';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { Field, Form, Formik } from 'formik';
 import { ReactElement, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -62,10 +63,10 @@ export function RejectPaymentPlan({
       showMessage(t('Payment Plan has been rejected.'));
       setRejectDialogOpen(false);
       queryClient.invalidateQueries({
-        queryKey: ['paymentPlan', businessArea, paymentPlanId, programId],
+        queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansRetrieve),
       });
       queryClient.invalidateQueries({
-        queryKey: ['businessAreasProgramsPaymentPlansList'],
+        queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansList),
       });
       queryClient.invalidateQueries({
         queryKey: ['businessAreasPaymentPlans'],

--- a/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/RejectPaymentPlan.tsx
+++ b/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/RejectPaymentPlan.tsx
@@ -68,9 +68,6 @@ export function RejectPaymentPlan({
       queryClient.invalidateQueries({
         queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansList),
       });
-      queryClient.invalidateQueries({
-        queryKey: ['businessAreasPaymentPlans'],
-      });
     },
   });
 

--- a/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/SplitIntoPaymentLists.tsx
+++ b/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/SplitIntoPaymentLists.tsx
@@ -19,6 +19,7 @@ import { RestService } from '@restgenerated/services/RestService';
 import { FormikSelectField } from '@shared/Formik/FormikSelectField';
 import { FormikTextField } from '@shared/Formik/FormikTextField';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { Field, Form, Formik } from 'formik';
 import { ReactElement, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -72,10 +73,10 @@ export const SplitIntoPaymentLists = ({
       showMessage(t('Payment Plan has been split successfully.'));
       setDialogOpen(false);
       queryClient.invalidateQueries({
-        queryKey: ['paymentPlan', businessArea, paymentPlan.id, programId],
+        queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansRetrieve),
       });
       queryClient.invalidateQueries({
-        queryKey: ['businessAreasProgramsPaymentPlansList'],
+        queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansList),
       });
       queryClient.invalidateQueries({
         queryKey: ['businessAreasPaymentPlans'],

--- a/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/SplitIntoPaymentLists.tsx
+++ b/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/SplitIntoPaymentLists.tsx
@@ -78,9 +78,6 @@ export const SplitIntoPaymentLists = ({
       queryClient.invalidateQueries({
         queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansList),
       });
-      queryClient.invalidateQueries({
-        queryKey: ['businessAreasPaymentPlans'],
-      });
     },
   });
 

--- a/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/SplitIntoPaymentLists.tsx
+++ b/src/frontend/src/components/paymentmodule/PaymentPlanDetails/PaymentPlanDetailsHeader/SplitIntoPaymentLists.tsx
@@ -18,7 +18,7 @@ import { SplitPaymentPlan } from '@restgenerated/models/SplitPaymentPlan';
 import { RestService } from '@restgenerated/services/RestService';
 import { FormikSelectField } from '@shared/Formik/FormikSelectField';
 import { FormikTextField } from '@shared/Formik/FormikTextField';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { Field, Form, Formik } from 'formik';
 import { ReactElement, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -49,6 +49,7 @@ export const SplitIntoPaymentLists = ({
   const { showMessage } = useSnackbar();
   const { businessArea, programId } = useBaseUrl();
   const { t } = useTranslation();
+  const queryClient = useQueryClient();
   const { mutateAsync: mutate, isPending: loading } = useMutation({
     mutationFn: ({
       businessAreaSlug,
@@ -70,6 +71,15 @@ export const SplitIntoPaymentLists = ({
     onSuccess: () => {
       showMessage(t('Payment Plan has been split successfully.'));
       setDialogOpen(false);
+      queryClient.invalidateQueries({
+        queryKey: ['paymentPlan', businessArea, paymentPlan.id, programId],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ['businessAreasProgramsPaymentPlansList'],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ['businessAreasPaymentPlans'],
+      });
     },
   });
 

--- a/src/frontend/src/components/payments/ActivateVerificationPlan.tsx
+++ b/src/frontend/src/components/payments/ActivateVerificationPlan.tsx
@@ -9,6 +9,7 @@ import { Box, Button, DialogContent, DialogTitle } from '@mui/material';
 import { RestService } from '@restgenerated/services/RestService';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { showApiErrorMessages } from '@utils/utils';
+import { restQueryKey } from '@utils/queryKeys';
 import { ReactElement, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useProgramContext } from '../../programContext';
@@ -42,12 +43,9 @@ export function ActivateVerificationPlan({
 
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: [
-          'PaymentVerificationPlanDetails',
-          businessArea,
-          paymentPlanId,
-          programCode,
-        ],
+        queryKey: restQueryKey(
+          RestService.restBusinessAreasProgramsPaymentVerificationsRetrieve,
+        ),
       });
     },
   });

--- a/src/frontend/src/components/payments/CreateVerificationPlan.tsx
+++ b/src/frontend/src/components/payments/CreateVerificationPlan.tsx
@@ -32,6 +32,7 @@ import { FormikSelectField } from '@shared/Formik/FormikSelectField';
 import { FormikSliderField } from '@shared/Formik/FormikSliderField';
 import { FormikTextField } from '@shared/Formik/FormikTextField';
 import { getPercentage, showApiErrorMessages } from '@utils/utils';
+import { restQueryKey } from '@utils/queryKeys';
 import { AutoSubmitFormOnEnter } from '@core/AutoSubmitFormOnEnter';
 import { ButtonTooltip } from '@core/ButtonTooltip';
 import { FormikEffect } from '@core/FormikEffect';
@@ -178,12 +179,9 @@ export const CreateVerificationPlan = ({
 
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: [
-          'PaymentVerificationPlanDetails',
-          businessArea,
-          paymentPlanId,
-          programCode,
-        ],
+        queryKey: restQueryKey(
+          RestService.restBusinessAreasProgramsPaymentVerificationsRetrieve,
+        ),
       });
     },
   });
@@ -191,7 +189,10 @@ export const CreateVerificationPlan = ({
   const [formValues, setFormValues] = useState(initialValues);
 
   const { data: rapidProFlowsData, refetch: refetchRapidProFlows } = useQuery({
-    queryKey: ['rapidProFlows', businessArea, programCode],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsSurveysAvailableFlowsList,
+      { businessAreaSlug: businessArea, programCode },
+    ),
     queryFn: () =>
       RestService.restBusinessAreasProgramsSurveysAvailableFlowsList({
         businessAreaSlug: businessArea,
@@ -207,7 +208,10 @@ export const CreateVerificationPlan = ({
   const loadRapidProFlows = refetchRapidProFlows;
 
   const { data: adminAreasData } = useQuery<AreaList[]>({
-    queryKey: ['adminAreas', businessArea, { level: 2 }],
+    queryKey: restQueryKey(RestService.restBusinessAreasGeoAreasList, {
+      businessAreaSlug: businessArea,
+      level: 2,
+    }),
     queryFn: async () => {
       return RestService.restBusinessAreasGeoAreasList({
         businessAreaSlug: businessArea,

--- a/src/frontend/src/components/payments/DeleteVerificationPlan.tsx
+++ b/src/frontend/src/components/payments/DeleteVerificationPlan.tsx
@@ -15,6 +15,7 @@ import { ErrorButton } from '@core/ErrorButton';
 import { ErrorButtonContained } from '@core/ErrorButtonContained';
 import { useProgramContext } from '../../programContext';
 import { showApiErrorMessages } from '@utils/utils';
+import { restQueryKey } from '@utils/queryKeys';
 
 export interface DeleteVerificationPlanProps {
   paymentVerificationPlanId: string;
@@ -44,12 +45,9 @@ export function DeleteVerificationPlan({
 
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: [
-          'PaymentVerificationPlanDetails',
-          businessArea,
-          paymentPlanId,
-          programCode,
-        ],
+        queryKey: restQueryKey(
+          RestService.restBusinessAreasProgramsPaymentVerificationsRetrieve,
+        ),
       });
     },
   });

--- a/src/frontend/src/components/payments/DiscardVerificationPlan.tsx
+++ b/src/frontend/src/components/payments/DiscardVerificationPlan.tsx
@@ -15,6 +15,7 @@ import { ErrorButton } from '@core/ErrorButton';
 import { ErrorButtonContained } from '@core/ErrorButtonContained';
 import { useProgramContext } from '../../programContext';
 import { showApiErrorMessages } from '@utils/utils';
+import { restQueryKey } from '@utils/queryKeys';
 
 export interface DiscardVerificationPlanProps {
   paymentVerificationPlanId: string;
@@ -45,12 +46,9 @@ export function DiscardVerificationPlan({
 
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: [
-          'PaymentVerificationPlanDetails',
-          businessArea,
-          paymentPlanId,
-          programCode,
-        ],
+        queryKey: restQueryKey(
+          RestService.restBusinessAreasProgramsPaymentVerificationsRetrieve,
+        ),
       });
     },
   });

--- a/src/frontend/src/components/payments/EditVerificationPlan.tsx
+++ b/src/frontend/src/components/payments/EditVerificationPlan.tsx
@@ -43,6 +43,7 @@ import { AreaList } from '@restgenerated/models/AreaList';
 import { RestService } from '@restgenerated/services/RestService';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { MessageSampleSize } from '@restgenerated/models/MessageSampleSize';
+import { restQueryKey } from '@utils/queryKeys';
 import { SamplingTypeE86Enum } from '@restgenerated/models/SamplingTypeE86Enum';
 import { PatchedPaymentVerificationPlanCreate } from '@restgenerated/models/PatchedPaymentVerificationPlanCreate';
 import { formatFigure, showApiErrorMessages } from '@utils/utils';
@@ -187,12 +188,9 @@ export const EditVerificationPlan = ({
 
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: [
-          'PaymentVerificationPlanDetails',
-          businessArea,
-          paymentPlanId,
-          programCode,
-        ],
+        queryKey: restQueryKey(
+          RestService.restBusinessAreasProgramsPaymentVerificationsRetrieve,
+        ),
       });
     },
   });
@@ -229,7 +227,10 @@ export const EditVerificationPlan = ({
   const [formValues, setFormValues] = useState(initialValues);
 
   const { data: rapidProFlowsData, refetch: refetchRapidProFlows } = useQuery({
-    queryKey: ['rapidProFlows', businessArea, programCode],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsSurveysAvailableFlowsList,
+      { businessAreaSlug: businessArea, programCode },
+    ),
     queryFn: () =>
       RestService.restBusinessAreasProgramsSurveysAvailableFlowsList({
         businessAreaSlug: businessArea,
@@ -244,7 +245,10 @@ export const EditVerificationPlan = ({
   const loadRapidProFlows = refetchRapidProFlows;
 
   const { data: adminAreasData } = useQuery<AreaList[]>({
-    queryKey: ['adminAreas', businessArea, { level: 2 }],
+    queryKey: restQueryKey(RestService.restBusinessAreasGeoAreasList, {
+      businessAreaSlug: businessArea,
+      level: 2,
+    }),
     queryFn: async () => {
       return RestService.restBusinessAreasGeoAreasList({
         businessAreaSlug: businessArea,

--- a/src/frontend/src/components/payments/FinishVerificationPlan.tsx
+++ b/src/frontend/src/components/payments/FinishVerificationPlan.tsx
@@ -14,6 +14,7 @@ import { DialogFooter } from '@containers/dialogs/DialogFooter';
 import { DialogTitleWrapper } from '@containers/dialogs/DialogTitleWrapper';
 import { useSnackbar } from '@hooks/useSnackBar';
 import { getPercentage, showApiErrorMessages } from '@utils/utils';
+import { restQueryKey } from '@utils/queryKeys';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { RestService } from '@restgenerated/services/RestService';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
@@ -49,12 +50,9 @@ export function FinishVerificationPlan({
 
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: [
-          'PaymentVerificationPlanDetails',
-          businessArea,
-          paymentPlanId,
-          programCode,
-        ],
+        queryKey: restQueryKey(
+          RestService.restBusinessAreasProgramsPaymentVerificationsRetrieve,
+        ),
       });
     },
   });

--- a/src/frontend/src/components/payments/ImportXlsx.tsx
+++ b/src/frontend/src/components/payments/ImportXlsx.tsx
@@ -10,6 +10,7 @@ import { PaymentVerificationPlanImport } from '@restgenerated/models/PaymentVeri
 import { RestService } from '@restgenerated/services/RestService';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { getApiErrorMessages } from '@utils/utils';
+import { restQueryKey } from '@utils/queryKeys';
 import { ReactElement, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
@@ -48,17 +49,14 @@ export const ImportXlsx = ({
       ),
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: [
-          'PaymentVerificationPlanDetails',
-          businessArea,
-          paymentPlanId,
-          programCode,
-        ],
+        queryKey: restQueryKey(
+          RestService.restBusinessAreasProgramsPaymentVerificationsRetrieve,
+        ),
       });
       queryClient.invalidateQueries({
-        queryKey: [
-          'businessAreasProgramsPaymentVerificationsVerificationsList',
-        ],
+        queryKey: restQueryKey(
+          RestService.restBusinessAreasProgramsPaymentVerificationsVerificationsList,
+        ),
       });
       setOpenImport(false);
       showMessage(t('Your import was successful!'));

--- a/src/frontend/src/components/payments/VerificationPlanActions.tsx
+++ b/src/frontend/src/components/payments/VerificationPlanActions.tsx
@@ -20,6 +20,7 @@ import { ImportXlsx } from './ImportXlsx';
 import { ReactElement, useEffect, useRef } from 'react';
 import { PaymentVerificationPlanDetails } from '@restgenerated/models/PaymentVerificationPlanDetails';
 import { showApiErrorMessages } from '@utils/utils';
+import { restQueryKey } from '@utils/queryKeys';
 
 const StyledLink = styled.a`
   text-decoration: none;
@@ -59,12 +60,9 @@ export function VerificationPlanActions({
 
       pollingIntervalRef.current = setInterval(() => {
         queryClient.invalidateQueries({
-          queryKey: [
-            'PaymentVerificationPlanDetails',
-            businessArea,
-            paymentPlanNode.id,
-            programCode,
-          ],
+          queryKey: restQueryKey(
+            RestService.restBusinessAreasProgramsPaymentVerificationsRetrieve,
+          ),
         });
       }, 2000);
     },
@@ -97,12 +95,9 @@ export function VerificationPlanActions({
 
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: [
-          'PaymentVerificationPlanDetails',
-          businessArea,
-          paymentPlanNode.id,
-          programCode,
-        ],
+        queryKey: restQueryKey(
+          RestService.restBusinessAreasProgramsPaymentVerificationsRetrieve,
+        ),
       });
     },
   });
@@ -252,12 +247,9 @@ export function VerificationPlanActions({
                       onClick={() => {
                         setTimeout(() => {
                           queryClient.invalidateQueries({
-                            queryKey: [
-                              'PaymentVerificationPlanDetails',
-                              businessArea,
-                              paymentPlanNode.id,
-                              programCode,
-                            ],
+                            queryKey: restQueryKey(
+                              RestService.restBusinessAreasProgramsPaymentVerificationsRetrieve,
+                            ),
                           });
                         }, 1000);
                       }}

--- a/src/frontend/src/components/payments/VerifyManual.tsx
+++ b/src/frontend/src/components/payments/VerifyManual.tsx
@@ -61,8 +61,7 @@ export function VerifyManual({
         },
       ),
 
-    onSuccess: async (data) => {
-      queryClient.setQueryData(paymentQueryKey, data);
+    onSuccess: async () => {
       await queryClient.invalidateQueries({
         queryKey: paymentQueryKey,
       });

--- a/src/frontend/src/components/payments/VerifyManual.tsx
+++ b/src/frontend/src/components/payments/VerifyManual.tsx
@@ -12,6 +12,7 @@ import { RestService } from '@restgenerated/services/RestService';
 import { FormikRadioGroup } from '@shared/Formik/FormikRadioGroup';
 import { FormikTextField } from '@shared/Formik/FormikTextField';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { showApiErrorMessages } from '@utils/utils';
 import { Field, Form, Formik } from 'formik';
 import { ReactElement, useState } from 'react';
@@ -34,20 +35,15 @@ export function VerifyManual({
   receivedAmount,
   verificationPlanId,
   paymentId,
-  paymentPlanId,
 }: Props): ReactElement {
   const { t } = useTranslation();
   const [verifyManualDialogOpen, setVerifyManualDialogOpen] = useState(false);
   const { showMessage } = useSnackbar();
   const queryClient = useQueryClient();
   const { programCode, businessAreaSlug } = useBaseUrl();
-  const paymentQueryKey = [
-    'payment',
-    businessAreaSlug,
-    paymentId,
-    programCode,
-    paymentPlanId,
-  ];
+  const paymentQueryKey = restQueryKey(
+    RestService.restBusinessAreasProgramsPaymentVerificationsVerificationsRetrieve,
+  );
   const formId = `verify-manual-form-${paymentId}`;
   const updateVerificationMutation = useMutation({
     mutationFn: (data: PatchedPaymentVerificationUpdate) =>

--- a/src/frontend/src/components/periodicDataUpdates/AuthorizedUsersOnlineListCreate.tsx
+++ b/src/frontend/src/components/periodicDataUpdates/AuthorizedUsersOnlineListCreate.tsx
@@ -26,6 +26,7 @@ import {
 } from '@mui/material';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { renderUserName } from '@utils/utils';
+import { restQueryKey } from '@utils/queryKeys';
 
 interface AuthorizedUsersOnlineListCreateProps {
   setFieldValue: (field: string, value: any, shouldValidate?: boolean) => void;
@@ -49,7 +50,10 @@ export const AuthorizedUsersOnlineListCreate: React.FC<
   const [permission, setPermission] = React.useState<string[]>([]);
 
   const { data, isLoading, error } = useQuery({
-    queryKey: ['availableUsers', businessAreaSlug, programCode],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsPeriodicDataUpdateOnlineEditsUsersAvailableList,
+      { businessAreaSlug, programCode },
+    ),
     queryFn: () =>
       RestService.restBusinessAreasProgramsPeriodicDataUpdateOnlineEditsUsersAvailableList(
         {

--- a/src/frontend/src/components/periodicDataUpdates/AuthorizedUsersOnlineListEdit.tsx
+++ b/src/frontend/src/components/periodicDataUpdates/AuthorizedUsersOnlineListEdit.tsx
@@ -26,6 +26,7 @@ import {
 } from '@mui/material';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { renderUserName } from '@utils/utils';
+import { restQueryKey } from '@utils/queryKeys';
 import { useParams } from 'react-router-dom';
 
 interface AuthorizedUsersOnlineListEditProps {
@@ -56,7 +57,10 @@ export const AuthorizedUsersOnlineListEdit: React.FC<
     isLoading: isEditLoading,
     error: editError,
   } = useQuery({
-    queryKey: ['onlineEdit', businessAreaSlug, programCode, id],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsPeriodicDataUpdateOnlineEditsRetrieve,
+      { businessAreaSlug, programCode, id: id ? Number(id) : undefined },
+    ),
     queryFn: () =>
       RestService.restBusinessAreasProgramsPeriodicDataUpdateOnlineEditsRetrieve(
         {
@@ -74,7 +78,10 @@ export const AuthorizedUsersOnlineListEdit: React.FC<
     isLoading: isAvailableLoading,
     error: availableError,
   } = useQuery({
-    queryKey: ['availableUsers', businessAreaSlug, programCode],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsPeriodicDataUpdateOnlineEditsUsersAvailableList,
+      { businessAreaSlug, programCode },
+    ),
     queryFn: () =>
       RestService.restBusinessAreasProgramsPeriodicDataUpdateOnlineEditsUsersAvailableList(
         {

--- a/src/frontend/src/components/periodicDataUpdates/EditAuthorizedUsersOnline.tsx
+++ b/src/frontend/src/components/periodicDataUpdates/EditAuthorizedUsersOnline.tsx
@@ -11,6 +11,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useSnackbar } from '@hooks/useSnackBar';
 import { showApiErrorMessages } from '@utils/utils';
+import { restQueryKey } from '@utils/queryKeys';
 import { RestService } from '@restgenerated/services/RestService';
 import { useProgramContext } from 'src/programContext';
 import { useTranslation } from 'react-i18next';
@@ -40,10 +41,14 @@ const EditAuthorizedUsersOnline = (): ReactElement => {
     onSuccess: () => {
       showMessage(t('Authorized users updated successfully.'));
       queryClient.invalidateQueries({
-        queryKey: ['onlineEdit', businessAreaSlug, programCode, id],
+        queryKey: restQueryKey(
+          RestService.restBusinessAreasProgramsPeriodicDataUpdateOnlineEditsRetrieve,
+        ),
       });
       queryClient.invalidateQueries({
-        queryKey: ['availableUsers', businessAreaSlug, programCode],
+        queryKey: restQueryKey(
+          RestService.restBusinessAreasProgramsPeriodicDataUpdateOnlineEditsUsersAvailableList,
+        ),
       });
       const url = `/${baseUrl}/population/individuals/online-templates/${id}`;
       navigate(url);

--- a/src/frontend/src/components/periodicDataUpdates/FilterIndividualsOffline.tsx
+++ b/src/frontend/src/components/periodicDataUpdates/FilterIndividualsOffline.tsx
@@ -10,6 +10,7 @@ import { RdiAutocompleteRestFilter } from '@shared/autocompletes/RdiAutocomplete
 import { AdminAreaAutocompleteMultipleRestFilter } from '@shared/autocompletes/rest/AdminAreaAutocompleteMultipleRestFilter';
 import { TargetPopulationAutocompleteRestFilter } from '@shared/autocompletes/rest/TargetPopulationAutocompleteRestFilter';
 import { useQuery } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { t } from 'i18next';
 import React, { FC } from 'react';
 
@@ -27,7 +28,9 @@ export const FilterIndividualsOffline: FC<FilterIndividualsOfflineProps> = ({
 }) => {
   const { businessArea } = useBaseUrl();
   const { data: individualChoicesData } = useQuery<IndividualChoices>({
-    queryKey: ['individualChoices', businessArea],
+    queryKey: restQueryKey(RestService.restBusinessAreasIndividualsChoicesRetrieve, {
+      businessAreaSlug: businessArea,
+    }),
     queryFn: () =>
       RestService.restBusinessAreasIndividualsChoicesRetrieve({
         businessAreaSlug: businessArea,

--- a/src/frontend/src/components/periodicDataUpdates/FilterIndividualsOnline.tsx
+++ b/src/frontend/src/components/periodicDataUpdates/FilterIndividualsOnline.tsx
@@ -10,6 +10,7 @@ import { RdiAutocompleteRestFilter } from '@shared/autocompletes/RdiAutocomplete
 import { AdminAreaAutocompleteMultipleRestFilter } from '@shared/autocompletes/rest/AdminAreaAutocompleteMultipleRestFilter';
 import { TargetPopulationAutocompleteRestFilter } from '@shared/autocompletes/rest/TargetPopulationAutocompleteRestFilter';
 import { useQuery } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { t } from 'i18next';
 import { FC } from 'react';
 
@@ -27,7 +28,9 @@ export const FilterIndividualsOnline: FC<FilterIndividualsOnlineProps> = ({
 }) => {
   const { businessArea } = useBaseUrl();
   const { data: individualChoicesData } = useQuery<IndividualChoices>({
-    queryKey: ['individualChoices', businessArea],
+    queryKey: restQueryKey(RestService.restBusinessAreasIndividualsChoicesRetrieve, {
+      businessAreaSlug: businessArea,
+    }),
     queryFn: () =>
       RestService.restBusinessAreasIndividualsChoicesRetrieve({
         businessAreaSlug: businessArea,

--- a/src/frontend/src/components/periodicDataUpdates/MergedPeriodicDataUpdates.tsx
+++ b/src/frontend/src/components/periodicDataUpdates/MergedPeriodicDataUpdates.tsx
@@ -9,6 +9,7 @@ import { BlackLink } from '@components/core/BlackLink';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { useQuery } from '@tanstack/react-query';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { PaginatedPDUOnlineEditListList } from '@restgenerated/models/PaginatedPDUOnlineEditListList';
 import { periodicDataUpdatesOnlineEditsStatusToColor } from '@utils/utils';
 import { useNavigate } from 'react-router-dom';
@@ -70,12 +71,15 @@ const MergedPeriodicDataUpdates = () => {
   const [queryVariables, setQueryVariables] = useState(initialQueryVariables);
 
   const { data, isLoading, error } = useQuery<PaginatedPDUOnlineEditListList>({
-    queryKey: [
-      'mergedPeriodicDataUpdates',
-      queryVariables,
-      businessAreaSlug,
-      programId,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsPeriodicDataUpdateOnlineEditsList,
+      {
+        businessAreaSlug,
+        programCode: programId,
+        ordering: queryVariables.ordering,
+        status: queryVariables.status,
+      },
+    ),
     queryFn: () =>
       RestService.restBusinessAreasProgramsPeriodicDataUpdateOnlineEditsList({
         businessAreaSlug,

--- a/src/frontend/src/components/periodicDataUpdates/NewPeriodicDataUpdates.tsx
+++ b/src/frontend/src/components/periodicDataUpdates/NewPeriodicDataUpdates.tsx
@@ -6,6 +6,7 @@ import AddIcon from '@mui/icons-material/Add';
 import { ReactElement, useEffect, useMemo, useState } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { ClickableTableRow } from '@components/core/Table/ClickableTableRow';
 import { HeadCell } from '@components/core/Table/EnhancedTableHead';
 import { UniversalRestTable } from '@components/rest/UniversalRestTable/UniversalRestTable';
@@ -101,12 +102,15 @@ const NewPeriodicDataUpdates = (): ReactElement => {
   }, [initialQueryVariables]);
 
   const { data, isLoading, error } = useQuery<PaginatedPDUOnlineEditListList>({
-    queryKey: [
-      'periodicDataUpdateOnlineEdits',
-      queryVariables,
-      businessAreaSlug,
-      programId,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsPeriodicDataUpdateOnlineEditsList,
+      {
+        businessAreaSlug,
+        programCode: programId,
+        ordering: queryVariables.ordering,
+        status: queryVariables.status,
+      },
+    ),
     queryFn: () =>
       RestService.restBusinessAreasProgramsPeriodicDataUpdateOnlineEditsList({
         businessAreaSlug,

--- a/src/frontend/src/components/periodicDataUpdates/OtherPeriodicDataUpdates.tsx
+++ b/src/frontend/src/components/periodicDataUpdates/OtherPeriodicDataUpdates.tsx
@@ -9,6 +9,7 @@ import { BlackLink } from '@components/core/BlackLink';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { useQuery } from '@tanstack/react-query';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { PaginatedPDUOnlineEditListList } from '@restgenerated/models/PaginatedPDUOnlineEditListList';
 import { periodicDataUpdatesOnlineEditsStatusToColor } from '@utils/utils';
 import { useNavigate } from 'react-router-dom';
@@ -80,12 +81,15 @@ const OtherPeriodicDataUpdates = () => {
   const [queryVariables, setQueryVariables] = useState(initialQueryVariables);
 
   const { data, isLoading, error } = useQuery<PaginatedPDUOnlineEditListList>({
-    queryKey: [
-      'otherPeriodicDataUpdates',
-      queryVariables,
-      businessAreaSlug,
-      programId,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsPeriodicDataUpdateOnlineEditsList,
+      {
+        businessAreaSlug,
+        programCode: programId,
+        ordering: queryVariables.ordering,
+        status: [...queryVariables.status],
+      },
+    ),
     queryFn: () =>
       RestService.restBusinessAreasProgramsPeriodicDataUpdateOnlineEditsList({
         businessAreaSlug,

--- a/src/frontend/src/components/periodicDataUpdates/PeriodicDataUpdatePendingForApproval.tsx
+++ b/src/frontend/src/components/periodicDataUpdates/PeriodicDataUpdatePendingForApproval.tsx
@@ -115,8 +115,7 @@ const PeriodicDataUpdatePendingForApproval = () => {
     onSuccess: () => {
       showMessage(t('Templates approved successfully.'));
       setSelected([]);
-      // Refresh every online-edit list (approved items move between them);
-      // the bare prefix matches all status-filtered variants.
+      // Approved items move between the status-filtered lists.
       queryClient.invalidateQueries({
         queryKey: restQueryKey(
           RestService.restBusinessAreasProgramsPeriodicDataUpdateOnlineEditsList,

--- a/src/frontend/src/components/periodicDataUpdates/PeriodicDataUpdatePendingForApproval.tsx
+++ b/src/frontend/src/components/periodicDataUpdates/PeriodicDataUpdatePendingForApproval.tsx
@@ -123,17 +123,7 @@ const PeriodicDataUpdatePendingForApproval = () => {
         ],
       });
       queryClient.invalidateQueries({
-        queryKey: [
-          'periodicDataUpdatePendingForMerge',
-          {
-            ordering: 'created_at',
-            businessAreaSlug,
-            programCode: programId,
-            status: ['APPROVED' as const],
-          },
-          businessAreaSlug,
-          programId,
-        ],
+        queryKey: ['periodicDataUpdatePendingForMerge'],
       });
     },
     onError: (error: any) => {

--- a/src/frontend/src/components/periodicDataUpdates/PeriodicDataUpdatePendingForApproval.tsx
+++ b/src/frontend/src/components/periodicDataUpdates/PeriodicDataUpdatePendingForApproval.tsx
@@ -16,6 +16,7 @@ import { UniversalMoment } from '@components/core/UniversalMoment';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { PaginatedPDUOnlineEditListList } from '@restgenerated/models/PaginatedPDUOnlineEditListList';
 import {
   periodicDataUpdatesOnlineEditsStatusToColor,
@@ -114,16 +115,12 @@ const PeriodicDataUpdatePendingForApproval = () => {
     onSuccess: () => {
       showMessage(t('Templates approved successfully.'));
       setSelected([]);
+      // Refresh every online-edit list (approved items move between them);
+      // the bare prefix matches all status-filtered variants.
       queryClient.invalidateQueries({
-        queryKey: [
-          'periodicDataUpdatePendingForApproval',
-          queryVariables,
-          businessAreaSlug,
-          programId,
-        ],
-      });
-      queryClient.invalidateQueries({
-        queryKey: ['periodicDataUpdatePendingForMerge'],
+        queryKey: restQueryKey(
+          RestService.restBusinessAreasProgramsPeriodicDataUpdateOnlineEditsList,
+        ),
       });
     },
     onError: (error: any) => {
@@ -137,12 +134,15 @@ const PeriodicDataUpdatePendingForApproval = () => {
   };
 
   const { data, isLoading, error } = useQuery<PaginatedPDUOnlineEditListList>({
-    queryKey: [
-      'periodicDataUpdatePendingForApproval',
-      queryVariables,
-      businessAreaSlug,
-      programId,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsPeriodicDataUpdateOnlineEditsList,
+      {
+        businessAreaSlug,
+        programCode: programId,
+        ordering: queryVariables.ordering,
+        status: queryVariables.status,
+      },
+    ),
     queryFn: () =>
       RestService.restBusinessAreasProgramsPeriodicDataUpdateOnlineEditsList({
         businessAreaSlug,

--- a/src/frontend/src/components/periodicDataUpdates/PeriodicDataUpdatePendingForMerge.tsx
+++ b/src/frontend/src/components/periodicDataUpdates/PeriodicDataUpdatePendingForMerge.tsx
@@ -109,8 +109,7 @@ const PeriodicDataUpdatePendingForMerge = () => {
     onSuccess: () => {
       showMessage('Templates merged successfully.');
       setSelected([]);
-      // Refresh every online-edit list (merged items move between them);
-      // the bare prefix matches all status-filtered variants.
+      // Merged items move between the status-filtered lists.
       queryClient.invalidateQueries({
         queryKey: restQueryKey(
           RestService.restBusinessAreasProgramsPeriodicDataUpdateOnlineEditsList,

--- a/src/frontend/src/components/periodicDataUpdates/PeriodicDataUpdatePendingForMerge.tsx
+++ b/src/frontend/src/components/periodicDataUpdates/PeriodicDataUpdatePendingForMerge.tsx
@@ -16,6 +16,7 @@ import { BlackLink } from '@components/core/BlackLink';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { PaginatedPDUOnlineEditListList } from '@restgenerated/models/PaginatedPDUOnlineEditListList';
 import {
   periodicDataUpdatesOnlineEditsStatusToColor,
@@ -108,16 +109,12 @@ const PeriodicDataUpdatePendingForMerge = () => {
     onSuccess: () => {
       showMessage('Templates merged successfully.');
       setSelected([]);
+      // Refresh every online-edit list (merged items move between them);
+      // the bare prefix matches all status-filtered variants.
       queryClient.invalidateQueries({
-        queryKey: [
-          'periodicDataUpdatePendingForMerge',
-          queryVariables,
-          businessAreaSlug,
-          programId,
-        ],
-      });
-      queryClient.invalidateQueries({
-        queryKey: ['mergedPeriodicDataUpdates'],
+        queryKey: restQueryKey(
+          RestService.restBusinessAreasProgramsPeriodicDataUpdateOnlineEditsList,
+        ),
       });
     },
     onError: (error: any) => {
@@ -131,12 +128,15 @@ const PeriodicDataUpdatePendingForMerge = () => {
   };
 
   const { data, isLoading, error } = useQuery<PaginatedPDUOnlineEditListList>({
-    queryKey: [
-      'periodicDataUpdatePendingForMerge',
-      queryVariables,
-      businessAreaSlug,
-      programId,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsPeriodicDataUpdateOnlineEditsList,
+      {
+        businessAreaSlug,
+        programCode: programId,
+        ordering: queryVariables.ordering,
+        status: queryVariables.status,
+      },
+    ),
     queryFn: () =>
       RestService.restBusinessAreasProgramsPeriodicDataUpdateOnlineEditsList({
         businessAreaSlug,

--- a/src/frontend/src/components/periodicDataUpdates/PeriodicDataUpdatePendingForMerge.tsx
+++ b/src/frontend/src/components/periodicDataUpdates/PeriodicDataUpdatePendingForMerge.tsx
@@ -117,17 +117,7 @@ const PeriodicDataUpdatePendingForMerge = () => {
         ],
       });
       queryClient.invalidateQueries({
-        queryKey: [
-          'mergedPeriodicDataUpdates',
-          {
-            ordering: 'created_at',
-            businessAreaSlug,
-            programCode: programId,
-            status: ['MERGED' as const],
-          },
-          businessAreaSlug,
-          programId,
-        ],
+        queryKey: ['mergedPeriodicDataUpdates'],
       });
     },
     onError: (error: any) => {

--- a/src/frontend/src/components/periodicDataUpdates/PeriodicDataUpdatesOfflineEdits.tsx
+++ b/src/frontend/src/components/periodicDataUpdates/PeriodicDataUpdatesOfflineEdits.tsx
@@ -85,6 +85,7 @@ export const PeriodicDataUpdatesOfflineEdits = (): ReactElement => {
   const {
     data: updatesData,
     isLoading,
+    isFetching,
     error,
   } = useQuery<PaginatedPDUXlsxUploadListList>({
     queryKey: [
@@ -179,6 +180,7 @@ export const PeriodicDataUpdatesOfflineEdits = (): ReactElement => {
         headCells={updatesHeadCells}
         data={updatesData ?? {}}
         isLoading={isLoading}
+        isFetching={isFetching}
         error={error}
         queryVariables={queryVariables}
         setQueryVariables={setQueryVariables}

--- a/src/frontend/src/components/periodicDataUpdates/PeriodicDataUpdatesOfflineEdits.tsx
+++ b/src/frontend/src/components/periodicDataUpdates/PeriodicDataUpdatesOfflineEdits.tsx
@@ -11,7 +11,7 @@ import { IconButton, TableCell } from '@mui/material';
 import { PaginatedPDUXlsxUploadListList } from '@restgenerated/models/PaginatedPDUXlsxUploadListList';
 import { PDUXlsxUploadList } from '@restgenerated/models/PDUXlsxUploadList';
 import { RestService } from '@restgenerated/services/RestService';
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { createApiParams } from '@utils/apiUtils';
 import { periodicDataUpdatesUpdatesStatusToColor } from '@utils/utils';
 import { ReactElement, useEffect, useMemo, useState } from 'react';
@@ -103,6 +103,7 @@ export const PeriodicDataUpdatesOfflineEdits = (): ReactElement => {
         ),
       );
     },
+    placeholderData: keepPreviousData,
   });
 
   const { data: uploadsCountData } = useQuery({

--- a/src/frontend/src/components/periodicDataUpdates/PeriodicDataUpdatesOfflineEdits.tsx
+++ b/src/frontend/src/components/periodicDataUpdates/PeriodicDataUpdatesOfflineEdits.tsx
@@ -12,6 +12,7 @@ import { PaginatedPDUXlsxUploadListList } from '@restgenerated/models/PaginatedP
 import { PDUXlsxUploadList } from '@restgenerated/models/PDUXlsxUploadList';
 import { RestService } from '@restgenerated/services/RestService';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { createApiParams } from '@utils/apiUtils';
 import { periodicDataUpdatesUpdatesStatusToColor } from '@utils/utils';
 import { ReactElement, useEffect, useMemo, useState } from 'react';
@@ -88,13 +89,14 @@ export const PeriodicDataUpdatesOfflineEdits = (): ReactElement => {
     isFetching,
     error,
   } = useQuery<PaginatedPDUXlsxUploadListList>({
-    queryKey: [
-      'periodicDataUpdateUploads',
-      queryVariables,
-      businessAreaSlug,
-      programId,
-      page,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsPeriodicDataUpdateUploadsList,
+      createApiParams(
+        { businessAreaSlug, programCode: programId },
+        queryVariables,
+        { withPagination: true, rowsPerPage: 5 },
+      ),
+    ),
     queryFn: () => {
       return RestService.restBusinessAreasProgramsPeriodicDataUpdateUploadsList(
         createApiParams(
@@ -108,7 +110,10 @@ export const PeriodicDataUpdatesOfflineEdits = (): ReactElement => {
   });
 
   const { data: uploadsCountData } = useQuery({
-    queryKey: ['periodicDataUpdateUploadsCount', businessAreaSlug, programId],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsPeriodicDataUpdateUploadsCountRetrieve,
+      { businessAreaSlug, programCode: programId },
+    ),
     queryFn: () =>
       RestService.restBusinessAreasProgramsPeriodicDataUpdateUploadsCountRetrieve(
         {

--- a/src/frontend/src/components/periodicDataUpdates/PeriodicDataUpdatesOfflineTemplates.tsx
+++ b/src/frontend/src/components/periodicDataUpdates/PeriodicDataUpdatesOfflineTemplates.tsx
@@ -156,6 +156,7 @@ export const PeriodicDataUpdatesOfflineTemplates = (): ReactElement => {
   const {
     data: templatesData,
     isLoading,
+    isFetching,
     error,
   } = useQuery<PaginatedPDUXlsxTemplateListList>({
     queryKey: [
@@ -280,6 +281,7 @@ export const PeriodicDataUpdatesOfflineTemplates = (): ReactElement => {
         headCells={templatesHeadCells}
         data={templatesData ?? {}}
         isLoading={isLoading}
+        isFetching={isFetching}
         error={error}
         queryVariables={queryVariables}
         setQueryVariables={setQueryVariables}

--- a/src/frontend/src/components/periodicDataUpdates/PeriodicDataUpdatesOfflineTemplates.tsx
+++ b/src/frontend/src/components/periodicDataUpdates/PeriodicDataUpdatesOfflineTemplates.tsx
@@ -13,6 +13,7 @@ import VisibilityIcon from '@mui/icons-material/Visibility';
 import { Box, IconButton, TableCell, Tooltip } from '@mui/material';
 import { RestService } from '@restgenerated/services/RestService';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { periodicDataUpdateTemplateStatusToColor } from '@utils/utils';
 import { createApiParams } from '@utils/apiUtils';
 import { ReactElement, useEffect, useMemo, useState } from 'react';
@@ -92,7 +93,10 @@ export const PeriodicDataUpdatesOfflineTemplates = (): ReactElement => {
   const { businessArea: businessAreaSlug, programId } = useBaseUrl();
 
   const { data: templateCountData } = useQuery({
-    queryKey: ['periodicDataUpdateTemplatesCount', businessAreaSlug, programId],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsPeriodicDataUpdateTemplatesCountRetrieve,
+      { businessAreaSlug, programCode: programId },
+    ),
     queryFn: () =>
       RestService.restBusinessAreasProgramsPeriodicDataUpdateTemplatesCountRetrieve(
         {
@@ -159,12 +163,14 @@ export const PeriodicDataUpdatesOfflineTemplates = (): ReactElement => {
     isFetching,
     error,
   } = useQuery<PaginatedPDUXlsxTemplateListList>({
-    queryKey: [
-      'periodicDataUpdateTemplates',
-      queryVariables,
-      businessAreaSlug,
-      programId,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsPeriodicDataUpdateTemplatesList,
+      createApiParams(
+        { businessAreaSlug, programCode: programId },
+        queryVariables,
+        { withPagination: true },
+      ),
+    ),
     queryFn: () => {
       return RestService.restBusinessAreasProgramsPeriodicDataUpdateTemplatesList(
         createApiParams(

--- a/src/frontend/src/components/periodicDataUpdates/PeriodicDataUpdatesOfflineTemplates.tsx
+++ b/src/frontend/src/components/periodicDataUpdates/PeriodicDataUpdatesOfflineTemplates.tsx
@@ -12,7 +12,7 @@ import UploadIcon from '@mui/icons-material/Upload';
 import VisibilityIcon from '@mui/icons-material/Visibility';
 import { Box, IconButton, TableCell, Tooltip } from '@mui/material';
 import { RestService } from '@restgenerated/services/RestService';
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { periodicDataUpdateTemplateStatusToColor } from '@utils/utils';
 import { createApiParams } from '@utils/apiUtils';
 import { ReactElement, useEffect, useMemo, useState } from 'react';
@@ -173,6 +173,7 @@ export const PeriodicDataUpdatesOfflineTemplates = (): ReactElement => {
         ),
       );
     },
+    placeholderData: keepPreviousData,
   });
 
   const selectedTemplate = templatesData?.results?.find(

--- a/src/frontend/src/components/periodicDataUpdates/PeriodicDataUpdatesOnlineEditsTemplateDetailsPage.tsx
+++ b/src/frontend/src/components/periodicDataUpdates/PeriodicDataUpdatesOnlineEditsTemplateDetailsPage.tsx
@@ -34,6 +34,7 @@ import {
   periodicDataUpdatesOnlineEditsStatusToColor,
   showApiErrorMessages,
 } from '@utils/utils';
+import { restQueryKey } from '@utils/queryKeys';
 import { ReactElement, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useNavigate, useParams } from 'react-router-dom';
@@ -110,12 +111,9 @@ const PeriodicDataUpdatesOnlineEditsTemplateDetailsPage = (): ReactElement => {
     onSuccess: () => {
       showMessage(t('Template approved successfully.'));
       queryClient.invalidateQueries({
-        queryKey: [
-          'onlineEditsTemplateDetails',
-          businessArea,
-          programId,
-          numericId,
-        ],
+        queryKey: restQueryKey(
+          RestService.restBusinessAreasProgramsPeriodicDataUpdateOnlineEditsRetrieve,
+        ),
       });
     },
     onError: (error: any) => {
@@ -142,12 +140,9 @@ const PeriodicDataUpdatesOnlineEditsTemplateDetailsPage = (): ReactElement => {
       setSendBackDialogOpen(false);
       setSendBackComment('');
       queryClient.invalidateQueries({
-        queryKey: [
-          'onlineEditsTemplateDetails',
-          businessArea,
-          programId,
-          numericId,
-        ],
+        queryKey: restQueryKey(
+          RestService.restBusinessAreasProgramsPeriodicDataUpdateOnlineEditsRetrieve,
+        ),
       });
     } catch (e) {
       showApiErrorMessages(
@@ -172,12 +167,9 @@ const PeriodicDataUpdatesOnlineEditsTemplateDetailsPage = (): ReactElement => {
       );
       showMessage(t('Periodic data update sent for approval.'));
       queryClient.invalidateQueries({
-        queryKey: [
-          'onlineEditsTemplateDetails',
-          businessArea,
-          programId,
-          numericId,
-        ],
+        queryKey: restQueryKey(
+          RestService.restBusinessAreasProgramsPeriodicDataUpdateOnlineEditsRetrieve,
+        ),
       });
     } catch (e) {
       showApiErrorMessages(e, showMessage, t('Failed to send for approval.'));
@@ -199,12 +191,9 @@ const PeriodicDataUpdatesOnlineEditsTemplateDetailsPage = (): ReactElement => {
     onSuccess: () => {
       showMessage('Template merged successfully.');
       queryClient.invalidateQueries({
-        queryKey: [
-          'onlineEditsTemplateDetails',
-          businessArea,
-          programId,
-          numericId,
-        ],
+        queryKey: restQueryKey(
+          RestService.restBusinessAreasProgramsPeriodicDataUpdateOnlineEditsRetrieve,
+        ),
       });
     },
     onError: (error: any) => {
@@ -221,12 +210,10 @@ const PeriodicDataUpdatesOnlineEditsTemplateDetailsPage = (): ReactElement => {
     useState(false);
 
   const { data, isLoading } = useQuery({
-    queryKey: [
-      'onlineEditsTemplateDetails',
-      businessArea,
-      programId,
-      numericId,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsPeriodicDataUpdateOnlineEditsRetrieve,
+      { businessAreaSlug: businessArea, programCode: programId, id: numericId },
+    ),
     queryFn: () =>
       RestService.restBusinessAreasProgramsPeriodicDataUpdateOnlineEditsRetrieve(
         {

--- a/src/frontend/src/components/periodicDataUpdates/PeriodicDataUpdatesTemplateDetailsDialog.tsx
+++ b/src/frontend/src/components/periodicDataUpdates/PeriodicDataUpdatesTemplateDetailsDialog.tsx
@@ -18,6 +18,7 @@ import { PDUXlsxTemplateDetail } from '@restgenerated/models/PDUXlsxTemplateDeta
 import { PDUXlsxTemplateList } from '@restgenerated/models/PDUXlsxTemplateList';
 import { RestService } from '@restgenerated/services/RestService';
 import { useQuery } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { FC } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -34,12 +35,14 @@ export const PeriodicDataUpdatesTemplateDetailsDialog: FC<
   const { businessArea, programId } = useBaseUrl();
   const { data: templateDetailsData, isLoading } =
     useQuery<PDUXlsxTemplateDetail>({
-      queryKey: [
-        'PDUXlsxTemplateDetails',
-        businessArea,
-        programId,
-        template.id,
-      ],
+      queryKey: restQueryKey(
+        RestService.restBusinessAreasProgramsPeriodicDataUpdateTemplatesRetrieve,
+        {
+          businessAreaSlug: businessArea,
+          id: template.id,
+          programCode: programId,
+        },
+      ),
 
       queryFn: () =>
         RestService.restBusinessAreasProgramsPeriodicDataUpdateTemplatesRetrieve(
@@ -52,7 +55,10 @@ export const PeriodicDataUpdatesTemplateDetailsDialog: FC<
     });
   const { data: periodicFieldsData, isLoading: periodicFieldsLoading } =
     useQuery({
-      queryKey: ['periodicFields', businessArea, programId],
+      queryKey: restQueryKey(
+        RestService.restBusinessAreasProgramsPeriodicFieldsList,
+        { businessAreaSlug: businessArea, programCode: programId },
+      ),
       queryFn: () =>
         RestService.restBusinessAreasProgramsPeriodicFieldsList({
           businessAreaSlug: businessArea,

--- a/src/frontend/src/components/periodicDataUpdates/PeriodicDataUpdatesTemplatesListActions.tsx
+++ b/src/frontend/src/components/periodicDataUpdates/PeriodicDataUpdatesTemplatesListActions.tsx
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 
 export const useExportPeriodicDataUpdateTemplate = () => {
   const queryClient = useQueryClient();
@@ -22,7 +23,9 @@ export const useExportPeriodicDataUpdateTemplate = () => {
       ),
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: ['periodicDataUpdateTemplates'],
+        queryKey: restQueryKey(
+          RestService.restBusinessAreasProgramsPeriodicDataUpdateTemplatesList,
+        ),
       });
     },
   });
@@ -47,7 +50,9 @@ export const useUploadPeriodicDataUpdateTemplate = () => {
       }),
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: ['periodicDataUpdateUploads'],
+        queryKey: restQueryKey(
+          RestService.restBusinessAreasProgramsPeriodicDataUpdateUploadsList,
+        ),
       });
     },
   });

--- a/src/frontend/src/components/periodicDataUpdates/PeriodicDataUpdatesUploadDetailsDialog.tsx
+++ b/src/frontend/src/components/periodicDataUpdates/PeriodicDataUpdatesUploadDetailsDialog.tsx
@@ -12,6 +12,7 @@ import { useTranslation } from 'react-i18next';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { useQuery } from '@tanstack/react-query';
 import { LoadingComponent } from '@components/core/LoadingComponent';
+import { restQueryKey } from '@utils/queryKeys';
 
 interface PeriodicDataUpdatesUploadDetailsDialogProps {
   open: boolean;
@@ -71,12 +72,14 @@ export const PeriodicDataUpdatesUploadDetailsDialog: FC<
   const { t } = useTranslation();
   const { businessArea, programId } = useBaseUrl();
   const { data: uploadDetailsData, isLoading } = useQuery({
-    queryKey: [
-      'periodicDataUpdateUploadDetails',
-      businessArea,
-      programId,
-      uploadId,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsPeriodicDataUpdateUploadsRetrieve,
+      {
+        businessAreaSlug: businessArea,
+        programCode: programId,
+        id: uploadId,
+      },
+    ),
     queryFn: () =>
       RestService.restBusinessAreasProgramsPeriodicDataUpdateUploadsRetrieve({
         businessAreaSlug: businessArea,

--- a/src/frontend/src/components/periodicDataUpdates/PeriodicDataUpdatesUploadDialog.tsx
+++ b/src/frontend/src/components/periodicDataUpdates/PeriodicDataUpdatesUploadDialog.tsx
@@ -15,6 +15,7 @@ import { hasPermissions, PERMISSIONS } from 'src/config/permissions';
 import { ButtonTooltip } from '@components/core/ButtonTooltip';
 import { GreyText } from '@components/core/GreyText';
 import { useQueryClient } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 
 const Error = styled.div`
   color: ${({ theme }) => theme.palette.error.dark};
@@ -57,10 +58,14 @@ export const PeriodDataUpdatesUploadDialog = (): ReactElement => {
         );
         showMessage(t('File uploaded successfully'));
         queryClient.invalidateQueries({
-          queryKey: ['periodicDataUpdateUploads'],
+          queryKey: restQueryKey(
+            RestService.restBusinessAreasProgramsPeriodicDataUpdateUploadsList,
+          ),
         });
         queryClient.invalidateQueries({
-          queryKey: ['periodicDataUpdateUploadsCount'],
+          queryKey: restQueryKey(
+            RestService.restBusinessAreasProgramsPeriodicDataUpdateUploadsCountRetrieve,
+          ),
           refetchType: 'active',
         });
         setOpenImport(false);

--- a/src/frontend/src/components/periodicDataUpdates/PeriodicDataUpdatesUploadDialog.tsx
+++ b/src/frontend/src/components/periodicDataUpdates/PeriodicDataUpdatesUploadDialog.tsx
@@ -66,7 +66,6 @@ export const PeriodDataUpdatesUploadDialog = (): ReactElement => {
           queryKey: restQueryKey(
             RestService.restBusinessAreasProgramsPeriodicDataUpdateUploadsCountRetrieve,
           ),
-          refetchType: 'active',
         });
         setOpenImport(false);
         setFileToImport(null);

--- a/src/frontend/src/components/periodicDataUpdates/PeriodicDataUpdatesUploadDialog.tsx
+++ b/src/frontend/src/components/periodicDataUpdates/PeriodicDataUpdatesUploadDialog.tsx
@@ -57,17 +57,7 @@ export const PeriodDataUpdatesUploadDialog = (): ReactElement => {
         );
         showMessage(t('File uploaded successfully'));
         queryClient.invalidateQueries({
-          queryKey: [
-            'periodicDataUpdateUploads',
-            {
-              ordering: 'created_at',
-              businessAreaSlug: businessArea,
-              programCode: programId,
-            },
-            businessArea,
-            programId,
-            0,
-          ],
+          queryKey: ['periodicDataUpdateUploads'],
         });
         queryClient.invalidateQueries({
           queryKey: ['periodicDataUpdateUploadsCount'],

--- a/src/frontend/src/components/population/DocumentPopulationPhotoModal.tsx
+++ b/src/frontend/src/components/population/DocumentPopulationPhotoModal.tsx
@@ -3,6 +3,7 @@ import { ReactElement } from 'react';
 import { IndividualDetail } from '@restgenerated/models/IndividualDetail';
 import { IndividualPhotoDetail } from '@restgenerated/models/IndividualPhotoDetail';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useQuery } from '@tanstack/react-query';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { useProgramContext } from 'src/programContext';
@@ -21,19 +22,21 @@ export function DocumentPopulationPhotoModal({
   const { businessArea } = useBaseUrl();
   const { selectedProgram } = useProgramContext();
 
+  const individualPhotosParams = {
+    businessAreaSlug: businessArea,
+    programCode: selectedProgram?.code || '',
+    id: individual?.id,
+  };
+
   const { data } = useQuery<IndividualPhotoDetail>({
-    queryKey: [
-      'individualPhotos',
-      businessArea,
-      selectedProgram?.code,
-      individual?.id,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsIndividualsPhotosRetrieve,
+      individualPhotosParams,
+    ),
     queryFn: () =>
-      RestService.restBusinessAreasProgramsIndividualsPhotosRetrieve({
-        businessAreaSlug: businessArea,
-        programCode: selectedProgram?.code || '',
-        id: individual?.id,
-      }),
+      RestService.restBusinessAreasProgramsIndividualsPhotosRetrieve(
+        individualPhotosParams,
+      ),
     enabled: !!businessArea && !!selectedProgram?.code && !!individual?.id,
   });
 

--- a/src/frontend/src/components/population/HouseholdFlexFieldPhotoModal.tsx
+++ b/src/frontend/src/components/population/HouseholdFlexFieldPhotoModal.tsx
@@ -4,6 +4,7 @@ import PhotoModal from '@core/PhotoModal/PhotoModal';
 import { ReactElement } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { HouseholdDetail } from '@restgenerated/models/HouseholdDetail';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { useProgramContext } from 'src/programContext';
@@ -13,14 +14,19 @@ export function HouseholdFlexFieldPhotoModal({ field }): ReactElement {
   const { businessArea, programId } = useBaseUrl();
   const { selectedProgram } = useProgramContext();
 
+  const householdParams = {
+    businessAreaSlug: businessArea,
+    id: id,
+    programCode: programId || selectedProgram?.code || '',
+  };
+
   const { data } = useQuery<HouseholdDetail>({
-    queryKey: ['household', businessArea, id, programId, selectedProgram?.code],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsHouseholdsRetrieve,
+      householdParams,
+    ),
     queryFn: () =>
-      RestService.restBusinessAreasProgramsHouseholdsRetrieve({
-        businessAreaSlug: businessArea,
-        id: id,
-        programCode: programId || selectedProgram?.code || '',
-      }),
+      RestService.restBusinessAreasProgramsHouseholdsRetrieve(householdParams),
     enabled: !!businessArea && !!id && (!!programId || !!selectedProgram?.code),
   });
 

--- a/src/frontend/src/components/population/IndividualFlexFieldPhotoModal.tsx
+++ b/src/frontend/src/components/population/IndividualFlexFieldPhotoModal.tsx
@@ -5,20 +5,26 @@ import { ReactElement } from 'react';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { IndividualDetail } from '@restgenerated/models/IndividualDetail';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useQuery } from '@tanstack/react-query';
 
 export function IndividualFlexFieldPhotoModal({ field }): ReactElement {
   const { id } = useParams();
   const { businessArea, programId } = useBaseUrl();
 
+  const individualParams = {
+    businessAreaSlug: businessArea,
+    programCode: programId,
+    id: id,
+  };
+
   const { data } = useQuery<IndividualDetail>({
-    queryKey: ['individual', businessArea, programId, id],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsIndividualsRetrieve,
+      individualParams,
+    ),
     queryFn: () =>
-      RestService.restBusinessAreasProgramsIndividualsRetrieve({
-        businessAreaSlug: businessArea,
-        programCode: programId,
-        id: id,
-      }),
+      RestService.restBusinessAreasProgramsIndividualsRetrieve(individualParams),
     enabled: !!businessArea && !!programId && !!id,
   });
 

--- a/src/frontend/src/components/population/IndividualPhotoModal.tsx
+++ b/src/frontend/src/components/population/IndividualPhotoModal.tsx
@@ -3,6 +3,7 @@ import { ReactElement } from 'react';
 import { IndividualDetail } from '@restgenerated/models/IndividualDetail';
 import { IndividualPhotoDetail } from '@restgenerated/models/IndividualPhotoDetail';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useQuery } from '@tanstack/react-query';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { useProgramContext } from 'src/programContext';
@@ -17,19 +18,21 @@ export function IndividualPhotoModal({
   const { businessArea } = useBaseUrl();
   const { selectedProgram } = useProgramContext();
 
+  const individualPhotosParams = {
+    businessAreaSlug: businessArea,
+    programCode: selectedProgram?.code || '',
+    id: individual?.id,
+  };
+
   const { data } = useQuery<IndividualPhotoDetail>({
-    queryKey: [
-      'individualPhotos',
-      businessArea,
-      selectedProgram?.code,
-      individual?.id,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsIndividualsPhotosRetrieve,
+      individualPhotosParams,
+    ),
     queryFn: () =>
-      RestService.restBusinessAreasProgramsIndividualsPhotosRetrieve({
-        businessAreaSlug: businessArea,
-        programCode: selectedProgram?.code || '',
-        id: individual?.id,
-      }),
+      RestService.restBusinessAreasProgramsIndividualsPhotosRetrieve(
+        individualPhotosParams,
+      ),
     enabled: !!businessArea && !!selectedProgram?.code && !!individual?.id,
   });
 

--- a/src/frontend/src/components/population/LinkedGrievancesModal/LinkedGrievancesModal.tsx
+++ b/src/frontend/src/components/population/LinkedGrievancesModal/LinkedGrievancesModal.tsx
@@ -25,7 +25,7 @@ import { HouseholdDetail } from '@restgenerated/models/HouseholdDetail';
 import { HouseholdSimple } from '@restgenerated/models/HouseholdSimple';
 import { PaginatedGrievanceTicketListList } from '@restgenerated/models/PaginatedGrievanceTicketListList';
 import { RestService } from '@restgenerated/services/RestService';
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { choicesToDict, grievanceTicketStatusToColor } from '@utils/utils';
 import { createApiParams } from '@utils/apiUtils';
 import { ReactElement, useState } from 'react';
@@ -95,6 +95,7 @@ export function LinkedGrievancesModal({
         );
       }
     },
+    placeholderData: keepPreviousData,
     refetchOnWindowFocus: false,
   });
 

--- a/src/frontend/src/components/population/LinkedGrievancesModal/LinkedGrievancesModal.tsx
+++ b/src/frontend/src/components/population/LinkedGrievancesModal/LinkedGrievancesModal.tsx
@@ -25,6 +25,7 @@ import { HouseholdDetail } from '@restgenerated/models/HouseholdDetail';
 import { HouseholdSimple } from '@restgenerated/models/HouseholdSimple';
 import { PaginatedGrievanceTicketListList } from '@restgenerated/models/PaginatedGrievanceTicketListList';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { choicesToDict, grievanceTicketStatusToColor } from '@utils/utils';
 import { createApiParams } from '@utils/apiUtils';
@@ -68,33 +69,28 @@ export function LinkedGrievancesModal({
   const { selectedProgram } = useProgramContext();
   const beneficiaryGroup = selectedProgram?.beneficiaryGroup;
 
-  const { data: grievances } = useQuery<PaginatedGrievanceTicketListList>({
-    queryKey: [
-      'linkedGrievanceTickets',
-      businessArea,
-      selectedProgram?.id,
-      selectedProgram?.code,
-      household.unicefId,
-    ],
-    queryFn: () => {
-      const queryParams = {
-        household: household.unicefId,
-        limit: 1000, // Get all tickets for this household
-      };
-
-      if (selectedProgram?.id && selectedProgram.id !== 'all') {
-        return RestService.restBusinessAreasProgramsGrievanceTicketsList(
-          createApiParams(
-            {
-              businessAreaSlug: businessArea,
-              programCode: selectedProgram.code,
-            },
-            queryParams,
-            { withPagination: true },
-          ),
-        );
-      }
+  const linkedGrievancesParams = createApiParams(
+    {
+      businessAreaSlug: businessArea,
+      programCode: selectedProgram?.code,
     },
+    {
+      household: household.unicefId,
+      limit: 1000, // Get all tickets for this household
+    },
+    { withPagination: true },
+  );
+
+  const { data: grievances } = useQuery<PaginatedGrievanceTicketListList>({
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsGrievanceTicketsList,
+      linkedGrievancesParams,
+    ),
+    queryFn: () =>
+      RestService.restBusinessAreasProgramsGrievanceTicketsList(
+        linkedGrievancesParams,
+      ),
+    enabled: !!selectedProgram?.id && selectedProgram.id !== 'all',
     placeholderData: keepPreviousData,
     refetchOnWindowFocus: false,
   });

--- a/src/frontend/src/components/rdi/RegistrationFilters.tsx
+++ b/src/frontend/src/components/rdi/RegistrationFilters.tsx
@@ -16,6 +16,7 @@ import withErrorBoundary from '@components/core/withErrorBoundary';
 import { useQuery } from '@tanstack/react-query';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 
 interface RegistrationFiltersProps {
   filter;
@@ -58,12 +59,10 @@ const RegistrationFilters = ({
 
   const { t } = useTranslation();
   const { data: registrationChoicesData } = useQuery({
-    queryKey: [
-      RestService
-        .restBusinessAreasProgramsRegistrationDataImportsStatusChoicesList.name,
-      businessAreaSlug,
-      programCode,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsRegistrationDataImportsStatusChoicesList,
+      { businessAreaSlug, programCode },
+    ),
     queryFn: () => {
       return RestService.restBusinessAreasProgramsRegistrationDataImportsStatusChoicesList(
         { businessAreaSlug, programCode },

--- a/src/frontend/src/components/rdi/RegistrationPeopleFilters.tsx
+++ b/src/frontend/src/components/rdi/RegistrationPeopleFilters.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { AssigneeAutocompleteRestFilter } from '@shared/autocompletes/AssigneeAutocompleteRestFilter';
 import { createHandleApplyFilterChange } from '@utils/utils';
@@ -56,12 +57,10 @@ const RegistrationPeopleFilters = ({
   const { businessAreaSlug, programCode } = useBaseUrl();
 
   const { data: registrationChoicesData } = useQuery({
-    queryKey: [
-      RestService
-        .restBusinessAreasProgramsRegistrationDataImportsStatusChoicesList.name,
-      businessAreaSlug,
-      programCode,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsRegistrationDataImportsStatusChoicesList,
+      { businessAreaSlug, programCode },
+    ),
     queryFn: () => {
       return RestService.restBusinessAreasProgramsRegistrationDataImportsStatusChoicesList(
         { businessAreaSlug, programCode },

--- a/src/frontend/src/components/rdi/create/ScreenBeneficiaryField.tsx
+++ b/src/frontend/src/components/rdi/create/ScreenBeneficiaryField.tsx
@@ -5,13 +5,17 @@ import { useBaseUrl } from '@hooks/useBaseUrl';
 import { ReactElement } from 'react';
 import { RestService } from '@restgenerated/services/RestService';
 import { useQuery } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { ProgramDetail } from '@restgenerated/models/ProgramDetail';
 
 export function ScreenBeneficiaryField(): ReactElement {
   const { t } = useTranslation();
   const { programCode, businessAreaSlug } = useBaseUrl();
   const { data: program, isLoading } = useQuery<ProgramDetail>({
-    queryKey: ['program', businessAreaSlug, programCode],
+    queryKey: restQueryKey(RestService.restBusinessAreasProgramsRetrieve, {
+      businessAreaSlug: businessAreaSlug,
+      code: programCode,
+    }),
     queryFn: () =>
       RestService.restBusinessAreasProgramsRetrieve({
         businessAreaSlug: businessAreaSlug,

--- a/src/frontend/src/components/rdi/create/kobo/KoboProjectSelect.tsx
+++ b/src/frontend/src/components/rdi/create/kobo/KoboProjectSelect.tsx
@@ -13,6 +13,7 @@ import { useBaseUrl } from '@hooks/useBaseUrl';
 import { ReactElement } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 
 const ComboBox = styled(Select)`
   & {
@@ -35,7 +36,9 @@ export function KoboProjectSelect(): ReactElement {
     isLoading: loading,
     error,
   } = useQuery({
-    queryKey: ['koboProjects', businessArea],
+    queryKey: restQueryKey(RestService.restBusinessAreasAllKoboProjectsCreate, {
+      slug: businessArea,
+    }),
     queryFn: async() => {
       return RestService.restBusinessAreasAllKoboProjectsCreate({
         slug: businessArea,

--- a/src/frontend/src/components/rdi/create/kobo/useSaveKoboImportDataAndCheckStatus.tsx
+++ b/src/frontend/src/components/rdi/create/kobo/useSaveKoboImportDataAndCheckStatus.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { KoboImportData } from '@restgenerated/models/KoboImportData';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useBaseUrl } from '@hooks/useBaseUrl';
@@ -44,7 +45,10 @@ export function useSaveKoboImportDataAndCheckStatus(): UseSaveKoboImportDataAndC
 
   // Query for polling kobo import data status
   const { data: koboImportData } = useQuery({
-    queryKey: ['koboImportData', importDataId, businessAreaSlug],
+    queryKey: restQueryKey(RestService.restBusinessAreasKoboImportDataRetrieve, {
+      businessAreaSlug,
+      id: importDataId,
+    }),
     queryFn: async () => {
       if (!importDataId || !businessAreaSlug) return null;
       return RestService.restBusinessAreasKoboImportDataRetrieve({

--- a/src/frontend/src/components/rdi/create/programPopulation/CreateImportFromProgramPopulation.tsx
+++ b/src/frontend/src/components/rdi/create/programPopulation/CreateImportFromProgramPopulation.tsx
@@ -5,6 +5,7 @@ import { useSnackbar } from '@hooks/useSnackBar';
 import { Box } from '@mui/material';
 import { PaginatedProgramListList } from '@restgenerated/models/PaginatedProgramListList';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { FormikRadioGroup } from '@shared/Formik/FormikRadioGroup';
 import { FormikAutocomplete } from '@shared/Formik/FormikAutocomplete/FormikAutocomplete';
 import { FormikTextField } from '@shared/Formik/FormikTextField';
@@ -63,22 +64,15 @@ export const CreateImportFromProgramPopulationForm = ({
     limit: 100,
   };
 
+  const programsParams = createApiParams(
+    { businessAreaSlug: businessArea, programCode: programId },
+    queryVariables,
+    { withPagination: true },
+  );
   const { data: programsData, isLoading: programsDataLoading } =
     useQuery<PaginatedProgramListList>({
-      queryKey: [
-        'businessAreasProgramsList',
-        queryVariables,
-        businessArea,
-        programId,
-      ],
-      queryFn: () =>
-        RestService.restBusinessAreasProgramsList(
-          createApiParams(
-            { businessAreaSlug: businessArea, programCode: programId },
-            queryVariables,
-            { withPagination: true },
-          ),
-        ),
+      queryKey: restQueryKey(RestService.restBusinessAreasProgramsList, programsParams),
+      queryFn: () => RestService.restBusinessAreasProgramsList(programsParams),
       placeholderData: keepPreviousData,
     });
 

--- a/src/frontend/src/components/rdi/create/programPopulation/CreateImportFromProgramPopulation.tsx
+++ b/src/frontend/src/components/rdi/create/programPopulation/CreateImportFromProgramPopulation.tsx
@@ -8,7 +8,7 @@ import { RestService } from '@restgenerated/services/RestService';
 import { FormikRadioGroup } from '@shared/Formik/FormikRadioGroup';
 import { FormikAutocomplete } from '@shared/Formik/FormikAutocomplete/FormikAutocomplete';
 import { FormikTextField } from '@shared/Formik/FormikTextField';
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { createApiParams } from '@utils/apiUtils';
 import { showApiErrorMessages } from '@utils/utils';
 import { Field, FormikProvider, useFormik } from 'formik';
@@ -79,6 +79,7 @@ export const CreateImportFromProgramPopulationForm = ({
             { withPagination: true },
           ),
         ),
+      placeholderData: keepPreviousData,
     });
 
   const onSubmit = async (values): Promise<void> => {

--- a/src/frontend/src/components/rdi/create/xlsx/useSaveXlsxImportDataAndCheckStatus.tsx
+++ b/src/frontend/src/components/rdi/create/xlsx/useSaveXlsxImportDataAndCheckStatus.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { ImportData } from '@restgenerated/models/ImportData';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useBaseUrl } from '@hooks/useBaseUrl';
@@ -41,7 +42,10 @@ export function useSaveXlsxImportDataAndCheckStatus(): UseSaveXlsxImportDataAndC
 
   // Query for polling import data status
   const { data: xlsxImportData } = useQuery({
-    queryKey: ['importData', importDataId, businessAreaSlug],
+    queryKey: restQueryKey(RestService.restBusinessAreasImportDataRetrieve, {
+      businessAreaSlug,
+      id: importDataId,
+    }),
     queryFn: async () => {
       if (!importDataId || !businessAreaSlug) return null;
       return RestService.restBusinessAreasImportDataRetrieve({

--- a/src/frontend/src/components/rdi/details/BiometricsResultsRdi.tsx
+++ b/src/frontend/src/components/rdi/details/BiometricsResultsRdi.tsx
@@ -8,6 +8,7 @@ import { usePermissions } from '@hooks/usePermissions';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { useQuery } from '@tanstack/react-query';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import PersonIcon from '@mui/icons-material/Person';
 import {
   Box,
@@ -68,25 +69,33 @@ const BiometricsResultsRdi = ({
 
   const { businessAreaSlug, programCode } = useBaseUrl();
 
+  const individual1Params = {
+    businessAreaSlug,
+    id: individual1?.id,
+    programCode,
+  };
   const individual1Query = useQuery({
-    queryKey: ['individual', individual1?.id, businessAreaSlug, programCode],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsIndividualsRetrieve,
+      individual1Params,
+    ),
     queryFn: () =>
-      RestService.restBusinessAreasProgramsIndividualsRetrieve({
-        businessAreaSlug,
-        id: individual1?.id,
-        programCode,
-      }),
+      RestService.restBusinessAreasProgramsIndividualsRetrieve(individual1Params),
     enabled: dialogOpen && !!individual1?.id,
   });
 
+  const individual2Params = {
+    businessAreaSlug,
+    id: individual2?.id,
+    programCode,
+  };
   const individual2Query = useQuery({
-    queryKey: ['individual', individual2?.id, businessAreaSlug, programCode],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsIndividualsRetrieve,
+      individual2Params,
+    ),
     queryFn: () =>
-      RestService.restBusinessAreasProgramsIndividualsRetrieve({
-        businessAreaSlug,
-        id: individual2?.id,
-        programCode,
-      }),
+      RestService.restBusinessAreasProgramsIndividualsRetrieve(individual2Params),
     enabled: dialogOpen && !!individual2?.id,
   });
 

--- a/src/frontend/src/components/rdi/details/MergeRegistrationDataImportDialog.tsx
+++ b/src/frontend/src/components/rdi/details/MergeRegistrationDataImportDialog.tsx
@@ -16,6 +16,7 @@ import { LoadingButton } from '@core/LoadingButton';
 import { useProgramContext } from '../../../programContext';
 import withErrorBoundary from '@components/core/withErrorBoundary';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useActionMutation } from '@hooks/useActionMutation';
 import { RegistrationDataImportDetail } from '@restgenerated/models/RegistrationDataImportDetail';
 
@@ -35,7 +36,9 @@ function MergeRegistrationDataImportDialog({
   const { mutateAsync, isPending } = useActionMutation(
     registration.id,
     RestService.restBusinessAreasProgramsRegistrationDataImportsMergeCreate,
-    [RestService.restBusinessAreasProgramsRegistrationDataImportsRetrieve.name],
+    restQueryKey(
+      RestService.restBusinessAreasProgramsRegistrationDataImportsRetrieve,
+    ),
   );
   const merge = async(): Promise<void> => {
     const { errors } = await mutateAsync();

--- a/src/frontend/src/components/rdi/details/RegistrationDataImportDetailsPageHeader.tsx
+++ b/src/frontend/src/components/rdi/details/RegistrationDataImportDetailsPageHeader.tsx
@@ -71,10 +71,9 @@ const RegistrationDataImportDetailsPageHeader = ({
     useActionMutation(
       registration.id,
       RestService.restBusinessAreasProgramsRegistrationDataImportsEraseCreate,
-      [
-        RestService.restBusinessAreasProgramsRegistrationDataImportsRetrieve
-          .name,
-      ],
+      restQueryKey(
+        RestService.restBusinessAreasProgramsRegistrationDataImportsRetrieve,
+      ),
     );
   const [showRefuseRdiForm, setShowRefuseRdiForm] = useState(false);
 

--- a/src/frontend/src/components/rdi/details/RegistrationDataImportDetailsPageHeader.tsx
+++ b/src/frontend/src/components/rdi/details/RegistrationDataImportDetailsPageHeader.tsx
@@ -18,6 +18,7 @@ import { RegistrationDataImportStatusEnum } from '@restgenerated/models/Registra
 import { RegistrationDataImportDetail } from '@restgenerated/models/RegistrationDataImportDetail';
 import { useActionMutation } from '@hooks/useActionMutation';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import type { RefuseRdi } from '@restgenerated/models/RefuseRdi';
 
@@ -60,10 +61,9 @@ const RegistrationDataImportDetailsPageHeader = ({
     },
     onSuccess: () => {
       client.invalidateQueries({
-        queryKey: [
-          RestService.restBusinessAreasProgramsRegistrationDataImportsRetrieve
-            .name,
-        ],
+        queryKey: restQueryKey(
+          RestService.restBusinessAreasProgramsRegistrationDataImportsRetrieve,
+        ),
       });
     },
   });

--- a/src/frontend/src/components/rdi/details/RerunDedupe.tsx
+++ b/src/frontend/src/components/rdi/details/RerunDedupe.tsx
@@ -17,6 +17,7 @@ import { RegistrationDataImportDetail } from '@restgenerated/models/Registration
 import { useActionMutation } from '@hooks/useActionMutation';
 import { RestService } from '@restgenerated/services/RestService';
 import { showApiErrorMessages } from '@utils/utils';
+import { restQueryKey } from '@utils/queryKeys';
 
 interface RerunDedupeProps {
   registration: RegistrationDataImportDetail;
@@ -32,7 +33,9 @@ export const RerunDedupe = ({
   const { mutateAsync: mutate, isPending: loading } = useActionMutation(
     registration.id,
     RestService.restBusinessAreasProgramsRegistrationDataImportsDeduplicateCreate,
-    [RestService.restBusinessAreasProgramsRegistrationDataImportsRetrieve.name],
+    restQueryKey(
+      RestService.restBusinessAreasProgramsRegistrationDataImportsRetrieve,
+    ),
   );
   const rerunDedupe = async(): Promise<void> => {
     try {

--- a/src/frontend/src/components/rdi/details/households/RegistrationDetails.tsx
+++ b/src/frontend/src/components/rdi/details/households/RegistrationDetails.tsx
@@ -8,6 +8,7 @@ import { Title } from '@core/Title';
 import { ReactElement } from 'react';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useQuery } from '@tanstack/react-query';
 
 const Overview = styled(Paper)<{ theme?: Theme }>`
@@ -36,14 +37,20 @@ export function RegistrationDetails({
   const { t } = useTranslation();
   const { businessArea, programId } = useBaseUrl();
 
+  const rdiParams = {
+    businessAreaSlug: businessArea,
+    id: hctId,
+    programCode: programId,
+  };
   const { data, isLoading } = useQuery({
-    queryKey: ['registrationDataImport', businessArea, programId, hctId],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsRegistrationDataImportsRetrieve,
+      rdiParams,
+    ),
     queryFn: () =>
-      RestService.restBusinessAreasProgramsRegistrationDataImportsRetrieve({
-        businessAreaSlug: businessArea,
-        id: hctId,
-        programCode: programId,
-      }),
+      RestService.restBusinessAreasProgramsRegistrationDataImportsRetrieve(
+        rdiParams,
+      ),
     enabled: !!businessArea && !!programId && !!hctId,
   });
 

--- a/src/frontend/src/components/rdi/details/individual/DocumentRegistrationPhotoModal.tsx
+++ b/src/frontend/src/components/rdi/details/individual/DocumentRegistrationPhotoModal.tsx
@@ -2,6 +2,7 @@ import PhotoModal from '@core/PhotoModal/PhotoModal';
 import { IndividualDetail } from '@restgenerated/models/IndividualDetail';
 import { IndividualPhotoDetail } from '@restgenerated/models/IndividualPhotoDetail';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useQuery } from '@tanstack/react-query';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { useProgramContext } from 'src/programContext';
@@ -21,19 +22,20 @@ export function DocumentRegistrationPhotoModal({
   const { businessArea } = useBaseUrl();
   const { selectedProgram } = useProgramContext();
 
+  const photoParams = {
+    businessAreaSlug: businessArea,
+    programCode: selectedProgram?.code || '',
+    id: individual?.id,
+  };
   const { data } = useQuery<IndividualPhotoDetail>({
-    queryKey: [
-      'individualPhotos',
-      businessArea,
-      selectedProgram?.code,
-      individual?.id,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsIndividualsPhotosRetrieve,
+      photoParams,
+    ),
     queryFn: () =>
-      RestService.restBusinessAreasProgramsIndividualsPhotosRetrieve({
-        businessAreaSlug: businessArea,
-        programCode: selectedProgram?.code || '',
-        id: individual?.id,
-      }),
+      RestService.restBusinessAreasProgramsIndividualsPhotosRetrieve(
+        photoParams,
+      ),
     enabled: !!businessArea && !!selectedProgram?.code && !!individual?.id,
   });
 

--- a/src/frontend/src/components/rdi/details/individual/ImportedIndividualFlexFieldPhotoModal.tsx
+++ b/src/frontend/src/components/rdi/details/individual/ImportedIndividualFlexFieldPhotoModal.tsx
@@ -4,20 +4,25 @@ import PhotoModal from '@components/core/PhotoModal/PhotoModal';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { IndividualDetail } from '@restgenerated/models/IndividualDetail';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useQuery } from '@tanstack/react-query';
 
 export function ImportedIndividualFlexFieldPhotoModal({ field }): ReactElement {
   const { id } = useParams();
   const { businessArea, programId } = useBaseUrl();
 
+  const individualParams = {
+    businessAreaSlug: businessArea,
+    programCode: programId,
+    id: id,
+  };
   const { data } = useQuery<IndividualDetail>({
-    queryKey: ['individual', businessArea, programId, id],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsIndividualsRetrieve,
+      individualParams,
+    ),
     queryFn: () =>
-      RestService.restBusinessAreasProgramsIndividualsRetrieve({
-        businessAreaSlug: businessArea,
-        programCode: programId,
-        id: id,
-      }),
+      RestService.restBusinessAreasProgramsIndividualsRetrieve(individualParams),
     enabled: !!businessArea && !!programId && !!id,
   });
 

--- a/src/frontend/src/components/rest/TableRestComponent/TableRestComponent.tsx
+++ b/src/frontend/src/components/rest/TableRestComponent/TableRestComponent.tsx
@@ -12,6 +12,7 @@ import {
   TableCell as MuiTableCell,
   TableContainer as MuiTableContainer,
   TableRow as MuiTableRow,
+  LinearProgress,
   Skeleton,
   TablePagination,
 } from '@mui/material';
@@ -165,6 +166,7 @@ interface TableRestComponentProps<T extends { [key: string]: any }> {
   order: Order;
   title?: string;
   loading?: boolean;
+  isFetching?: boolean;
   allowSort?: boolean;
   isOnPaper?: boolean;
   actions?: Array<ReactElement>;
@@ -190,6 +192,7 @@ export function TableRestComponent<T>({
   orderBy,
   onSelectAllClick,
   loading: loadingProp = false,
+  isFetching = false,
   allowSort = true,
   isOnPaper = true,
   actions = [],
@@ -260,9 +263,28 @@ export function TableRestComponent<T>({
     body = <>{data.map((row) => renderRow(row))}</>;
   }
 
+  // A background refetch while previous rows stay visible (keepPreviousData) — show a
+  // thin progress bar over the existing rows. `position: relative` is only applied when the
+  // bar is present so tables render identically (and snapshots stay stable) when idle.
+  const showFetchingProgress = isFetching && !loadingProp;
+
   const table = (
     <>
-      <StyledTableContainer>
+      <StyledTableContainer
+        sx={showFetchingProgress ? { position: 'relative' } : undefined}
+      >
+        {showFetchingProgress && (
+          <LinearProgress
+            data-cy="table-fetching-progress"
+            sx={{
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              right: 0,
+              zIndex: 1,
+            }}
+          />
+        )}
         <StyledBox>
           {title ? <EnhancedTableToolbar title={title} /> : null}
           <StyledBox

--- a/src/frontend/src/components/rest/TableRestComponent/TableRestComponent.tsx
+++ b/src/frontend/src/components/rest/TableRestComponent/TableRestComponent.tsx
@@ -263,9 +263,8 @@ export function TableRestComponent<T>({
     body = <>{data.map((row) => renderRow(row))}</>;
   }
 
-  // A background refetch while previous rows stay visible (keepPreviousData) — show a
-  // thin progress bar over the existing rows. `position: relative` is only applied when the
-  // bar is present so tables render identically (and snapshots stay stable) when idle.
+  // Background refetch with previous rows still visible (keepPreviousData). `position:
+  // relative` is applied only when the bar is present, so idle tables render unchanged.
   const showFetchingProgress = isFetching && !loadingProp;
 
   const table = (

--- a/src/frontend/src/components/rest/UniversalRestQueryTable/UniversalRestQueryTable.tsx
+++ b/src/frontend/src/components/rest/UniversalRestQueryTable/UniversalRestQueryTable.tsx
@@ -5,6 +5,7 @@ import { useBaseUrl } from '@hooks/useBaseUrl';
 import { HeadCell } from '@core/Table/EnhancedTableHead';
 import { Order } from '@components/rest/TableRestComponent/TableRestComponent';
 import { isUndefined, omitBy } from 'lodash';
+import { restQueryKey } from '@utils/queryKeys';
 
 interface UniversalRestQueryTableProps<T = any, K = any> {
   rowsPerPageOptions?: number[];
@@ -37,9 +38,12 @@ export const UniversalRestQueryTable = <T, K>(
   const { businessArea, programCode } = useBaseUrl();
   const { queryVariables } = props;
   const cleanedQueryVariables = omitBy(queryVariables, isUndefined);
-  // eslint-disable-next-line @tanstack/query/exhaustive-deps
   const { data, isLoading, error } = useQuery({
-    queryKey: [query.name, cleanedQueryVariables, programCode, businessArea],
+    queryKey: restQueryKey(query, {
+      ...cleanedQueryVariables,
+      programCode,
+      businessArea,
+    }),
     queryFn: () =>
       query({
         businessAreaSlug: businessArea,

--- a/src/frontend/src/components/rest/UniversalRestTable/UniversalRestTable.tsx
+++ b/src/frontend/src/components/rest/UniversalRestTable/UniversalRestTable.tsx
@@ -33,6 +33,7 @@ interface UniversalRestTableProps<T = any, K = any> {
   data: any;
   error;
   isLoading: boolean;
+  isFetching?: boolean;
   queryVariables: any;
   setQueryVariables: (variables: K) => void;
   itemsCount?: number;
@@ -62,6 +63,7 @@ export const UniversalRestTable = <T, K>({
   data,
   error,
   isLoading,
+  isFetching,
   queryVariables,
   setQueryVariables,
   itemsCount,
@@ -148,6 +150,7 @@ export const UniversalRestTable = <T, K>({
       actions={actions}
       data={typedResults}
       loading={isLoading}
+      isFetching={isFetching}
       renderRow={renderRow}
       isOnPaper={isOnPaper}
       headCells={headCells}

--- a/src/frontend/src/components/targeting/EditTargetPopulation/EditTargetPopulation.tsx
+++ b/src/frontend/src/components/targeting/EditTargetPopulation/EditTargetPopulation.tsx
@@ -37,6 +37,7 @@ import { ProgramDetail } from '@restgenerated/models/ProgramDetail';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { PatchedTargetPopulationCreate } from '@restgenerated/models/PatchedTargetPopulationCreate';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { showApiErrorMessages } from '@utils/utils';
 import { hasPermissions, PERMISSIONS } from '../../../config/permissions';
 
@@ -144,10 +145,14 @@ const EditTargetPopulation = ({
       onSuccess: () => {
         // Invalidate the target population detail and the list so edits are reflected.
         queryClient.invalidateQueries({
-          queryKey: ['targetPopulation', businessArea, id, programCode],
+          queryKey: restQueryKey(
+            RestService.restBusinessAreasProgramsTargetPopulationsRetrieve,
+          ),
         });
         queryClient.invalidateQueries({
-          queryKey: ['businessAreasProgramsTargetPopulationsList'],
+          queryKey: restQueryKey(
+            RestService.restBusinessAreasProgramsTargetPopulationsList,
+          ),
         });
       },
     });

--- a/src/frontend/src/components/targeting/EditTargetPopulation/EditTargetPopulation.tsx
+++ b/src/frontend/src/components/targeting/EditTargetPopulation/EditTargetPopulation.tsx
@@ -146,7 +146,6 @@ const EditTargetPopulation = ({
           requestBody,
         }),
       onSuccess: () => {
-        // Invalidate the target population detail and the list so edits are reflected.
         queryClient.invalidateQueries({
           queryKey: restQueryKey(
             RestService.restBusinessAreasProgramsTargetPopulationsRetrieve,

--- a/src/frontend/src/components/targeting/EditTargetPopulation/EditTargetPopulation.tsx
+++ b/src/frontend/src/components/targeting/EditTargetPopulation/EditTargetPopulation.tsx
@@ -106,7 +106,10 @@ const EditTargetPopulation = ({
   };
 
   const { data: programData } = useQuery<ProgramDetail>({
-    queryKey: ['programDetail', businessArea, programCode],
+    queryKey: restQueryKey(RestService.restBusinessAreasProgramsRetrieve, {
+      businessAreaSlug: businessArea,
+      code: programCode,
+    }),
     queryFn: () =>
       RestService.restBusinessAreasProgramsRetrieve({
         businessAreaSlug: businessArea,

--- a/src/frontend/src/components/targeting/EditTargetPopulation/EditTargetPopulation.tsx
+++ b/src/frontend/src/components/targeting/EditTargetPopulation/EditTargetPopulation.tsx
@@ -142,9 +142,12 @@ const EditTargetPopulation = ({
           requestBody,
         }),
       onSuccess: () => {
-        // Invalidate and refetch the grievance ticket details
+        // Invalidate the target population detail and the list so edits are reflected.
         queryClient.invalidateQueries({
           queryKey: ['targetPopulation', businessArea, id, programCode],
+        });
+        queryClient.invalidateQueries({
+          queryKey: ['businessAreasProgramsTargetPopulationsList'],
         });
       },
     });

--- a/src/frontend/src/components/targeting/TargetPopulationForPeopleFilters.tsx
+++ b/src/frontend/src/components/targeting/TargetPopulationForPeopleFilters.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { PaymentPlanStatusEnum } from '@restgenerated/models/PaymentPlanStatusEnum';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useQuery } from '@tanstack/react-query';
 import { createHandleApplyFilterChange } from '@utils/utils';
 import { DatePickerFilter } from '@core/DatePickerFilter';
@@ -62,7 +63,7 @@ export const TargetPopulationForPeopleFilters = ({
   ];
 
   const { data: statusChoicesData } = useQuery({
-    queryKey: ['choicesPaymentPlanStatusList'],
+    queryKey: restQueryKey(RestService.restChoicesPaymentPlanStatusList),
     queryFn: () => RestService.restChoicesPaymentPlanStatusList(),
   });
 

--- a/src/frontend/src/components/targeting/TargetPopulationTableFilters.tsx
+++ b/src/frontend/src/components/targeting/TargetPopulationTableFilters.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { PaymentPlanStatusEnum } from '@restgenerated/models/PaymentPlanStatusEnum';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useQuery } from '@tanstack/react-query';
 import { createHandleApplyFilterChange } from '@utils/utils';
 import { DatePickerFilter } from '@core/DatePickerFilter';
@@ -65,7 +66,7 @@ export const TargetPopulationTableFilters = ({
   ];
 
   const { data: statusChoicesData } = useQuery({
-    queryKey: ['choicesPaymentPlanStatusList'],
+    queryKey: restQueryKey(RestService.restChoicesPaymentPlanStatusList),
     queryFn: () => RestService.restChoicesPaymentPlanStatusList(),
   });
 

--- a/src/frontend/src/components/targeting/TargetingCriteriaDisplay/AddFilterTargetingCriteriaDisplay.tsx
+++ b/src/frontend/src/components/targeting/TargetingCriteriaDisplay/AddFilterTargetingCriteriaDisplay.tsx
@@ -4,6 +4,7 @@ import { AddCircleOutlined } from '@mui/icons-material';
 import { Box, Button } from '@mui/material';
 import { TargetPopulationDetail } from '@restgenerated/models/TargetPopulationDetail';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useQuery } from '@tanstack/react-query';
 import { Fragment, ReactElement, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -94,7 +95,10 @@ const AddFilterTargetingCriteriaDisplay = ({
   const { businessArea, isAllPrograms } = useBaseUrl();
 
   const { data: allCoreFieldsAttributesData, isLoading: loading } = useQuery({
-    queryKey: ['allFieldsAttributes', businessArea, selectedProgram?.id],
+    queryKey: restQueryKey(RestService.restBusinessAreasAllFieldsAttributesList, {
+      slug: businessArea,
+      programId: selectedProgram?.id,
+    }),
     queryFn: () =>
       RestService.restBusinessAreasAllFieldsAttributesList({
         slug: businessArea,

--- a/src/frontend/src/components/targeting/TargetingCriteriaDisplay/AddFilterTargetingCriteriaDisplay.tsx
+++ b/src/frontend/src/components/targeting/TargetingCriteriaDisplay/AddFilterTargetingCriteriaDisplay.tsx
@@ -115,7 +115,8 @@ const AddFilterTargetingCriteriaDisplay = ({
 
   useEffect(() => {
     if (loading) return;
-    const allDataChoicesDictTmp = allCoreFieldsAttributesData?.results?.reduce(
+    // restBusinessAreasAllFieldsAttributesList returns a bare array, not a paginated page.
+    const allDataChoicesDictTmp = allCoreFieldsAttributesData?.reduce(
       (acc, item) => {
         acc[item.name] = item.choices;
         return acc;

--- a/src/frontend/src/components/targeting/TargetingCriteriaDisplay/Criteria.tsx
+++ b/src/frontend/src/components/targeting/TargetingCriteriaDisplay/Criteria.tsx
@@ -27,6 +27,7 @@ import { useProgramContext } from 'src/programContext';
 import withErrorBoundary from '@components/core/withErrorBoundary';
 import { LabelizedField } from '@components/core/LabelizedField';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useQuery } from '@tanstack/react-query';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { FspChoices } from '@restgenerated/models/FspChoices';
@@ -291,10 +292,10 @@ export function Criteria({
   const { data: availableFspsForDeliveryMechanismData } = useQuery<
     FspChoices[]
   >({
-    queryKey: [
-      'businessAreasAvailableFspsForDeliveryMechanismsList',
-      businessArea,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasAvailableFspsForDeliveryMechanismsList,
+      { businessAreaSlug: businessArea },
+    ),
     queryFn: () =>
       RestService.restBusinessAreasAvailableFspsForDeliveryMechanismsList({
         businessAreaSlug: businessArea,

--- a/src/frontend/src/components/targeting/TargetingCriteriaDisplay/VulnerabilityScoreComponent.tsx
+++ b/src/frontend/src/components/targeting/TargetingCriteriaDisplay/VulnerabilityScoreComponent.tsx
@@ -16,6 +16,7 @@ import { ApplyEngineFormula } from '@restgenerated/models/ApplyEngineFormula';
 import { PatchedTargetPopulationCreate } from '@restgenerated/models/PatchedTargetPopulationCreate';
 import { TargetPopulationDetail } from '@restgenerated/models/TargetPopulationDetail';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useMutation, useQueryClient, useQuery } from '@tanstack/react-query';
 import { ReactElement, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -130,15 +131,14 @@ export function VulnerabilityScoreComponent({
     onSuccess: () => {
       showMessage(t('Formula is executing, please wait until completed'));
       queryClient.invalidateQueries({
-        queryKey: [
-          'targetPopulation',
-          businessArea,
-          targetPopulation.id,
-          programId,
-        ],
+        queryKey: restQueryKey(
+          RestService.restBusinessAreasProgramsTargetPopulationsRetrieve,
+        ),
       });
       queryClient.invalidateQueries({
-        queryKey: ['businessAreasProgramsTargetPopulationsList'],
+        queryKey: restQueryKey(
+          RestService.restBusinessAreasProgramsTargetPopulationsList,
+        ),
       });
     },
     onError: (error) => {
@@ -166,15 +166,14 @@ export function VulnerabilityScoreComponent({
         }),
       onSuccess: () => {
         queryClient.invalidateQueries({
-          queryKey: [
-            'targetPopulation',
-            businessArea,
-            targetPopulation.id,
-            programId,
-          ],
+          queryKey: restQueryKey(
+            RestService.restBusinessAreasProgramsTargetPopulationsRetrieve,
+          ),
         });
         queryClient.invalidateQueries({
-          queryKey: ['businessAreasProgramsTargetPopulationsList'],
+          queryKey: restQueryKey(
+            RestService.restBusinessAreasProgramsTargetPopulationsList,
+          ),
         });
       },
     });

--- a/src/frontend/src/components/targeting/TargetingCriteriaDisplay/VulnerabilityScoreComponent.tsx
+++ b/src/frontend/src/components/targeting/TargetingCriteriaDisplay/VulnerabilityScoreComponent.tsx
@@ -188,19 +188,16 @@ export function VulnerabilityScoreComponent({
       ? String(targetPopulation.steficonRuleTargeting.rule.id)
       : '',
   );
+  const engineRulesParams = {
+    enabled: true,
+    deprecated: false,
+    type: 'TARGETING' as const,
+    businessArea: businessArea,
+  };
+
   const { data, isLoading: loading } = useQuery({
-    queryKey: [
-      'engineRules',
-      businessArea,
-      { enabled: true, deprecated: false, type: 'TARGETING' },
-    ],
-    queryFn: () =>
-      RestService.restEngineRulesList({
-        enabled: true,
-        deprecated: false,
-        type: 'TARGETING',
-        businessArea: businessArea,
-      }),
+    queryKey: restQueryKey(RestService.restEngineRulesList, engineRulesParams),
+    queryFn: () => RestService.restEngineRulesList(engineRulesParams),
   });
 
   if (loading) return <LoadingComponent />;

--- a/src/frontend/src/components/targeting/TargetingCriteriaDisplay/VulnerabilityScoreComponent.tsx
+++ b/src/frontend/src/components/targeting/TargetingCriteriaDisplay/VulnerabilityScoreComponent.tsx
@@ -137,6 +137,9 @@ export function VulnerabilityScoreComponent({
           programId,
         ],
       });
+      queryClient.invalidateQueries({
+        queryKey: ['businessAreasProgramsTargetPopulationsList'],
+      });
     },
     onError: (error) => {
       showApiErrorMessages(error, showMessage);
@@ -169,6 +172,9 @@ export function VulnerabilityScoreComponent({
             targetPopulation.id,
             programId,
           ],
+        });
+        queryClient.invalidateQueries({
+          queryKey: ['businessAreasProgramsTargetPopulationsList'],
         });
       },
     });

--- a/src/frontend/src/containers/BusinessAreaSelect.tsx
+++ b/src/frontend/src/containers/BusinessAreaSelect.tsx
@@ -12,6 +12,7 @@ import {
 } from 'react';
 import { RestService } from '@restgenerated/index';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 
 const CountrySelect = styled(Select)`
   && {
@@ -70,16 +71,21 @@ export function BusinessAreaSelect(): ReactElement {
     }
   }, [businessAreaSlug, selectedBusinessArea]);
 
+  const profileParams = {
+    businessAreaSlug,
+    program: programCode === 'all' ? undefined : programCode,
+  };
+
   const { data } = useQuery({
-    queryKey: ['businessAreasProfile', businessAreaSlug, programCode],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasUsersProfileRetrieve,
+      profileParams,
+    ),
     queryFn: () => {
-      return RestService.restBusinessAreasUsersProfileRetrieve({
-        businessAreaSlug,
-        program: programCode === 'all' ? undefined : programCode,
-      });
+      return RestService.restBusinessAreasUsersProfileRetrieve(profileParams);
     },
-    staleTime: 15 * 60 * 1000, // Data is considered fresh for 15 minutes (business areas don't change often)
-    gcTime: 60 * 60 * 1000, // Keep unused data in cache for 1 hour
+    staleTime: 5 * 60 * 1000, // Data is considered fresh for 5 minutes
+    gcTime: 30 * 60 * 1000, // Keep unused data in cache for 30 minutes
     refetchOnWindowFocus: false, // Don't refetch when window regains focus
   });
 

--- a/src/frontend/src/containers/DefaultRoute.tsx
+++ b/src/frontend/src/containers/DefaultRoute.tsx
@@ -3,16 +3,23 @@ import { RestService } from '@restgenerated/index';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { useQuery } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
+import { restQueryKey } from '@utils/queryKeys';
 
 export const DefaultRoute = (): ReactElement | null => {
   const { businessAreaSlug, programCode } = useBaseUrl();
+
+  const profileParams = {
+    businessAreaSlug,
+    program: programCode === 'all' ? undefined : programCode,
+  };
+
   const { data: meData } = useQuery({
-    queryKey: ['profile', businessAreaSlug, programCode],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasUsersProfileRetrieve,
+      profileParams,
+    ),
     queryFn: () => {
-      return RestService.restBusinessAreasUsersProfileRetrieve({
-        businessAreaSlug,
-        program: programCode === 'all' ? undefined : programCode,
-      });
+      return RestService.restBusinessAreasUsersProfileRetrieve(profileParams);
     },
     staleTime: 5 * 60 * 1000, // Data is considered fresh for 5 minutes
     gcTime: 30 * 60 * 1000, // Keep unused data in cache for 30 minutes

--- a/src/frontend/src/containers/GlobalProgramSelect.tsx
+++ b/src/frontend/src/containers/GlobalProgramSelect.tsx
@@ -21,6 +21,7 @@ import { styled } from '@mui/material/styles';
 import { ProgramDetail } from '@restgenerated/models/ProgramDetail';
 import { RestService } from '@restgenerated/services/RestService';
 import { useQuery } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { programStatusToColor } from '@utils/utils';
 import {
   ChangeEvent,
@@ -130,7 +131,10 @@ export const GlobalProgramSelect = () => {
     isLoading: loadingPrograms,
     refetch: refetchPrograms,
   } = useQuery<PaginatedProgramListList>({
-    queryKey: ['businessAreaProgram', businessArea, queryParams],
+    queryKey: restQueryKey(RestService.restBusinessAreasProgramsList, {
+      businessAreaSlug: businessArea,
+      ...queryParams,
+    }),
     queryFn: () =>
       RestService.restBusinessAreasProgramsList({
         businessAreaSlug: businessArea,
@@ -147,7 +151,10 @@ export const GlobalProgramSelect = () => {
     isError: programError,
     error: programQueryError,
   } = useQuery<ProgramDetail>({
-    queryKey: ['businessAreaProgram', businessArea, programId],
+    queryKey: restQueryKey(RestService.restBusinessAreasProgramsRetrieve, {
+      businessAreaSlug: businessArea,
+      code: programId,
+    }),
     queryFn: async () => {
       try {
         return await RestService.restBusinessAreasProgramsRetrieve({

--- a/src/frontend/src/containers/dialogs/programs/ActivateProgram.tsx
+++ b/src/frontend/src/containers/dialogs/programs/ActivateProgram.tsx
@@ -5,6 +5,7 @@ import { Button, Dialog, DialogContent, DialogTitle } from '@mui/material';
 import { ProgramDetail } from '@restgenerated/models/ProgramDetail';
 import { RestService } from '@restgenerated/services/RestService';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { showApiErrorMessages } from '@utils/utils';
 import { ReactElement, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -36,10 +37,10 @@ export const ActivateProgram = ({
     onSuccess: () => {
       showMessage(t('Programme activated.'));
       queryClient.invalidateQueries({
-        queryKey: ['program', businessArea, program.code],
+        queryKey: restQueryKey(RestService.restBusinessAreasProgramsRetrieve),
       });
       queryClient.invalidateQueries({
-        queryKey: ['businessAreasProgramsList'],
+        queryKey: restQueryKey(RestService.restBusinessAreasProgramsList),
       });
       setOpen(false);
     },

--- a/src/frontend/src/containers/dialogs/programs/ActivateProgram.tsx
+++ b/src/frontend/src/containers/dialogs/programs/ActivateProgram.tsx
@@ -38,6 +38,9 @@ export const ActivateProgram = ({
       queryClient.invalidateQueries({
         queryKey: ['program', businessArea, program.code],
       });
+      queryClient.invalidateQueries({
+        queryKey: ['businessAreasProgramsList'],
+      });
       setOpen(false);
     },
     onError: (error) => {

--- a/src/frontend/src/containers/dialogs/programs/DeleteProgram.tsx
+++ b/src/frontend/src/containers/dialogs/programs/DeleteProgram.tsx
@@ -47,7 +47,7 @@ export const DeleteProgram = ({
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
   const { showMessage } = useSnackbar();
-  const { businessArea, programId } = useBaseUrl();
+  const { businessArea } = useBaseUrl();
   const queryClient = useQueryClient();
 
   const { mutateAsync: deleteProgram, isPending: isPendingDelete } =
@@ -59,7 +59,7 @@ export const DeleteProgram = ({
         }),
       onSuccess: async () => {
         await queryClient.invalidateQueries({
-          queryKey: ['businessAreasProgramsList', businessArea, programId],
+          queryKey: ['businessAreasProgramsList'],
         });
         showMessage(t('Programme removed'));
         navigate(`/${businessArea}/programs/all/list`);

--- a/src/frontend/src/containers/dialogs/programs/DeleteProgram.tsx
+++ b/src/frontend/src/containers/dialogs/programs/DeleteProgram.tsx
@@ -5,6 +5,7 @@ import { Button, Dialog, DialogContent, DialogTitle } from '@mui/material';
 import { ProgramDetail } from '@restgenerated/models/ProgramDetail';
 import { RestService } from '@restgenerated/services/RestService';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { ReactElement, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
@@ -59,7 +60,7 @@ export const DeleteProgram = ({
         }),
       onSuccess: async () => {
         await queryClient.invalidateQueries({
-          queryKey: ['businessAreasProgramsList'],
+          queryKey: restQueryKey(RestService.restBusinessAreasProgramsList),
         });
         showMessage(t('Programme removed'));
         navigate(`/${businessArea}/programs/all/list`);

--- a/src/frontend/src/containers/dialogs/programs/FinishProgram.tsx
+++ b/src/frontend/src/containers/dialogs/programs/FinishProgram.tsx
@@ -6,6 +6,7 @@ import { useBaseUrl } from '@hooks/useBaseUrl';
 import { useSnackbar } from '@hooks/useSnackBar';
 import { RestService } from '@restgenerated/services/RestService';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { DialogActions } from '../DialogActions';
 import { DialogDescription } from '../DialogDescription';
 import { DialogFooter } from '../DialogFooter';
@@ -38,10 +39,10 @@ export function FinishProgram({ program }: FinishProgramProps): ReactElement {
         }),
       onSuccess: () => {
         queryClient.invalidateQueries({
-          queryKey: ['program', businessArea, program.code],
+          queryKey: restQueryKey(RestService.restBusinessAreasProgramsRetrieve),
         });
         queryClient.invalidateQueries({
-          queryKey: ['businessAreasProgramsList'],
+          queryKey: restQueryKey(RestService.restBusinessAreasProgramsList),
         });
       },
     });

--- a/src/frontend/src/containers/dialogs/programs/FinishProgram.tsx
+++ b/src/frontend/src/containers/dialogs/programs/FinishProgram.tsx
@@ -40,6 +40,9 @@ export function FinishProgram({ program }: FinishProgramProps): ReactElement {
         queryClient.invalidateQueries({
           queryKey: ['program', businessArea, program.code],
         });
+        queryClient.invalidateQueries({
+          queryKey: ['businessAreasProgramsList'],
+        });
       },
     });
 

--- a/src/frontend/src/containers/dialogs/programs/ReactivateProgram.tsx
+++ b/src/frontend/src/containers/dialogs/programs/ReactivateProgram.tsx
@@ -12,6 +12,7 @@ import { ProgramDetail } from '@restgenerated/models/ProgramDetail';
 import { ProgramStatusEnum } from '@restgenerated/models/ProgramStatusEnum';
 import { RestService } from '@restgenerated/services/RestService';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { ReactElement, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useProgramContext } from '../../../programContext';
@@ -46,10 +47,10 @@ export function ReactivateProgram({
         status: ProgramStatusEnum.ACTIVE,
       });
       queryClient.invalidateQueries({
-        queryKey: ['program', businessAreaSlug, program.code],
+        queryKey: restQueryKey(RestService.restBusinessAreasProgramsRetrieve),
       });
       queryClient.invalidateQueries({
-        queryKey: ['businessAreasProgramsList'],
+        queryKey: restQueryKey(RestService.restBusinessAreasProgramsList),
       });
       showMessage(t('Programme reactivated.'));
       setOpen(false);

--- a/src/frontend/src/containers/dialogs/programs/ReactivateProgram.tsx
+++ b/src/frontend/src/containers/dialogs/programs/ReactivateProgram.tsx
@@ -48,6 +48,9 @@ export function ReactivateProgram({
       queryClient.invalidateQueries({
         queryKey: ['program', businessAreaSlug, program.code],
       });
+      queryClient.invalidateQueries({
+        queryKey: ['businessAreasProgramsList'],
+      });
       showMessage(t('Programme reactivated.'));
       setOpen(false);
     },

--- a/src/frontend/src/containers/dialogs/targetPopulation/DeleteTargetPopulation.tsx
+++ b/src/frontend/src/containers/dialogs/targetPopulation/DeleteTargetPopulation.tsx
@@ -9,6 +9,7 @@ import {
   DialogTitle,
 } from '@mui/material';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -50,7 +51,9 @@ export const DeleteTargetPopulation = ({
       }),
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: ['businessAreasProgramsTargetPopulationsList'],
+        queryKey: restQueryKey(
+          RestService.restBusinessAreasProgramsTargetPopulationsList,
+        ),
       });
     },
   });

--- a/src/frontend/src/containers/dialogs/targetPopulation/DeleteTargetPopulation.tsx
+++ b/src/frontend/src/containers/dialogs/targetPopulation/DeleteTargetPopulation.tsx
@@ -9,7 +9,7 @@ import {
   DialogTitle,
 } from '@mui/material';
 import { RestService } from '@restgenerated/services/RestService';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
@@ -32,6 +32,7 @@ export const DeleteTargetPopulation = ({
   const { t } = useTranslation();
   const { baseUrl, businessArea, programId } = useBaseUrl();
   const { showMessage } = useSnackbar();
+  const queryClient = useQueryClient();
   const { mutateAsync: mutate, isPending: loadingDelete } = useMutation({
     mutationFn: ({
       businessAreaSlug,
@@ -47,6 +48,11 @@ export const DeleteTargetPopulation = ({
         programCode,
         id,
       }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['businessAreasProgramsTargetPopulationsList'],
+      });
+    },
   });
   const handleDelete = async(): Promise<void> => {
     try {

--- a/src/frontend/src/containers/dialogs/targetPopulation/DuplicateTargetPopulation.tsx
+++ b/src/frontend/src/containers/dialogs/targetPopulation/DuplicateTargetPopulation.tsx
@@ -7,6 +7,7 @@ import { ProgramDetail } from '@restgenerated/models/ProgramDetail';
 import { TargetPopulationCopy } from '@restgenerated/models/TargetPopulationCopy';
 import { TargetPopulationDetail } from '@restgenerated/models/TargetPopulationDetail';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { PaymentPlanGroupAutocompleteRest } from '@shared/autocompletes/rest/PaymentPlanGroupAutocompleteRest';
 import { ProgramCycleAutocompleteRest } from '@shared/autocompletes/rest/ProgramCycleAutocompleteRest';
 import { FormikChipAutocomplete } from '@shared/Formik/FormikChipAutocomplete/FormikChipAutocomplete';
@@ -84,7 +85,9 @@ export const DuplicateTargetPopulation = ({
       }),
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: ['businessAreasProgramsTargetPopulationsList'],
+        queryKey: restQueryKey(
+          RestService.restBusinessAreasProgramsTargetPopulationsList,
+        ),
       });
     },
   });

--- a/src/frontend/src/containers/dialogs/targetPopulation/DuplicateTargetPopulation.tsx
+++ b/src/frontend/src/containers/dialogs/targetPopulation/DuplicateTargetPopulation.tsx
@@ -11,7 +11,7 @@ import { PaymentPlanGroupAutocompleteRest } from '@shared/autocompletes/rest/Pay
 import { ProgramCycleAutocompleteRest } from '@shared/autocompletes/rest/ProgramCycleAutocompleteRest';
 import { FormikChipAutocomplete } from '@shared/Formik/FormikChipAutocomplete/FormikChipAutocomplete';
 import { FormikTextField } from '@shared/Formik/FormikTextField';
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { showApiErrorMessages } from '@utils/utils';
 import { Field, Formik } from 'formik';
 import { ReactElement } from 'react';
@@ -49,6 +49,7 @@ export const DuplicateTargetPopulation = ({
   const { t } = useTranslation();
   const { showMessage } = useSnackbar();
   const { baseUrl, businessArea, programId } = useBaseUrl();
+  const queryClient = useQueryClient();
 
   const { data: programData } = useQuery<ProgramDetail>({
     queryKey: ['programDetail', businessArea, programId],
@@ -81,6 +82,11 @@ export const DuplicateTargetPopulation = ({
         id,
         requestBody,
       }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['businessAreasProgramsTargetPopulationsList'],
+      });
+    },
   });
 
   const initialValues = {

--- a/src/frontend/src/containers/dialogs/targetPopulation/DuplicateTargetPopulation.tsx
+++ b/src/frontend/src/containers/dialogs/targetPopulation/DuplicateTargetPopulation.tsx
@@ -53,7 +53,10 @@ export const DuplicateTargetPopulation = ({
   const queryClient = useQueryClient();
 
   const { data: programData } = useQuery<ProgramDetail>({
-    queryKey: ['programDetail', businessArea, programId],
+    queryKey: restQueryKey(RestService.restBusinessAreasProgramsRetrieve, {
+      businessAreaSlug: businessArea,
+      code: programId,
+    }),
     queryFn: () =>
       RestService.restBusinessAreasProgramsRetrieve({
         businessAreaSlug: businessArea,

--- a/src/frontend/src/containers/dialogs/targetPopulation/FinalizeTargetPopulationPaymentPlan.tsx
+++ b/src/frontend/src/containers/dialogs/targetPopulation/FinalizeTargetPopulationPaymentPlan.tsx
@@ -12,6 +12,7 @@ import { useNavigate } from 'react-router-dom';
 import { useProgramContext } from '../../../programContext';
 import { ReactElement } from 'react';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { showApiErrorMessages } from '@utils/utils';
 
@@ -45,15 +46,14 @@ export const FinalizeTargetPopulationPaymentPlan = ({
       setOpen(false);
 
       queryClient.invalidateQueries({
-        queryKey: [
-          'targetPopulation',
-          businessArea,
-          targetPopulationId,
-          programId,
-        ],
+        queryKey: restQueryKey(
+          RestService.restBusinessAreasProgramsTargetPopulationsRetrieve,
+        ),
       });
       queryClient.invalidateQueries({
-        queryKey: ['businessAreasProgramsTargetPopulationsList'],
+        queryKey: restQueryKey(
+          RestService.restBusinessAreasProgramsTargetPopulationsList,
+        ),
       });
       navigate(`/${baseUrl}/target-population/${targetPopulationId}`);
     },

--- a/src/frontend/src/containers/dialogs/targetPopulation/FinalizeTargetPopulationPaymentPlan.tsx
+++ b/src/frontend/src/containers/dialogs/targetPopulation/FinalizeTargetPopulationPaymentPlan.tsx
@@ -52,6 +52,9 @@ export const FinalizeTargetPopulationPaymentPlan = ({
           programId,
         ],
       });
+      queryClient.invalidateQueries({
+        queryKey: ['businessAreasProgramsTargetPopulationsList'],
+      });
       navigate(`/${baseUrl}/target-population/${targetPopulationId}`);
     },
     onError: (error) => {

--- a/src/frontend/src/containers/dialogs/targetPopulation/LockTargetPopulationDialog.tsx
+++ b/src/frontend/src/containers/dialogs/targetPopulation/LockTargetPopulationDialog.tsx
@@ -56,6 +56,9 @@ export const LockTargetPopulationDialog = ({
           programId,
         ],
       });
+      queryClient.invalidateQueries({
+        queryKey: ['businessAreasProgramsTargetPopulationsList'],
+      });
       showMessage(t('Payment Plan has been locked.'));
     },
     onError: (error) => {

--- a/src/frontend/src/containers/dialogs/targetPopulation/LockTargetPopulationDialog.tsx
+++ b/src/frontend/src/containers/dialogs/targetPopulation/LockTargetPopulationDialog.tsx
@@ -3,6 +3,7 @@ import { useBaseUrl } from '@hooks/useBaseUrl';
 import { useSnackbar } from '@hooks/useSnackBar';
 import { Button, DialogContent, DialogTitle } from '@mui/material';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -49,15 +50,14 @@ export const LockTargetPopulationDialog = ({
 
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: [
-          'targetPopulation',
-          businessArea,
-          targetPopulationId,
-          programId,
-        ],
+        queryKey: restQueryKey(
+          RestService.restBusinessAreasProgramsTargetPopulationsRetrieve,
+        ),
       });
       queryClient.invalidateQueries({
-        queryKey: ['businessAreasProgramsTargetPopulationsList'],
+        queryKey: restQueryKey(
+          RestService.restBusinessAreasProgramsTargetPopulationsList,
+        ),
       });
       showMessage(t('Payment Plan has been locked.'));
     },

--- a/src/frontend/src/containers/dialogs/targetPopulation/TargetingInfoDialog/FlexFieldTab.tsx
+++ b/src/frontend/src/containers/dialogs/targetPopulation/TargetingInfoDialog/FlexFieldTab.tsx
@@ -33,8 +33,9 @@ export function FlexFieldTab(): ReactElement {
   const [selectedOption, setSelectedOption] = useState('All');
   const [selectedFieldType, setSelectedFieldType] = useState('All');
   useEffect(() => {
-    if (data?.results && !selectOptions.length) {
-      const options = data.results.map((el) => el.associatedWith);
+    // restBusinessAreasAllFieldsAttributesList returns a bare array, not a paginated page.
+    if (data?.length && !selectOptions.length) {
+      const options = data.map((el) => el.associatedWith);
       const filteredOptions = options.filter(
         (item, index) => options.indexOf(item) === index,
       );
@@ -104,7 +105,7 @@ export function FlexFieldTab(): ReactElement {
         selectedOption={selectedOption}
         searchValue={searchValue}
         selectedFieldType={selectedFieldType}
-        fields={data.results}
+        fields={data}
       />
     </Box>
   );

--- a/src/frontend/src/containers/dialogs/targetPopulation/TargetingInfoDialog/FlexFieldTab.tsx
+++ b/src/frontend/src/containers/dialogs/targetPopulation/TargetingInfoDialog/FlexFieldTab.tsx
@@ -10,13 +10,17 @@ import { RestService } from '@restgenerated/services/RestService';
 import { FlexFieldsTable } from '../../../tables/targeting/TargetPopulation/FlexFields';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { useProgramContext } from 'src/programContext';
+import { restQueryKey } from '@utils/queryKeys';
 
 export function FlexFieldTab(): ReactElement {
   const { t } = useTranslation();
   const { businessArea, isAllPrograms } = useBaseUrl();
   const { selectedProgram } = useProgramContext();
   const { data } = useQuery({
-    queryKey: ['allFieldsAttributes', businessArea, selectedProgram?.id],
+    queryKey: restQueryKey(RestService.restBusinessAreasAllFieldsAttributesList, {
+      slug: businessArea,
+      programId: selectedProgram?.id,
+    }),
     queryFn: () =>
       RestService.restBusinessAreasAllFieldsAttributesList({
         slug: businessArea,

--- a/src/frontend/src/containers/forms/ProgramForm.tsx
+++ b/src/frontend/src/containers/forms/ProgramForm.tsx
@@ -12,6 +12,7 @@ import { FormikRadioGroup } from '@shared/Formik/FormikRadioGroup';
 import { FormikSelectField } from '@shared/Formik/FormikSelectField';
 import { FormikTextField } from '@shared/Formik/FormikTextField';
 import { useQuery } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { Field, Form, useFormikContext } from 'formik';
 import { ReactElement, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -35,7 +36,9 @@ const ProgramForm = ({
   const isEditProgram = location.pathname.indexOf('edit') !== -1;
 
   const { data } = useQuery<ProgramChoices>({
-    queryKey: ['programChoices', businessArea],
+    queryKey: restQueryKey(RestService.restBusinessAreasProgramsChoicesRetrieve, {
+      businessAreaSlug: businessArea,
+    }),
     queryFn: () =>
       RestService.restBusinessAreasProgramsChoicesRetrieve({
         businessAreaSlug: businessArea,
@@ -46,7 +49,7 @@ const ProgramForm = ({
 
   const { data: beneficiaryGroupsData } =
     useQuery<PaginatedBeneficiaryGroupList>({
-      queryKey: ['beneficiaryGroups'],
+      queryKey: restQueryKey(RestService.restBeneficiaryGroupsList),
       queryFn: () => RestService.restBeneficiaryGroupsList({}),
     });
 

--- a/src/frontend/src/containers/forms/TargetingCriteriaForm.tsx
+++ b/src/frontend/src/containers/forms/TargetingCriteriaForm.tsx
@@ -255,7 +255,6 @@ export const TargetingCriteriaForm = ({
   const filteredIndividualData = useMemo(
     () => ({
       allFieldsAttributes: data
-        //@ts-ignore
         ?.filter(associatedWith('Individual'))
         .filter(isNot('IMAGE')),
     }),
@@ -264,7 +263,6 @@ export const TargetingCriteriaForm = ({
 
   const filteredHouseholdData = useMemo(
     () => ({
-      //@ts-ignore
       allFieldsAttributes: data?.filter(associatedWith('Household')),
     }),
     [data],
@@ -272,7 +270,6 @@ export const TargetingCriteriaForm = ({
 
   const allDataChoicesDictTmp = useMemo(
     () =>
-      // @ts-ignore
       data?.reduce((acc, item) => {
         acc[item.name] = item.choices;
         return acc;

--- a/src/frontend/src/containers/forms/TargetingCriteriaForm.tsx
+++ b/src/frontend/src/containers/forms/TargetingCriteriaForm.tsx
@@ -51,6 +51,7 @@ import { useConfirmation } from '@components/core/ConfirmationDialog';
 import { RestService } from '@restgenerated/services/RestService';
 import { useQuery } from '@tanstack/react-query';
 import { FspChoices } from '@restgenerated/models/FspChoices';
+import { restQueryKey } from '@utils/queryKeys';
 
 const ButtonBox = styled.div`
   width: 300px;
@@ -209,21 +210,20 @@ export const TargetingCriteriaForm = ({
   const { data: availableFspsForDeliveryMechanismData } = useQuery<
     FspChoices[]
   >({
-    queryKey: [
-      'businessAreasAvailableFspsForDeliveryMechanismsList',
-      businessArea,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasAvailableFspsForDeliveryMechanismsList,
+      { businessAreaSlug: businessArea },
+    ),
     queryFn: () =>
       RestService.restBusinessAreasAvailableFspsForDeliveryMechanismsList({
         businessAreaSlug: businessArea,
       }),
   });
   const { data, isLoading: loading } = useQuery({
-    queryKey: [
-      'businessAreasAllFieldsAttributesList',
-      businessArea,
-      selectedProgram?.id,
-    ],
+    queryKey: restQueryKey(RestService.restBusinessAreasAllFieldsAttributesList, {
+      slug: businessArea,
+      programId: selectedProgram?.id,
+    }),
     queryFn: () =>
       RestService.restBusinessAreasAllFieldsAttributesList({
         slug: businessArea,

--- a/src/frontend/src/containers/pages/accountability/communication/CommunicationDetailsPage.tsx
+++ b/src/frontend/src/containers/pages/accountability/communication/CommunicationDetailsPage.tsx
@@ -10,6 +10,7 @@ import { usePermissions } from '@hooks/usePermissions';
 import { isPermissionDeniedError } from '@utils/utils';
 import { useQuery } from '@tanstack/react-query';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { MessageDetail } from '@restgenerated/models/MessageDetail';
 import { UniversalActivityLogTable } from '../../../tables/UniversalActivityLogTable';
 import RecipientsTable from '../../../tables/Communication/RecipientsTable/RecipientsTable';
@@ -30,12 +31,14 @@ function CommunicationDetailsPage(): ReactElement {
     isLoading,
     error,
   } = useQuery<MessageDetail>({
-    queryKey: [
-      'accountabilityCommunicationMessage',
-      businessArea,
-      id,
-      programCode,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsMessagesRetrieve,
+      {
+        businessAreaSlug: businessArea,
+        id: id,
+        programCode,
+      },
+    ),
     queryFn: () =>
       RestService.restBusinessAreasProgramsMessagesRetrieve({
         businessAreaSlug: businessArea,

--- a/src/frontend/src/containers/pages/accountability/communication/CreateCommunicationPage.tsx
+++ b/src/frontend/src/containers/pages/accountability/communication/CreateCommunicationPage.tsx
@@ -9,6 +9,7 @@ import { TabPanel } from '@components/core/TabPanel';
 import withErrorBoundary from '@components/core/withErrorBoundary';
 import { PaperContainer } from '@components/targeting/PaperContainer';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { MessageCreate } from '@restgenerated/models/MessageCreate';
 import { SamplingTypeE86Enum } from '@restgenerated/models/SamplingTypeE86Enum';
 import { useBaseUrl } from '@hooks/useBaseUrl';
@@ -130,7 +131,9 @@ const CreateCommunicationPage = (): ReactElement => {
       }),
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: ['businessAreasProgramsMessagesList'],
+        queryKey: restQueryKey(
+          RestService.restBusinessAreasProgramsMessagesList,
+        ),
       });
     },
   });

--- a/src/frontend/src/containers/pages/accountability/communication/CreateCommunicationPage.tsx
+++ b/src/frontend/src/containers/pages/accountability/communication/CreateCommunicationPage.tsx
@@ -8,7 +8,7 @@ import { PermissionDenied } from '@components/core/PermissionDenied';
 import { TabPanel } from '@components/core/TabPanel';
 import withErrorBoundary from '@components/core/withErrorBoundary';
 import { PaperContainer } from '@components/targeting/PaperContainer';
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { MessageCreate } from '@restgenerated/models/MessageCreate';
 import { SamplingTypeE86Enum } from '@restgenerated/models/SamplingTypeE86Enum';
 import { useBaseUrl } from '@hooks/useBaseUrl';
@@ -120,6 +120,7 @@ function prepareSampleSizeRequest(
 const CreateCommunicationPage = (): ReactElement => {
   const { t } = useTranslation();
   const { baseUrl, businessArea, programId } = useBaseUrl();
+  const queryClient = useQueryClient();
   const { mutateAsync: mutate, isPending: loading } = useMutation({
     mutationFn: (data: MessageCreate) =>
       RestService.restBusinessAreasProgramsMessagesCreate({
@@ -127,6 +128,11 @@ const CreateCommunicationPage = (): ReactElement => {
         programCode: programId,
         requestBody: data,
       }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['businessAreasProgramsMessagesList'],
+      });
+    },
   });
   const { showMessage } = useSnackbar();
   const navigate = useNavigate();

--- a/src/frontend/src/containers/pages/accountability/communication/CreateCommunicationPage.tsx
+++ b/src/frontend/src/containers/pages/accountability/communication/CreateCommunicationPage.tsx
@@ -155,7 +155,10 @@ const CreateCommunicationPage = (): ReactElement => {
   const [sampleSizeError, setSampleSizeError] = useState<Error | null>(null);
 
   const { data: adminAreasData } = useQuery<AreaList[]>({
-    queryKey: ['adminAreas', businessArea, { level: 2 }],
+    queryKey: restQueryKey(RestService.restBusinessAreasGeoAreasList, {
+      businessAreaSlug: businessArea,
+      level: 2,
+    }),
     queryFn: async () => {
       return RestService.restBusinessAreasGeoAreasList({
         businessAreaSlug: businessArea,

--- a/src/frontend/src/containers/pages/accountability/feedback/CreateFeedbackPage.tsx
+++ b/src/frontend/src/containers/pages/accountability/feedback/CreateFeedbackPage.tsx
@@ -29,7 +29,7 @@ import { FormikAdminAreaAutocomplete } from '@shared/Formik/FormikAdminAreaAutoc
 import { FormikCheckboxField } from '@shared/Formik/FormikCheckboxField';
 import { FormikSelectField } from '@shared/Formik/FormikSelectField';
 import { FormikTextField } from '@shared/Formik/FormikTextField';
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { createApiParams } from '@utils/apiUtils';
 import { FeedbackSteps } from '@utils/constants';
 import { showApiErrorMessages } from '@utils/utils';
@@ -147,6 +147,7 @@ function CreateFeedbackPage(): ReactElement {
         ),
     });
 
+  const queryClient = useQueryClient();
   const { mutateAsync: mutate, isPending: loading } = useMutation({
     mutationFn: ({
       businessAreaSlug,
@@ -159,6 +160,14 @@ function CreateFeedbackPage(): ReactElement {
         businessAreaSlug,
         requestBody,
       }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['businessAreasProgramsFeedbacksList'],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ['businessAreasFeedbacksList'],
+      });
+    },
   });
 
   if (choicesLoading || programsDataLoading) return <LoadingComponent />;

--- a/src/frontend/src/containers/pages/accountability/feedback/CreateFeedbackPage.tsx
+++ b/src/frontend/src/containers/pages/accountability/feedback/CreateFeedbackPage.tsx
@@ -130,22 +130,24 @@ function CreateFeedbackPage(): ReactElement {
   };
 
   const { data: choicesData, isLoading: choicesLoading } = useQuery({
-    queryKey: ['choicesFeedbackIssueTypeList', businessArea],
+    queryKey: restQueryKey(RestService.restChoicesFeedbackIssueTypeList),
     queryFn: () => RestService.restChoicesFeedbackIssueTypeList(),
   });
 
+  const programsParams = createApiParams(
+    { businessAreaSlug: businessArea, limit: 100 },
+    {
+      withPagination: false,
+    },
+  );
+
   const { data: programsData, isLoading: programsDataLoading } =
     useQuery<PaginatedProgramListList>({
-      queryKey: ['businessAreasProgramsList', { limit: 100 }, businessArea],
-      queryFn: () =>
-        RestService.restBusinessAreasProgramsList(
-          createApiParams(
-            { businessAreaSlug: businessArea, limit: 100 },
-            {
-              withPagination: false,
-            },
-          ),
-        ),
+      queryKey: restQueryKey(
+        RestService.restBusinessAreasProgramsList,
+        programsParams,
+      ),
+      queryFn: () => RestService.restBusinessAreasProgramsList(programsParams),
     });
 
   const queryClient = useQueryClient();

--- a/src/frontend/src/containers/pages/accountability/feedback/CreateFeedbackPage.tsx
+++ b/src/frontend/src/containers/pages/accountability/feedback/CreateFeedbackPage.tsx
@@ -30,6 +30,7 @@ import { FormikCheckboxField } from '@shared/Formik/FormikCheckboxField';
 import { FormikSelectField } from '@shared/Formik/FormikSelectField';
 import { FormikTextField } from '@shared/Formik/FormikTextField';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { createApiParams } from '@utils/apiUtils';
 import { FeedbackSteps } from '@utils/constants';
 import { showApiErrorMessages } from '@utils/utils';
@@ -162,10 +163,12 @@ function CreateFeedbackPage(): ReactElement {
       }),
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: ['businessAreasProgramsFeedbacksList'],
+        queryKey: restQueryKey(
+          RestService.restBusinessAreasProgramsFeedbacksList,
+        ),
       });
       queryClient.invalidateQueries({
-        queryKey: ['businessAreasFeedbacksList'],
+        queryKey: restQueryKey(RestService.restBusinessAreasFeedbacksList),
       });
     },
   });

--- a/src/frontend/src/containers/pages/accountability/feedback/EditFeedbackPage.tsx
+++ b/src/frontend/src/containers/pages/accountability/feedback/EditFeedbackPage.tsx
@@ -80,22 +80,24 @@ const EditFeedbackPage = (): ReactElement => {
     });
 
   const { data: choicesData, isLoading: choicesLoading } = useQuery({
-    queryKey: ['choicesFeedbackIssueTypeList', businessArea],
+    queryKey: restQueryKey(RestService.restChoicesFeedbackIssueTypeList),
     queryFn: () => RestService.restChoicesFeedbackIssueTypeList(),
   });
 
+  const programsParams = createApiParams(
+    { businessAreaSlug: businessArea, limit: 100 },
+    {
+      withPagination: false,
+    },
+  );
+
   const { data: programsData, isLoading: programsDataLoading } =
     useQuery<PaginatedProgramListList>({
-      queryKey: ['businessAreasProgramsList', { limit: 100 }, businessArea],
-      queryFn: () =>
-        RestService.restBusinessAreasProgramsList(
-          createApiParams(
-            { businessAreaSlug: businessArea, limit: 100 },
-            {
-              withPagination: false,
-            },
-          ),
-        ),
+      queryKey: restQueryKey(
+        RestService.restBusinessAreasProgramsList,
+        programsParams,
+      ),
+      queryFn: () => RestService.restBusinessAreasProgramsList(programsParams),
     });
 
   const { mutateAsync: mutate, isPending: loading } = useMutation({

--- a/src/frontend/src/containers/pages/accountability/feedback/EditFeedbackPage.tsx
+++ b/src/frontend/src/containers/pages/accountability/feedback/EditFeedbackPage.tsx
@@ -22,6 +22,7 @@ import { FormikAdminAreaAutocomplete } from '@shared/Formik/FormikAdminAreaAutoc
 import { FormikSelectField } from '@shared/Formik/FormikSelectField';
 import { FormikTextField } from '@shared/Formik/FormikTextField';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { createApiParams } from '@utils/apiUtils';
 import { Field, Formik } from 'formik';
 import { ReactElement } from 'react';
@@ -67,7 +68,10 @@ const EditFeedbackPage = (): ReactElement => {
 
   const { data: feedbackData, isLoading: feedbackDataLoading } =
     useQuery<FeedbackDetail>({
-      queryKey: ['businessAreasFeedbacksRetrieve', businessArea, id],
+      queryKey: restQueryKey(RestService.restBusinessAreasFeedbacksRetrieve, {
+        businessAreaSlug: businessArea,
+        id: id,
+      }),
       queryFn: () =>
         RestService.restBusinessAreasFeedbacksRetrieve({
           businessAreaSlug: businessArea,
@@ -111,13 +115,15 @@ const EditFeedbackPage = (): ReactElement => {
       }),
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: ['businessAreasFeedbacksRetrieve', businessArea, id],
+        queryKey: restQueryKey(RestService.restBusinessAreasFeedbacksRetrieve),
       });
       queryClient.invalidateQueries({
-        queryKey: ['businessAreasProgramsFeedbacksList'],
+        queryKey: restQueryKey(
+          RestService.restBusinessAreasProgramsFeedbacksList,
+        ),
       });
       queryClient.invalidateQueries({
-        queryKey: ['businessAreasFeedbacksList'],
+        queryKey: restQueryKey(RestService.restBusinessAreasFeedbacksList),
       });
     },
   });

--- a/src/frontend/src/containers/pages/accountability/feedback/EditFeedbackPage.tsx
+++ b/src/frontend/src/containers/pages/accountability/feedback/EditFeedbackPage.tsx
@@ -21,7 +21,7 @@ import { RestService } from '@restgenerated/services/RestService';
 import { FormikAdminAreaAutocomplete } from '@shared/Formik/FormikAdminAreaAutocomplete';
 import { FormikSelectField } from '@shared/Formik/FormikSelectField';
 import { FormikTextField } from '@shared/Formik/FormikTextField';
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { createApiParams } from '@utils/apiUtils';
 import { Field, Formik } from 'formik';
 import { ReactElement } from 'react';
@@ -59,6 +59,7 @@ const EditFeedbackPage = (): ReactElement => {
   const { t } = useTranslation();
   const { id } = useParams();
   const { baseUrl, businessArea, isAllPrograms } = useBaseUrl();
+  const queryClient = useQueryClient();
   const permissions = usePermissions();
   const { showMessage } = useSnackbar();
   const { selectedProgram } = useProgramContext();
@@ -108,6 +109,17 @@ const EditFeedbackPage = (): ReactElement => {
         id: feedbackId,
         requestBody,
       }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['businessAreasFeedbacksRetrieve', businessArea, id],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ['businessAreasProgramsFeedbacksList'],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ['businessAreasFeedbacksList'],
+      });
+    },
   });
 
   if (feedbackDataLoading || choicesLoading || programsDataLoading)

--- a/src/frontend/src/containers/pages/accountability/surveys/CreateSurveyPage.tsx
+++ b/src/frontend/src/containers/pages/accountability/surveys/CreateSurveyPage.tsx
@@ -160,7 +160,10 @@ const CreateSurveyPage = (): ReactElement => {
   const { data: adminAreasData, isLoading: adminAreasLoading } = useQuery<
     AreaList[]
   >({
-    queryKey: ['adminAreas', businessArea, { level: 2 }],
+    queryKey: restQueryKey(RestService.restBusinessAreasGeoAreasList, {
+      businessAreaSlug: businessArea,
+      level: 2,
+    }),
     queryFn: async () => {
       return RestService.restBusinessAreasGeoAreasList({
         businessAreaSlug: businessArea,

--- a/src/frontend/src/containers/pages/accountability/surveys/CreateSurveyPage.tsx
+++ b/src/frontend/src/containers/pages/accountability/surveys/CreateSurveyPage.tsx
@@ -33,7 +33,7 @@ import { FormikMultiSelectField } from '@shared/Formik/FormikMultiSelectField';
 import { FormikSelectField } from '@shared/Formik/FormikSelectField';
 import { FormikSliderField } from '@shared/Formik/FormikSliderField';
 import { FormikTextField } from '@shared/Formik/FormikTextField';
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { SurveySteps, SurveyTabsValues } from '@utils/constants';
 import { SurveyCategoryEnum } from '@utils/enums';
 import { getPercentage, showApiErrorMessages } from '@utils/utils';
@@ -92,6 +92,7 @@ function prepareSampleSizeRequest(selectedSampleSizeType, values) {
 const CreateSurveyPage = (): ReactElement => {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const { mutateAsync: mutate, isPending: loading } = useMutation({
     mutationFn: ({
       businessAreaSlug,
@@ -107,6 +108,11 @@ const CreateSurveyPage = (): ReactElement => {
         programCode,
         requestBody,
       }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['businessAreasProgramsSurveysList'],
+      });
+    },
   });
   const { showMessage } = useSnackbar();
   const { baseUrl, businessArea, programId } = useBaseUrl();

--- a/src/frontend/src/containers/pages/accountability/surveys/CreateSurveyPage.tsx
+++ b/src/frontend/src/containers/pages/accountability/surveys/CreateSurveyPage.tsx
@@ -34,6 +34,7 @@ import { FormikSelectField } from '@shared/Formik/FormikSelectField';
 import { FormikSliderField } from '@shared/Formik/FormikSliderField';
 import { FormikTextField } from '@shared/Formik/FormikTextField';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { SurveySteps, SurveyTabsValues } from '@utils/constants';
 import { SurveyCategoryEnum } from '@utils/enums';
 import { getPercentage, showApiErrorMessages } from '@utils/utils';
@@ -110,7 +111,9 @@ const CreateSurveyPage = (): ReactElement => {
       }),
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: ['businessAreasProgramsSurveysList'],
+        queryKey: restQueryKey(
+          RestService.restBusinessAreasProgramsSurveysList,
+        ),
       });
     },
   });

--- a/src/frontend/src/containers/pages/core/MainActivityLogPage.tsx
+++ b/src/frontend/src/containers/pages/core/MainActivityLogPage.tsx
@@ -6,6 +6,7 @@ import { useLocation } from 'react-router-dom';
 import styled from 'styled-components';
 import { useQuery } from '@tanstack/react-query';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { ActivityLogPageFilters } from '@components/core/ActivityLogPageFilters';
 import { LoadingComponent } from '@components/core/LoadingComponent';
 import { PageHeader } from '@components/core/PageHeader';
@@ -69,29 +70,28 @@ export function ActivityLogPage(): ReactElement {
   );
 
   // Query for activity logs based on whether it's all programs or a specific program
-  const { data: logsData, isLoading: logsLoading } = useQuery({
-    queryKey: [
-      'activityLogs',
-      businessArea,
-      programId,
-      isAllPrograms,
-      page,
-      rowsPerPage,
-      appliedFilter,
-    ],
-    queryFn: () => {
-      const variables = {
-        businessAreaSlug: businessArea,
-        limit: rowsPerPage,
-        offset: page * rowsPerPage,
-        ...filtersToVariables(appliedFilter),
-      };
+  const activityLogsParams = {
+    businessAreaSlug: businessArea,
+    limit: rowsPerPage,
+    offset: page * rowsPerPage,
+    ...filtersToVariables(appliedFilter),
+  };
 
+  const { data: logsData, isLoading: logsLoading } = useQuery({
+    queryKey: restQueryKey(
+      isAllPrograms
+        ? RestService.restBusinessAreasActivityLogsList
+        : RestService.restBusinessAreasProgramsActivityLogsList,
+      isAllPrograms
+        ? activityLogsParams
+        : { ...activityLogsParams, programCode: programId },
+    ),
+    queryFn: () => {
       if (isAllPrograms) {
-        return RestService.restBusinessAreasActivityLogsList(variables);
+        return RestService.restBusinessAreasActivityLogsList(activityLogsParams);
       } else {
         return RestService.restBusinessAreasProgramsActivityLogsList({
-          ...variables,
+          ...activityLogsParams,
           programCode: programId,
         });
       }
@@ -104,7 +104,14 @@ export function ActivityLogPage(): ReactElement {
   });
 
   const { data: countData } = useQuery({
-    queryKey: ['activityLogsCount', businessArea, programId, isAllPrograms],
+    queryKey: restQueryKey(
+      isAllPrograms
+        ? RestService.restBusinessAreasActivityLogsCountRetrieve
+        : RestService.restBusinessAreasProgramsActivityLogsCountRetrieve,
+      isAllPrograms
+        ? { businessAreaSlug: businessArea }
+        : { businessAreaSlug: businessArea, programCode: programId },
+    ),
     queryFn: () => {
       if (isAllPrograms) {
         return RestService.restBusinessAreasActivityLogsCountRetrieve({

--- a/src/frontend/src/containers/pages/countrySearch/CountrySearchPage.tsx
+++ b/src/frontend/src/containers/pages/countrySearch/CountrySearchPage.tsx
@@ -22,6 +22,7 @@ import {
 import { useNavigate, useLocation } from 'react-router-dom';
 import { BaseSection } from '@components/core/BaseSection';
 import { RestService } from '@restgenerated/index';
+import { restQueryKey } from '@utils/queryKeys';
 import { PaginatedHouseholdListList } from '@restgenerated/models/PaginatedHouseholdListList';
 import { useQuery } from '@tanstack/react-query';
 import { createApiParams } from '@utils/apiUtils';
@@ -144,119 +145,110 @@ const OfficeSearchPage = (): ReactElement => {
   // Query variables for Payment Plans and Payments
 
   // Households query
+  const hhParams = createApiParams(
+    { businessAreaSlug: businessArea },
+    hhQueryVariables,
+    {
+      withPagination: false,
+    },
+  );
+
   const {
     data: hhData,
     isLoading: isLoadingHouseholds,
     error: errorHouseholds,
   } = useQuery<PaginatedHouseholdListList>({
-    queryKey: [
-      'businessAreasHouseholdsList',
-      hhQueryVariables,
-      businessArea,
-      appliedFilter.officeSearch,
-      appliedFilter.activePrograms,
-    ],
-    queryFn: () =>
-      RestService.restBusinessAreasHouseholdsList(
-        createApiParams({ businessAreaSlug: businessArea }, hhQueryVariables, {
-          withPagination: false,
-        }),
-      ),
+    queryKey: restQueryKey(RestService.restBusinessAreasHouseholdsList, hhParams),
+    queryFn: () => RestService.restBusinessAreasHouseholdsList(hhParams),
     enabled: appliedFilter.searchFor === 'HH' && !!appliedFilter.officeSearch,
   });
 
   // Individuals query
+  const indParams = createApiParams(
+    { businessAreaSlug: businessArea },
+    indQueryVariables,
+    {
+      withPagination: false,
+    },
+  );
+
   const {
     data: indData,
     isLoading: isLoadingIndividuals,
     error: errorIndividuals,
   } = useQuery<PaginatedIndividualListList>({
-    queryKey: [
-      'businessAreasIndividualsList',
-      indQueryVariables,
-      businessArea,
-      appliedFilter.officeSearch,
-      appliedFilter.activePrograms,
-    ],
-    queryFn: () =>
-      RestService.restBusinessAreasIndividualsList(
-        createApiParams({ businessAreaSlug: businessArea }, indQueryVariables, {
-          withPagination: false,
-        }),
-      ),
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasIndividualsList,
+      indParams,
+    ),
+    queryFn: () => RestService.restBusinessAreasIndividualsList(indParams),
     enabled: appliedFilter.searchFor === 'IND' && !!appliedFilter.officeSearch,
   });
 
   // Grievances query (if needed)
+  const grvParams = createApiParams(
+    { businessAreaSlug: businessArea },
+    grvQueryVariables,
+    {
+      withPagination: false,
+    },
+  );
+
   const {
     data: grvData,
     isLoading: isLoadingGrievances,
     error: errorGrievances,
   } = useQuery({
-    queryKey: [
-      'businessAreasGrievancesList',
-      grvQueryVariables,
-      businessArea,
-      appliedFilter.searchFor,
-      appliedFilter.officeSearch,
-      appliedFilter.activePrograms,
-    ],
-    queryFn: () =>
-      RestService.restBusinessAreasGrievanceTicketsList(
-        createApiParams({ businessAreaSlug: businessArea }, grvQueryVariables, {
-          withPagination: false,
-        }),
-      ),
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasGrievanceTicketsList,
+      grvParams,
+    ),
+    queryFn: () => RestService.restBusinessAreasGrievanceTicketsList(grvParams),
     enabled: appliedFilter.searchFor === 'GRV' && !!appliedFilter.officeSearch,
   });
 
   // Payment Plans query (for 'PP' search)
+  const ppParams = createApiParams(
+    { businessAreaSlug: businessArea },
+    ppQueryVariables,
+    {
+      withPagination: false,
+    },
+  );
+
   const {
     data: ppData,
     isLoading: isLoadingPaymentPlans,
     error: errorPaymentPlans,
   } = useQuery({
-    queryKey: [
-      'businessAreasPaymentPlansList',
-      ppQueryVariables,
-      businessArea,
-      appliedFilter.officeSearch,
-      appliedFilter.searchFor,
-      appliedFilter.activePrograms,
-    ],
-    queryFn: () =>
-      RestService.restBusinessAreasPaymentPlansList(
-        createApiParams({ businessAreaSlug: businessArea }, ppQueryVariables, {
-          withPagination: false,
-        }),
-      ),
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasPaymentPlansList,
+      ppParams,
+    ),
+    queryFn: () => RestService.restBusinessAreasPaymentPlansList(ppParams),
     enabled: appliedFilter.searchFor === 'PP' && !!appliedFilter.officeSearch,
   });
 
   // Payments query (for 'RCPT' search)
+
+  const paymentsParams = createApiParams(
+    { businessAreaSlug: businessArea },
+    paymentsQueryVariables,
+    {
+      withPagination: false,
+    },
+  );
 
   const {
     data: paymentsData,
     isLoading: isLoadingPayments,
     error: errorPayments,
   } = useQuery({
-    queryKey: [
-      'businessAreasPaymentsList',
-      paymentsQueryVariables,
-      businessArea,
-      appliedFilter.officeSearch,
-      appliedFilter.activePrograms,
-    ],
-    queryFn: () =>
-      RestService.restBusinessAreasPaymentsList(
-        createApiParams(
-          { businessAreaSlug: businessArea },
-          paymentsQueryVariables,
-          {
-            withPagination: false,
-          },
-        ),
-      ),
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasPaymentsList,
+      paymentsParams,
+    ),
+    queryFn: () => RestService.restBusinessAreasPaymentsList(paymentsParams),
     enabled: appliedFilter.searchFor === 'RCPT' && !!appliedFilter.officeSearch,
   });
 

--- a/src/frontend/src/containers/pages/grievances/CreateGrievancePage.tsx
+++ b/src/frontend/src/containers/pages/grievances/CreateGrievancePage.tsx
@@ -37,6 +37,7 @@ import Grid from '@mui/material/Grid';
 import { CreateGrievanceTicket } from '@restgenerated/models/CreateGrievanceTicket';
 import { PaginatedProgramListList } from '@restgenerated/models/PaginatedProgramListList';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { createApiParams } from '@utils/apiUtils';
 import {
@@ -119,19 +120,20 @@ function FormikSelectedEntitiesSync({
         individualForDelegate?.programCode)
       : undefined);
 
+  const householdForDelegateParams = {
+    businessAreaSlug: businessArea,
+    programCode: programCodeForDelegate,
+    id: String(householdIdForDelegate),
+  };
   const { data: householdForDelegate } = useQuery({
-    queryKey: [
-      'householdForDelegate',
-      businessArea,
-      programCodeForDelegate,
-      householdIdForDelegate,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsHouseholdsRetrieve,
+      householdForDelegateParams,
+    ),
     queryFn: () =>
-      RestService.restBusinessAreasProgramsHouseholdsRetrieve({
-        businessAreaSlug: businessArea,
-        programCode: programCodeForDelegate,
-        id: String(householdIdForDelegate),
-      }),
+      RestService.restBusinessAreasProgramsHouseholdsRetrieve(
+        householdForDelegateParams,
+      ),
     enabled: !!householdIdForDelegate && !!programCodeForDelegate,
   });
 
@@ -182,23 +184,28 @@ const CreateGrievancePage = (): ReactElement => {
   const selectedHousehold = location.state?.selectedHousehold;
   const feedbackProgramId = location.state?.feedbackProgramId;
 
+  const programsListParams = createApiParams(
+    { businessAreaSlug: businessArea, limit: 100 },
+    {
+      withPagination: false,
+    },
+  );
   const { data: programsData, isLoading: programsDataLoading } =
     useQuery<PaginatedProgramListList>({
-      queryKey: ['businessAreasProgramsList', { limit: 100 }, businessArea],
+      queryKey: restQueryKey(
+        RestService.restBusinessAreasProgramsList,
+        programsListParams,
+      ),
       queryFn: () =>
-        RestService.restBusinessAreasProgramsList(
-          createApiParams(
-            { businessAreaSlug: businessArea, limit: 100 },
-            {
-              withPagination: false,
-            },
-          ),
-        ),
+        RestService.restBusinessAreasProgramsList(programsListParams),
     });
 
   // Fetch linked ticket details when linked query param is provided
   const { data: linkedTicketData, isLoading: linkedTicketLoading } = useQuery({
-    queryKey: ['linkedTicket', businessArea, linkedTicketIdFromQuery],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasGrievanceTicketsRetrieve,
+      { businessAreaSlug: businessArea, id: linkedTicketIdFromQuery },
+    ),
     queryFn: () =>
       RestService.restBusinessAreasGrievanceTicketsRetrieve({
         businessAreaSlug: businessArea,
@@ -222,20 +229,21 @@ const CreateGrievancePage = (): ReactElement => {
   const entityProgramCode =
     feedbackProgramCode || (programId !== 'all' ? programId : undefined);
 
+  const fetchedHouseholdParams = {
+    businessAreaSlug: businessArea,
+    programCode: entityProgramCode,
+    id: String(selectedHousehold),
+  };
   const { data: fetchedHousehold, isLoading: fetchedHouseholdLoading } =
     useQuery({
-      queryKey: [
-        'household',
-        businessArea,
-        entityProgramCode,
-        selectedHousehold,
-      ],
+      queryKey: restQueryKey(
+        RestService.restBusinessAreasProgramsHouseholdsRetrieve,
+        fetchedHouseholdParams,
+      ),
       queryFn: () =>
-        RestService.restBusinessAreasProgramsHouseholdsRetrieve({
-          businessAreaSlug: businessArea,
-          programCode: entityProgramCode,
-          id: String(selectedHousehold),
-        }),
+        RestService.restBusinessAreasProgramsHouseholdsRetrieve(
+          fetchedHouseholdParams,
+        ),
       enabled: shouldFetchHousehold && !!entityProgramCode,
     });
   const selectedIndividual = location.state?.selectedIndividual;
@@ -247,20 +255,21 @@ const CreateGrievancePage = (): ReactElement => {
       typeof selectedIndividual === 'number'),
   );
 
+  const fetchedIndividualParams = {
+    businessAreaSlug: businessArea,
+    programCode: entityProgramCode,
+    id: String(selectedIndividual),
+  };
   const { data: fetchedIndividual, isLoading: fetchedIndividualLoading } =
     useQuery({
-      queryKey: [
-        'individual',
-        businessArea,
-        entityProgramCode,
-        selectedIndividual,
-      ],
+      queryKey: restQueryKey(
+        RestService.restBusinessAreasProgramsIndividualsRetrieve,
+        fetchedIndividualParams,
+      ),
       queryFn: () =>
-        RestService.restBusinessAreasProgramsIndividualsRetrieve({
-          businessAreaSlug: businessArea,
-          programCode: entityProgramCode,
-          id: String(selectedIndividual),
-        }),
+        RestService.restBusinessAreasProgramsIndividualsRetrieve(
+          fetchedIndividualParams,
+        ),
       enabled: shouldFetchIndividual && !!entityProgramCode,
     });
 
@@ -316,7 +325,10 @@ const CreateGrievancePage = (): ReactElement => {
   };
 
   const { data: choicesData, isLoading: choicesLoading } = useQuery<any>({
-    queryKey: ['businessAreasGrievanceTicketsChoices', businessArea],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasGrievanceTicketsChoicesRetrieve,
+      { businessAreaSlug: businessArea },
+    ),
     queryFn: () =>
       RestService.restBusinessAreasGrievanceTicketsChoicesRetrieve({
         businessAreaSlug: businessArea,
@@ -336,7 +348,10 @@ const CreateGrievancePage = (): ReactElement => {
     data: allAddIndividualFieldsData,
     isLoading: allAddIndividualFieldsDataLoading,
   } = useQuery({
-    queryKey: ['addIndividualFieldsAttributes', businessArea],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasGrievanceTicketsAllAddIndividualsFieldsAttributesList,
+      { businessAreaSlug: businessArea },
+    ),
     queryFn: () =>
       RestService.restBusinessAreasGrievanceTicketsAllAddIndividualsFieldsAttributesList(
         {
@@ -347,7 +362,10 @@ const CreateGrievancePage = (): ReactElement => {
 
   const { data: householdFieldsData, isLoading: householdFieldsLoading } =
     useQuery({
-      queryKey: ['householdFieldsAttributes', businessArea],
+      queryKey: restQueryKey(
+        RestService.restBusinessAreasGrievanceTicketsAllEditHouseholdFieldsAttributesList,
+        { businessAreaSlug: businessArea },
+      ),
       queryFn: () =>
         RestService.restBusinessAreasGrievanceTicketsAllEditHouseholdFieldsAttributesList(
           {
@@ -360,7 +378,10 @@ const CreateGrievancePage = (): ReactElement => {
     data: allEditPeopleFieldsData,
     isLoading: allEditPeopleFieldsLoading,
   } = useQuery({
-    queryKey: ['editPeopleFieldsAttributes', businessArea],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasGrievanceTicketsAllEditPeopleFieldsAttributesList,
+      { businessAreaSlug: businessArea },
+    ),
     queryFn: () =>
       RestService.restBusinessAreasGrievanceTicketsAllEditPeopleFieldsAttributesList(
         {

--- a/src/frontend/src/containers/pages/grievances/EditGrievancePage.tsx
+++ b/src/frontend/src/containers/pages/grievances/EditGrievancePage.tsx
@@ -35,6 +35,7 @@ import { Box, Button, FormHelperText, Grid, Typography } from '@mui/material';
 import { GrievanceTicketDetail } from '@restgenerated/models/GrievanceTicketDetail';
 import { PaginatedProgramListList } from '@restgenerated/models/PaginatedProgramListList';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { FormikAdminAreaAutocomplete } from '@shared/Formik/FormikAdminAreaAutocomplete';
 import { FormikSelectField } from '@shared/Formik/FormikSelectField';
 import { FormikTextField } from '@shared/Formik/FormikTextField';
@@ -98,7 +99,10 @@ const EditGrievancePage = (): ReactElement => {
     isLoading: ticketLoading,
     error,
   } = useQuery<GrievanceTicketDetail>({
-    queryKey: ['businessAreasGrievanceTicketsRetrieve', businessAreaSlug, id],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasGrievanceTicketsRetrieve,
+      { businessAreaSlug, id },
+    ),
     queryFn: () =>
       RestService.restBusinessAreasGrievanceTicketsRetrieve({
         businessAreaSlug,
@@ -139,11 +143,9 @@ const EditGrievancePage = (): ReactElement => {
         }),
       onSuccess: () => {
         queryClient.invalidateQueries({
-          queryKey: [
-            'businessAreasGrievanceTicketsRetrieve',
-            businessAreaSlug,
-            id,
-          ],
+          queryKey: restQueryKey(
+            RestService.restBusinessAreasGrievanceTicketsRetrieve,
+          ),
         });
       },
     });
@@ -157,11 +159,9 @@ const EditGrievancePage = (): ReactElement => {
       }),
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: [
-          'businessAreasGrievanceTicketsRetrieve',
-          businessAreaSlug,
-          id,
-        ],
+        queryKey: restQueryKey(
+          RestService.restBusinessAreasGrievanceTicketsRetrieve,
+        ),
       });
     },
   });

--- a/src/frontend/src/containers/pages/grievances/EditGrievancePage.tsx
+++ b/src/frontend/src/containers/pages/grievances/EditGrievancePage.tsx
@@ -110,14 +110,18 @@ const EditGrievancePage = (): ReactElement => {
       }),
   });
 
+  const profileParams = {
+    businessAreaSlug,
+    program: programCode === 'all' ? undefined : programCode,
+  };
   const { data: currentUserData, isLoading: currentUserDataLoading } = useQuery(
     {
-      queryKey: ['profile', businessAreaSlug, programCode],
+      queryKey: restQueryKey(
+        RestService.restBusinessAreasUsersProfileRetrieve,
+        profileParams,
+      ),
       queryFn: () => {
-        return RestService.restBusinessAreasUsersProfileRetrieve({
-          businessAreaSlug,
-          program: programCode === 'all' ? undefined : programCode,
-        });
+        return RestService.restBusinessAreasUsersProfileRetrieve(profileParams);
       },
       staleTime: 5 * 60 * 1000, // Data is considered fresh for 5 minutes
       gcTime: 30 * 60 * 1000, // Keep unused data in cache for 30 minutes
@@ -126,7 +130,10 @@ const EditGrievancePage = (): ReactElement => {
   );
 
   const { data: choicesData, isLoading: choicesLoading } = useQuery({
-    queryKey: ['businessAreasGrievanceTicketsChoices', businessAreaSlug],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasGrievanceTicketsChoicesRetrieve,
+      { businessAreaSlug },
+    ),
     queryFn: () =>
       RestService.restBusinessAreasGrievanceTicketsChoicesRetrieve({
         businessAreaSlug,
@@ -170,7 +177,10 @@ const EditGrievancePage = (): ReactElement => {
     data: allAddIndividualFieldsData,
     isLoading: allAddIndividualFieldsDataLoading,
   } = useQuery({
-    queryKey: ['addIndividualFieldsAttributes', businessAreaSlug],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasGrievanceTicketsAllAddIndividualsFieldsAttributesList,
+      { businessAreaSlug },
+    ),
     queryFn: () =>
       RestService.restBusinessAreasGrievanceTicketsAllAddIndividualsFieldsAttributesList(
         {
@@ -180,7 +190,10 @@ const EditGrievancePage = (): ReactElement => {
   });
   const { data: householdFieldsData, isLoading: householdFieldsLoading } =
     useQuery({
-      queryKey: ['householdFieldsAttributes', businessAreaSlug],
+      queryKey: restQueryKey(
+        RestService.restBusinessAreasGrievanceTicketsAllEditHouseholdFieldsAttributesList,
+        { businessAreaSlug },
+      ),
       queryFn: () =>
         RestService.restBusinessAreasGrievanceTicketsAllEditHouseholdFieldsAttributesList(
           {
@@ -192,7 +205,10 @@ const EditGrievancePage = (): ReactElement => {
     data: allEditPeopleFieldsData,
     isLoading: allEditPeopleFieldsLoading,
   } = useQuery({
-    queryKey: ['editPeopleFieldsAttributes', businessAreaSlug],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasGrievanceTicketsAllEditPeopleFieldsAttributesList,
+      { businessAreaSlug },
+    ),
     queryFn: () =>
       RestService.restBusinessAreasGrievanceTicketsAllEditPeopleFieldsAttributesList(
         {
@@ -201,18 +217,20 @@ const EditGrievancePage = (): ReactElement => {
       ),
   });
 
+  const programsListParams = createApiParams(
+    { businessAreaSlug, limit: 100 },
+    {
+      withPagination: false,
+    },
+  );
   const { data: programsData, isLoading: programsDataLoading } =
     useQuery<PaginatedProgramListList>({
-      queryKey: ['businessAreasProgramsList', { limit: 100 }, businessAreaSlug],
+      queryKey: restQueryKey(
+        RestService.restBusinessAreasProgramsList,
+        programsListParams,
+      ),
       queryFn: () =>
-        RestService.restBusinessAreasProgramsList(
-          createApiParams(
-            { businessAreaSlug, limit: 100 },
-            {
-              withPagination: false,
-            },
-          ),
-        ),
+        RestService.restBusinessAreasProgramsList(programsListParams),
     });
   const individualFieldsDict = useArrayToDict(
     allAddIndividualFieldsData,

--- a/src/frontend/src/containers/pages/grievances/EditGrievancePage.tsx
+++ b/src/frontend/src/containers/pages/grievances/EditGrievancePage.tsx
@@ -98,7 +98,7 @@ const EditGrievancePage = (): ReactElement => {
     isLoading: ticketLoading,
     error,
   } = useQuery<GrievanceTicketDetail>({
-    queryKey: ['businessAreaProgram', businessAreaSlug, id],
+    queryKey: ['businessAreasGrievanceTicketsRetrieve', businessAreaSlug, id],
     queryFn: () =>
       RestService.restBusinessAreasGrievanceTicketsRetrieve({
         businessAreaSlug,

--- a/src/frontend/src/containers/pages/grievances/EditGrievancePage.tsx
+++ b/src/frontend/src/containers/pages/grievances/EditGrievancePage.tsx
@@ -137,6 +137,15 @@ const EditGrievancePage = (): ReactElement => {
           id: data.id,
           formData: data.formData,
         }),
+      onSuccess: () => {
+        queryClient.invalidateQueries({
+          queryKey: [
+            'businessAreasGrievanceTicketsRetrieve',
+            businessAreaSlug,
+            id,
+          ],
+        });
+      },
     });
 
   const { mutateAsync: changeTicketStatus } = useMutation({

--- a/src/frontend/src/containers/pages/grievances/GrievancesDashboardPage.tsx
+++ b/src/frontend/src/containers/pages/grievances/GrievancesDashboardPage.tsx
@@ -17,6 +17,7 @@ import {
 } from '../../../config/permissions';
 import { useQuery } from '@tanstack/react-query';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { ReactElement } from 'react';
 import withErrorBoundary from '@components/core/withErrorBoundary';
@@ -30,12 +31,15 @@ function GrievancesDashboardPage(): ReactElement {
   // Use program-specific dashboard if we're in a specific program context,
   // otherwise use global dashboard
   const { data, isLoading: loading } = useQuery({
-    queryKey: [
-      'grievanceDashboard',
-      businessAreaSlug,
-      programCode,
-      isAllPrograms,
-    ],
+    queryKey: isAllPrograms
+      ? restQueryKey(
+          RestService.restBusinessAreasGrievanceTicketsDashboardRetrieve,
+          { businessAreaSlug },
+        )
+      : restQueryKey(
+          RestService.restBusinessAreasProgramsGrievanceTicketsDashboardRetrieve,
+          { businessAreaSlug, programCode },
+        ),
     queryFn: () => {
       if (isAllPrograms) {
         return RestService.restBusinessAreasGrievanceTicketsDashboardRetrieve({

--- a/src/frontend/src/containers/pages/grievances/GrievancesDetailsPage/GrievancesDetailsPage.tsx
+++ b/src/frontend/src/containers/pages/grievances/GrievancesDetailsPage/GrievancesDetailsPage.tsx
@@ -12,6 +12,7 @@ import Grid from '@mui/material/Grid';
 import { GrievanceChoices } from '@restgenerated/models/GrievanceChoices';
 import { GrievanceTicketDetail } from '@restgenerated/models/GrievanceTicketDetail';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useQuery } from '@tanstack/react-query';
 import { isPermissionDeniedError } from '@utils/utils';
 import { ReactElement } from 'react';
@@ -48,7 +49,10 @@ const GrievancesDetailsPage = (): ReactElement => {
     isLoading: loading,
     error,
   } = useQuery<GrievanceTicketDetail>({
-    queryKey: ['businessAreasGrievanceTicketsRetrieve', businessAreaSlug, id],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasGrievanceTicketsRetrieve,
+      { businessAreaSlug, id },
+    ),
     queryFn: () =>
       RestService.restBusinessAreasGrievanceTicketsRetrieve({
         businessAreaSlug,

--- a/src/frontend/src/containers/pages/grievances/GrievancesDetailsPage/GrievancesDetailsPage.tsx
+++ b/src/frontend/src/containers/pages/grievances/GrievancesDetailsPage/GrievancesDetailsPage.tsx
@@ -29,14 +29,18 @@ const GrievancesDetailsPage = (): ReactElement => {
   const { id } = useParams();
   const { businessAreaSlug, programCode } = useBaseUrl();
   const permissions = usePermissions();
+  const profileParams = {
+    businessAreaSlug,
+    program: programCode === 'all' ? undefined : programCode,
+  };
   const { data: currentUserData, isLoading: currentUserDataLoading } = useQuery(
     {
-      queryKey: ['profile', businessAreaSlug, programCode],
+      queryKey: restQueryKey(
+        RestService.restBusinessAreasUsersProfileRetrieve,
+        profileParams,
+      ),
       queryFn: () => {
-        return RestService.restBusinessAreasUsersProfileRetrieve({
-          businessAreaSlug: businessAreaSlug,
-          program: programCode === 'all' ? undefined : programCode,
-        });
+        return RestService.restBusinessAreasUsersProfileRetrieve(profileParams);
       },
       staleTime: 5 * 60 * 1000, // Data is considered fresh for 5 minutes
       gcTime: 30 * 60 * 1000, // Keep unused data in cache for 30 minutes
@@ -64,7 +68,10 @@ const GrievancesDetailsPage = (): ReactElement => {
 
   const { data: choicesData, isLoading: choicesLoading } =
     useQuery<GrievanceChoices>({
-      queryKey: ['businessAreasGrievanceTicketsChoices', businessAreaSlug],
+      queryKey: restQueryKey(
+        RestService.restBusinessAreasGrievanceTicketsChoicesRetrieve,
+        { businessAreaSlug },
+      ),
       queryFn: () =>
         RestService.restBusinessAreasGrievanceTicketsChoicesRetrieve({
           businessAreaSlug,

--- a/src/frontend/src/containers/pages/grievances/GrievancesTablePage.tsx
+++ b/src/frontend/src/containers/pages/grievances/GrievancesTablePage.tsx
@@ -27,6 +27,7 @@ import { t } from 'i18next';
 import { useProgramContext } from 'src/programContext';
 import withErrorBoundary from '@components/core/withErrorBoundary';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useQuery } from '@tanstack/react-query';
 
 export const GrievancesTablePage = (): ReactElement => {
@@ -39,7 +40,10 @@ export const GrievancesTablePage = (): ReactElement => {
   const location = useLocation();
   const navigate = useNavigate();
   const { data: choicesData, isLoading: choicesLoading } = useQuery({
-    queryKey: ['businessAreasGrievanceTicketsChoices', businessArea],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasGrievanceTicketsChoicesRetrieve,
+      { businessAreaSlug: businessArea },
+    ),
     queryFn: () =>
       RestService.restBusinessAreasGrievanceTicketsChoicesRetrieve({
         businessAreaSlug: businessArea,

--- a/src/frontend/src/containers/pages/headers/LockedTargetPopulationHeaderButtons.tsx
+++ b/src/frontend/src/containers/pages/headers/LockedTargetPopulationHeaderButtons.tsx
@@ -7,6 +7,7 @@ import { BusinessArea } from '@restgenerated/models/BusinessArea';
 import { ProgramStatusEnum } from '@restgenerated/models/ProgramStatusEnum';
 import { TargetPopulationDetail } from '@restgenerated/models/TargetPopulationDetail';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { ReactElement, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -59,15 +60,14 @@ export function LockedTargetPopulationHeaderButtons({
       }),
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: [
-          'targetPopulation',
-          businessArea,
-          targetPopulation.id,
-          programId,
-        ],
+        queryKey: restQueryKey(
+          RestService.restBusinessAreasProgramsTargetPopulationsRetrieve,
+        ),
       });
       queryClient.invalidateQueries({
-        queryKey: ['businessAreasProgramsTargetPopulationsList'],
+        queryKey: restQueryKey(
+          RestService.restBusinessAreasProgramsTargetPopulationsList,
+        ),
       });
 
       showMessage(t('Target Population Unlocked'));

--- a/src/frontend/src/containers/pages/headers/OpenTargetPopulationHeaderButtons.tsx
+++ b/src/frontend/src/containers/pages/headers/OpenTargetPopulationHeaderButtons.tsx
@@ -9,6 +9,7 @@ import {
 import { Box, Button, IconButton } from '@mui/material';
 import { TargetPopulationDetail } from '@restgenerated/models/TargetPopulationDetail';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { t } from 'i18next';
 import { ReactElement, useState } from 'react';
@@ -61,16 +62,15 @@ export function OpenTargetPopulationHeaderButtons({
     onSuccess: () => {
       showMessage(t('Payment Plan has been rebuilt.'));
       queryClient.invalidateQueries({
-        queryKey: [
-          'targetPopulation',
-          businessArea,
-          targetPopulation.id,
-          programId,
-        ],
+        queryKey: restQueryKey(
+          RestService.restBusinessAreasProgramsTargetPopulationsRetrieve,
+        ),
       });
 
       queryClient.invalidateQueries({
-        queryKey: ['businessAreasProgramsTargetPopulationsList'],
+        queryKey: restQueryKey(
+          RestService.restBusinessAreasProgramsTargetPopulationsList,
+        ),
       });
     },
     onError: (e) => showApiErrorMessages(e, showMessage),

--- a/src/frontend/src/containers/pages/headers/TargetPopulationPageHeader.tsx
+++ b/src/frontend/src/containers/pages/headers/TargetPopulationPageHeader.tsx
@@ -7,6 +7,7 @@ import { useBaseUrl } from '@hooks/useBaseUrl';
 import { BusinessArea } from '@restgenerated/models/BusinessArea';
 import { PaymentPlanStatusEnum } from '@restgenerated/models/PaymentPlanStatusEnum';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useQuery } from '@tanstack/react-query';
 import { paymentPlanBuildStatusToColor } from '@utils/utils';
 import { ReactElement } from 'react';
@@ -54,7 +55,9 @@ export function TargetPopulationPageHeader({
   const { baseUrl, businessArea } = useBaseUrl();
   const { data: businessAreaData, isLoading: businessAreaDataLoading } =
     useQuery<BusinessArea>({
-      queryKey: ['businessArea', businessArea],
+      queryKey: restQueryKey(RestService.restBusinessAreasRetrieve, {
+        slug: businessArea,
+      }),
       queryFn: () =>
         RestService.restBusinessAreasRetrieve({
           slug: businessArea,

--- a/src/frontend/src/containers/pages/managerialConsole/ManagerialConsolePage.tsx
+++ b/src/frontend/src/containers/pages/managerialConsole/ManagerialConsolePage.tsx
@@ -16,6 +16,7 @@ import { useTranslation } from 'react-i18next';
 import { PERMISSIONS, hasPermissions } from '../../../config/permissions';
 import withErrorBoundary from '@components/core/withErrorBoundary';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { PaginatedPaymentPlanList } from '@restgenerated/models/PaginatedPaymentPlanList';
 
 export const ManagerialConsolePage: FC = () => {
@@ -72,7 +73,10 @@ export const ManagerialConsolePage: FC = () => {
     refetch: refetchInApproval,
     // eslint-disable-next-line @tanstack/query/exhaustive-deps
   } = useQuery<PaginatedPaymentPlanList>({
-    queryKey: ['paymentPlansInApproval', businessAreaSlug],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasPaymentsPaymentPlansManagerialList,
+      { businessAreaSlug, limit: 10000, offset: 0, status: 'IN_APPROVAL' },
+    ),
     queryFn: () => fetchPaymentPlans('IN_APPROVAL'),
   });
 
@@ -82,7 +86,10 @@ export const ManagerialConsolePage: FC = () => {
     refetch: refetchInAuthorization,
     // eslint-disable-next-line @tanstack/query/exhaustive-deps
   } = useQuery<PaginatedPaymentPlanList>({
-    queryKey: ['paymentPlansInAuthorization', businessAreaSlug],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasPaymentsPaymentPlansManagerialList,
+      { businessAreaSlug, limit: 10000, offset: 0, status: 'IN_AUTHORIZATION' },
+    ),
     queryFn: () => fetchPaymentPlans('IN_AUTHORIZATION'),
   });
 
@@ -92,7 +99,10 @@ export const ManagerialConsolePage: FC = () => {
     refetch: refetchInReview,
     // eslint-disable-next-line @tanstack/query/exhaustive-deps
   } = useQuery<PaginatedPaymentPlanList>({
-    queryKey: ['paymentPlansInReview', businessAreaSlug],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasPaymentsPaymentPlansManagerialList,
+      { businessAreaSlug, limit: 10000, offset: 0, status: 'IN_REVIEW' },
+    ),
     queryFn: () => fetchPaymentPlans('IN_REVIEW'),
   });
 
@@ -102,7 +112,10 @@ export const ManagerialConsolePage: FC = () => {
     refetch: refetchReleased,
     // eslint-disable-next-line @tanstack/query/exhaustive-deps
   } = useQuery<PaginatedPaymentPlanList>({
-    queryKey: ['paymentPlansReleased', businessAreaSlug],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasPaymentsPaymentPlansManagerialList,
+      { businessAreaSlug, limit: 10000, offset: 0, status: 'ACCEPTED' },
+    ),
     queryFn: () => fetchPaymentPlans('ACCEPTED'),
   });
 

--- a/src/frontend/src/containers/pages/paymentmodule/EditFollowUpPaymentPlanPage.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/EditFollowUpPaymentPlanPage.tsx
@@ -65,11 +65,14 @@ const EditFollowUpPaymentPlanPage = (): ReactElement => {
     data: allTargetPopulationsData,
     isLoading: loadingTargetPopulations,
   } = useQuery<PaginatedTargetPopulationListList>({
-    queryKey: [
-      'businessAreasProgramsTargetPopulationsList',
-      businessArea,
-      programId,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsTargetPopulationsList,
+      {
+        businessAreaSlug: businessArea,
+        programCode: programId,
+        status: 'DRAFT',
+      },
+    ),
     queryFn: () => {
       return RestService.restBusinessAreasProgramsTargetPopulationsList({
         businessAreaSlug: businessArea,

--- a/src/frontend/src/containers/pages/paymentmodule/EditFollowUpPaymentPlanPage.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/EditFollowUpPaymentPlanPage.tsx
@@ -12,6 +12,7 @@ import { PaginatedTargetPopulationListList } from '@restgenerated/models/Paginat
 import { PaymentPlanDetail } from '@restgenerated/models/PaymentPlanDetail';
 import { RestService } from '@restgenerated/services/RestService';
 import { useMutation, useQuery } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { showApiErrorMessages, today } from '@utils/utils';
 import { Form, Formik } from 'formik';
 import moment from 'moment';
@@ -51,7 +52,7 @@ const EditFollowUpPaymentPlanPage = (): ReactElement => {
 
   const { data: paymentPlan, isLoading: loadingPaymentPlan } =
     useQuery<PaymentPlanDetail>({
-      queryKey: ['paymentPlan', businessArea, paymentPlanId, programId],
+      queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansRetrieve, { businessAreaSlug: businessArea, id: paymentPlanId, programCode: programId }),
       queryFn: () =>
         RestService.restBusinessAreasProgramsPaymentPlansRetrieve({
           businessAreaSlug: businessArea,

--- a/src/frontend/src/containers/pages/paymentmodule/EditPaymentPlanPage.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/EditPaymentPlanPage.tsx
@@ -69,14 +69,14 @@ const EditPaymentPlanForm = ({
         queryClient.invalidateQueries({
           queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansList),
         });
-        queryClient.invalidateQueries({
-          queryKey: ['businessAreasPaymentPlans'],
-        });
       },
     });
 
   const { data: cyclesData } = useQuery<PaginatedProgramCycleListList>({
-    queryKey: ['programCycles', businessArea, programId],
+    queryKey: restQueryKey(RestService.restBusinessAreasProgramsCyclesList, {
+      businessAreaSlug: businessArea,
+      programCode: programId,
+    }),
     queryFn: () =>
       RestService.restBusinessAreasProgramsCyclesList({
         businessAreaSlug: businessArea,

--- a/src/frontend/src/containers/pages/paymentmodule/EditPaymentPlanPage.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/EditPaymentPlanPage.tsx
@@ -13,6 +13,7 @@ import { PaginatedTargetPopulationListList } from '@restgenerated/models/Paginat
 import { PaymentPlanDetail } from '@restgenerated/models/PaymentPlanDetail';
 import { RestService } from '@restgenerated/services/RestService';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { showApiErrorMessages, today } from '@utils/utils';
 import { Form, Formik } from 'formik';
 import moment from 'moment';
@@ -63,10 +64,10 @@ const EditPaymentPlanForm = ({
         }),
       onSuccess: () => {
         queryClient.invalidateQueries({
-          queryKey: ['paymentPlan', businessArea, paymentPlanId, programId],
+          queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansRetrieve),
         });
         queryClient.invalidateQueries({
-          queryKey: ['businessAreasProgramsPaymentPlansList'],
+          queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansList),
         });
         queryClient.invalidateQueries({
           queryKey: ['businessAreasPaymentPlans'],
@@ -182,7 +183,7 @@ const EditPaymentPlanPage = (): ReactElement => {
   const { businessArea, programId } = useBaseUrl();
   const { data: paymentPlan, isLoading: loadingPaymentPlan } =
     useQuery<PaymentPlanDetail>({
-      queryKey: ['paymentPlan', businessArea, paymentPlanId, programId],
+      queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansRetrieve, { businessAreaSlug: businessArea, id: paymentPlanId, programCode: programId }),
       queryFn: () =>
         RestService.restBusinessAreasProgramsPaymentPlansRetrieve({
           businessAreaSlug: businessArea,

--- a/src/frontend/src/containers/pages/paymentmodule/EditPaymentPlanPage.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/EditPaymentPlanPage.tsx
@@ -196,11 +196,14 @@ const EditPaymentPlanPage = (): ReactElement => {
     data: allTargetPopulationsData,
     isLoading: loadingTargetPopulations,
   } = useQuery<PaginatedTargetPopulationListList>({
-    queryKey: [
-      'businessAreasProgramsTargetPopulationsList',
-      businessArea,
-      programId,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsTargetPopulationsList,
+      {
+        businessAreaSlug: businessArea,
+        programCode: programId,
+        status: 'DRAFT',
+      },
+    ),
     queryFn: () => {
       return RestService.restBusinessAreasProgramsTargetPopulationsList({
         businessAreaSlug: businessArea,

--- a/src/frontend/src/containers/pages/paymentmodule/EditPaymentPlanPage.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/EditPaymentPlanPage.tsx
@@ -12,7 +12,7 @@ import { PaginatedProgramCycleListList } from '@restgenerated/models/PaginatedPr
 import { PaginatedTargetPopulationListList } from '@restgenerated/models/PaginatedTargetPopulationListList';
 import { PaymentPlanDetail } from '@restgenerated/models/PaymentPlanDetail';
 import { RestService } from '@restgenerated/services/RestService';
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { showApiErrorMessages, today } from '@utils/utils';
 import { Form, Formik } from 'formik';
 import moment from 'moment';
@@ -40,6 +40,7 @@ const EditPaymentPlanForm = ({
   const { baseUrl, businessArea, programId } = useBaseUrl();
   const { t } = useTranslation();
   const { showMessage } = useSnackbar();
+  const queryClient = useQueryClient();
 
   const { mutateAsync: updatePaymentPlan, isPending: loadingUpdate } =
     useMutation({
@@ -60,6 +61,17 @@ const EditPaymentPlanForm = ({
           programCode,
           requestBody,
         }),
+      onSuccess: () => {
+        queryClient.invalidateQueries({
+          queryKey: ['paymentPlan', businessArea, paymentPlanId, programId],
+        });
+        queryClient.invalidateQueries({
+          queryKey: ['businessAreasProgramsPaymentPlansList'],
+        });
+        queryClient.invalidateQueries({
+          queryKey: ['businessAreasPaymentPlans'],
+        });
+      },
     });
 
   const { data: cyclesData } = useQuery<PaginatedProgramCycleListList>({

--- a/src/frontend/src/containers/pages/paymentmodule/FollowUpInstructionDetailsPage.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/FollowUpInstructionDetailsPage.tsx
@@ -12,6 +12,7 @@ import { PaymentPlanBackgroundActionStatusEnum } from '@restgenerated/models/Pay
 import { FollowUpInstructionDetail } from '@restgenerated/models/FollowUpInstructionDetail';
 import { RestService } from '@restgenerated/services/RestService';
 import { useQuery } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { isPermissionDeniedError } from '@utils/utils';
 import { ReactElement } from 'react';
 import { useParams } from 'react-router-dom';
@@ -32,7 +33,14 @@ const FollowUpInstructionDetailsPage = (): ReactElement => {
     isLoading,
     error,
   } = useQuery<FollowUpInstructionDetail>({
-    queryKey: ['followUpInstruction', businessArea, instructionId, programId],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsFollowUpInstructionsRetrieve,
+      {
+        businessAreaSlug: businessArea,
+        id: instructionId,
+        programCode: programId,
+      },
+    ),
     queryFn: () =>
       RestService.restBusinessAreasProgramsFollowUpInstructionsRetrieve({
         businessAreaSlug: businessArea,

--- a/src/frontend/src/containers/pages/paymentmodule/FollowUpInstructions/CreateFollowUpInstructionDialog.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/FollowUpInstructions/CreateFollowUpInstructionDialog.tsx
@@ -21,6 +21,7 @@ import { PaginatedPaymentPlanGroupListList } from '@restgenerated/models/Paginat
 import { RestService } from '@restgenerated/services/RestService';
 import { FormikDateField } from '@shared/Formik/FormikDateField';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { showApiErrorMessages } from '@utils/utils';
 import { format } from 'date-fns';
 import { Field, Form, Formik } from 'formik';
@@ -61,14 +62,18 @@ export function CreateFollowUpInstructionDialog(): ReactElement {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
 
+  const groupsListParams = {
+    businessAreaSlug: businessArea,
+    programCode: programId,
+    limit: 200,
+  };
   const { data: groupsData } = useQuery<PaginatedPaymentPlanGroupListList>({
-    queryKey: ['paymentPlanGroupsList', businessArea, programId, 'all'],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsPaymentPlanGroupsList,
+      groupsListParams,
+    ),
     queryFn: () =>
-      RestService.restBusinessAreasProgramsPaymentPlanGroupsList({
-        businessAreaSlug: businessArea,
-        programCode: programId,
-        limit: 200,
-      }),
+      RestService.restBusinessAreasProgramsPaymentPlanGroupsList(groupsListParams),
     enabled: open && !!businessArea && !!programId,
   });
 
@@ -103,7 +108,9 @@ export function CreateFollowUpInstructionDialog(): ReactElement {
       };
       const created = await createInstruction(body);
       await queryClient.invalidateQueries({
-        queryKey: ['followUpInstructionsList', businessArea, programId],
+        queryKey: restQueryKey(
+          RestService.restBusinessAreasProgramsFollowUpInstructionsList,
+        ),
       });
       setOpen(false);
       showMessage(t('Follow-up Instruction created'));

--- a/src/frontend/src/containers/pages/paymentmodule/FollowUpInstructions/FollowUpInstructionTable.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/FollowUpInstructions/FollowUpInstructionTable.tsx
@@ -8,6 +8,7 @@ import { FollowUpInstructionList } from '@restgenerated/models/FollowUpInstructi
 import { PaginatedFollowUpInstructionListList } from '@restgenerated/models/PaginatedFollowUpInstructionListList';
 import { RestService } from '@restgenerated/services/RestService';
 import { useQuery } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { createApiParams } from '@utils/apiUtils';
 import { ReactElement, useState } from 'react';
 
@@ -19,20 +20,21 @@ export const FollowUpInstructionTable = (): ReactElement => {
   });
   const [page, setPage] = useState(0);
 
+  const instructionsListParams = {
+    businessAreaSlug: businessArea,
+    programCode: programId,
+    ...queryVariables,
+  };
   const { data, isLoading, error } =
     useQuery<PaginatedFollowUpInstructionListList>({
-      queryKey: [
-        'followUpInstructionsList',
-        businessArea,
-        programId,
-        queryVariables,
-      ],
+      queryKey: restQueryKey(
+        RestService.restBusinessAreasProgramsFollowUpInstructionsList,
+        instructionsListParams,
+      ),
       queryFn: () =>
-        RestService.restBusinessAreasProgramsFollowUpInstructionsList({
-          businessAreaSlug: businessArea,
-          programCode: programId,
-          ...queryVariables,
-        }),
+        RestService.restBusinessAreasProgramsFollowUpInstructionsList(
+          instructionsListParams,
+        ),
       enabled: !!businessArea && !!programId,
       refetchInterval: (query) => {
         const results = query.state.data?.results ?? [];
@@ -44,19 +46,18 @@ export const FollowUpInstructionTable = (): ReactElement => {
       refetchIntervalInBackground: true,
     });
 
+  const instructionsCountParams = createApiParams(
+    { businessAreaSlug: businessArea, programCode: programId },
+    queryVariables,
+  );
   const { data: dataCount } = useQuery<CountResponse>({
-    queryKey: [
-      'followUpInstructionsCount',
-      businessArea,
-      programId,
-      queryVariables,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsFollowUpInstructionsCountRetrieve,
+      instructionsCountParams,
+    ),
     queryFn: () =>
       RestService.restBusinessAreasProgramsFollowUpInstructionsCountRetrieve(
-        createApiParams(
-          { businessAreaSlug: businessArea, programCode: programId },
-          queryVariables,
-        ),
+        instructionsCountParams,
       ),
     enabled: !!businessArea && !!programId && page === 0,
   });

--- a/src/frontend/src/containers/pages/paymentmodule/FollowUpInstructions/actions/ConfirmWorkflowButton.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/FollowUpInstructions/actions/ConfirmWorkflowButton.tsx
@@ -1,7 +1,6 @@
 import { DialogFooter } from '@containers/dialogs/DialogFooter';
 import { DialogTitleWrapper } from '@containers/dialogs/DialogTitleWrapper';
 import { LoadingButton } from '@core/LoadingButton';
-import { useBaseUrl } from '@hooks/useBaseUrl';
 import { useSnackbar } from '@hooks/useSnackBar';
 import {
   Button,
@@ -13,6 +12,8 @@ import {
 } from '@mui/material';
 import { FollowUpInstructionDetail } from '@restgenerated/models/FollowUpInstructionDetail';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { showApiErrorMessages } from '@utils/utils';
 import { ReactElement, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -31,7 +32,6 @@ interface ConfirmWorkflowButtonProps {
 
 export function ConfirmWorkflowButton({
   label,
-  instruction,
   mutationFn,
   successMessage,
   withComment = false,
@@ -43,7 +43,6 @@ export function ConfirmWorkflowButton({
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
   const [comment, setComment] = useState('');
-  const { businessArea, programId } = useBaseUrl();
   const { showMessage } = useSnackbar();
   const queryClient = useQueryClient();
 
@@ -51,15 +50,14 @@ export function ConfirmWorkflowButton({
     mutationFn: () => mutationFn(comment || undefined),
     onSuccess: async () => {
       await queryClient.invalidateQueries({
-        queryKey: [
-          'followUpInstruction',
-          businessArea,
-          instruction.id,
-          programId,
-        ],
+        queryKey: restQueryKey(
+          RestService.restBusinessAreasProgramsFollowUpInstructionsRetrieve,
+        ),
       });
       await queryClient.invalidateQueries({
-        queryKey: ['followUpInstructionsList', businessArea, programId],
+        queryKey: restQueryKey(
+          RestService.restBusinessAreasProgramsFollowUpInstructionsList,
+        ),
       });
       setOpen(false);
       setComment('');

--- a/src/frontend/src/containers/pages/paymentmodule/FollowUpInstructions/actions/ReconciliationImportButton.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/FollowUpInstructions/actions/ReconciliationImportButton.tsx
@@ -3,6 +3,7 @@ import { useBaseUrl } from '@hooks/useBaseUrl';
 import { FollowUpInstructionDetail } from '@restgenerated/models/FollowUpInstructionDetail';
 import { PaymentPlanImportFile } from '@restgenerated/models/PaymentPlanImportFile';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -28,12 +29,9 @@ export function ReconciliationImportButton({
           },
         )
       }
-      invalidateQueryKey={[
-        'followUpInstruction',
-        businessArea,
-        instruction.id,
-        programId,
-      ]}
+      invalidateQueryKey={restQueryKey(
+        RestService.restBusinessAreasProgramsFollowUpInstructionsRetrieve,
+      )}
       successMessage={t('Reconciliation import started')}
       buttonLabel={t('Upload Reconciliation')}
       dataCySuffix="reconciliation-import"

--- a/src/frontend/src/containers/pages/paymentmodule/FollowUpInstructions/actions/SimpleWorkflowButton.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/FollowUpInstructions/actions/SimpleWorkflowButton.tsx
@@ -1,8 +1,9 @@
 import { LoadingButton } from '@core/LoadingButton';
-import { useBaseUrl } from '@hooks/useBaseUrl';
 import { useSnackbar } from '@hooks/useSnackBar';
 import { FollowUpInstructionDetail } from '@restgenerated/models/FollowUpInstructionDetail';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { showApiErrorMessages } from '@utils/utils';
 import { ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -19,7 +20,6 @@ interface SimpleWorkflowButtonProps {
 
 export function SimpleWorkflowButton({
   label,
-  instruction,
   mutationFn,
   successMessage,
   color = 'primary',
@@ -27,7 +27,6 @@ export function SimpleWorkflowButton({
   dataCy,
 }: SimpleWorkflowButtonProps): ReactElement {
   const { t } = useTranslation();
-  const { businessArea, programId } = useBaseUrl();
   const { showMessage } = useSnackbar();
   const queryClient = useQueryClient();
 
@@ -35,15 +34,14 @@ export function SimpleWorkflowButton({
     mutationFn,
     onSuccess: async () => {
       await queryClient.invalidateQueries({
-        queryKey: [
-          'followUpInstruction',
-          businessArea,
-          instruction.id,
-          programId,
-        ],
+        queryKey: restQueryKey(
+          RestService.restBusinessAreasProgramsFollowUpInstructionsRetrieve,
+        ),
       });
       await queryClient.invalidateQueries({
-        queryKey: ['followUpInstructionsList', businessArea, programId],
+        queryKey: restQueryKey(
+          RestService.restBusinessAreasProgramsFollowUpInstructionsList,
+        ),
       });
       showMessage(t(successMessage));
     },

--- a/src/frontend/src/containers/pages/paymentmodule/FollowUpPaymentPlanDetailsPage.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/FollowUpPaymentPlanDetailsPage.tsx
@@ -17,6 +17,7 @@ import { PaymentPlanDetail } from '@restgenerated/models/PaymentPlanDetail';
 import { PaymentPlanStatusEnum } from '@restgenerated/models/PaymentPlanStatusEnum';
 import { RestService } from '@restgenerated/services/RestService';
 import { useQuery } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { isPermissionDeniedError } from '@utils/utils';
 import { ReactElement } from 'react';
 import { useParams } from 'react-router-dom';
@@ -28,7 +29,7 @@ export function FollowUpPaymentPlanDetailsPage(): ReactElement {
   const permissions = usePermissions();
   const { baseUrl, businessArea, programId } = useBaseUrl();
   const { data: paymentPlan, error } = useQuery<PaymentPlanDetail>({
-    queryKey: ['paymentPlan', businessArea, paymentPlanId, programId],
+    queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansRetrieve, { businessAreaSlug: businessArea, id: paymentPlanId, programCode: programId }),
     queryFn: () =>
       RestService.restBusinessAreasProgramsPaymentPlansRetrieve({
         businessAreaSlug: businessArea,

--- a/src/frontend/src/containers/pages/paymentmodule/Groups/BatchDetailsPage.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/Groups/BatchDetailsPage.tsx
@@ -6,6 +6,7 @@ import { useBaseUrl } from '@hooks/useBaseUrl';
 import { usePermissions } from '@hooks/usePermissions';
 import { RestService } from '@restgenerated/services/RestService';
 import { useQuery } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { ReactElement, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
@@ -32,7 +33,14 @@ const BatchDetailsPage = (): ReactElement => {
   const { businessArea, programId } = useBaseUrl();
 
   const { data: group } = useQuery({
-    queryKey: ['paymentPlanGroup', businessArea, programId, groupId],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsPaymentPlanGroupsRetrieve,
+      {
+        businessAreaSlug: businessArea,
+        id: groupId,
+        programCode: programId,
+      },
+    ),
     queryFn: () =>
       RestService.restBusinessAreasProgramsPaymentPlanGroupsRetrieve({
         businessAreaSlug: businessArea,

--- a/src/frontend/src/containers/pages/paymentmodule/Groups/PaymentPlanGroupDetailsPage.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/Groups/PaymentPlanGroupDetailsPage.tsx
@@ -13,6 +13,7 @@ import { hasPermissions, PERMISSIONS } from '../../../../config/permissions';
 import { RestService } from '@restgenerated/services/RestService';
 import { Box, Grid, Link, Typography } from '@mui/material';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { ReactElement, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
@@ -60,7 +61,7 @@ const PaymentPlanGroupDetailsPage = (): ReactElement => {
         queryKey: ['businessAreasPaymentPlans'],
       });
       queryClient.invalidateQueries({
-        queryKey: ['businessAreasProgramsPaymentPlansList'],
+        queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansList),
       });
     }
     wasBusy.current = isBusy;

--- a/src/frontend/src/containers/pages/paymentmodule/Groups/PaymentPlanGroupDetailsPage.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/Groups/PaymentPlanGroupDetailsPage.tsx
@@ -38,7 +38,14 @@ const PaymentPlanGroupDetailsPage = (): ReactElement => {
   const permissions = usePermissions();
   const queryClient = useQueryClient();
   const { data: group, isLoading } = useQuery({
-    queryKey: ['paymentPlanGroup', businessArea, programId, groupId],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsPaymentPlanGroupsRetrieve,
+      {
+        businessAreaSlug: businessArea,
+        id: groupId,
+        programCode: programId,
+      },
+    ),
     queryFn: () =>
       RestService.restBusinessAreasProgramsPaymentPlanGroupsRetrieve({
         businessAreaSlug: businessArea,

--- a/src/frontend/src/containers/pages/paymentmodule/Groups/PaymentPlanGroupDetailsPage.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/Groups/PaymentPlanGroupDetailsPage.tsx
@@ -65,9 +65,6 @@ const PaymentPlanGroupDetailsPage = (): ReactElement => {
     const isBusy = isGroupBackgroundActionBusy(group ?? null);
     if (wasBusy.current && !isBusy) {
       queryClient.invalidateQueries({
-        queryKey: ['businessAreasPaymentPlans'],
-      });
-      queryClient.invalidateQueries({
         queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansList),
       });
     }

--- a/src/frontend/src/containers/pages/paymentmodule/Groups/PaymentPlanGroupsFilters.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/Groups/PaymentPlanGroupsFilters.tsx
@@ -3,6 +3,7 @@ import { SearchTextField } from '@core/SearchTextField';
 import { SelectFilter } from '@core/SelectFilter';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { createHandleApplyFilterChange } from '@utils/utils';
 import { Grid, MenuItem } from '@mui/material';
 import { useQuery } from '@tanstack/react-query';
@@ -42,7 +43,12 @@ export const PaymentPlanGroupsFilters = ({
     );
 
   const { data: cycles } = useQuery({
-    queryKey: ['programCyclesList', businessArea, programId],
+    queryKey: restQueryKey(RestService.restBusinessAreasProgramsCyclesList, {
+      businessAreaSlug: businessArea,
+      programCode: programId,
+      limit: 100,
+      ordering: 'title',
+    }),
     queryFn: () =>
       RestService.restBusinessAreasProgramsCyclesList({
         businessAreaSlug: businessArea,

--- a/src/frontend/src/containers/pages/paymentmodule/Groups/PaymentPlanGroupsTable.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/Groups/PaymentPlanGroupsTable.tsx
@@ -8,6 +8,7 @@ import { PaginatedPaymentPlanGroupListList } from '@restgenerated/models/Paginat
 import { PaymentPlanGroupList } from '@restgenerated/models/PaymentPlanGroupList';
 import { RestService } from '@restgenerated/services/RestService';
 import { useQuery } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { createApiParams } from '@utils/apiUtils';
 import { ReactElement, useEffect, useState } from 'react';
 
@@ -34,25 +35,33 @@ export const PaymentPlanGroupsTable = ({
     setPage(0);
   }, [filter]);
 
+  const groupsListParams = {
+    businessAreaSlug: businessArea,
+    programCode: programId,
+    ...queryVariables,
+  };
   const { data, isLoading, error } = useQuery<PaginatedPaymentPlanGroupListList>({
-    queryKey: ['paymentPlanGroupsList', businessArea, programId, queryVariables],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsPaymentPlanGroupsList,
+      groupsListParams,
+    ),
     queryFn: () =>
-      RestService.restBusinessAreasProgramsPaymentPlanGroupsList({
-        businessAreaSlug: businessArea,
-        programCode: programId,
-        ...queryVariables,
-      }),
+      RestService.restBusinessAreasProgramsPaymentPlanGroupsList(groupsListParams),
     enabled: !!businessArea && !!programId,
   });
 
+  const groupsCountParams = createApiParams(
+    { businessAreaSlug: businessArea, programCode: programId },
+    queryVariables,
+  );
   const { data: dataCount } = useQuery<CountResponse>({
-    queryKey: ['paymentPlanGroupsCount', businessArea, programId, queryVariables],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsPaymentPlanGroupsCountRetrieve,
+      groupsCountParams,
+    ),
     queryFn: () =>
       RestService.restBusinessAreasProgramsPaymentPlanGroupsCountRetrieve(
-        createApiParams(
-          { businessAreaSlug: businessArea, programCode: programId },
-          queryVariables,
-        ),
+        groupsCountParams,
       ),
     enabled: !!businessArea && !!programId && page === 0,
   });

--- a/src/frontend/src/containers/pages/paymentmodule/Groups/actions/DeliveryImportXlsxGroupButton.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/Groups/actions/DeliveryImportXlsxGroupButton.tsx
@@ -3,6 +3,7 @@ import { useBaseUrl } from '@hooks/useBaseUrl';
 import { usePermissions } from '@hooks/usePermissions';
 import { PaymentPlanImportFile } from '@restgenerated/models/PaymentPlanImportFile';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
 import { hasPermissions, PERMISSIONS } from '../../../../../config/permissions';
@@ -37,12 +38,9 @@ export function DeliveryImportXlsxGroupButton({
           },
         )
       }
-      invalidateQueryKey={[
-        'paymentPlanGroup',
-        businessArea,
-        programId,
-        group?.id,
-      ]}
+      invalidateQueryKey={restQueryKey(
+        RestService.restBusinessAreasProgramsPaymentPlanGroupsRetrieve,
+      )}
       successMessage={t('Delivery reconciliation import started')}
       errorFallback={t('Import failed')}
       buttonLabel={t('Upload Reconciliation')}

--- a/src/frontend/src/containers/pages/paymentmodule/Groups/actions/EditGroupName.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/Groups/actions/EditGroupName.tsx
@@ -15,6 +15,7 @@ import {
 } from '@mui/material';
 import { RestService } from '@restgenerated/services/RestService';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { Field, Formik } from 'formik';
 import { ReactElement, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -47,7 +48,9 @@ export function EditGroupName({ group }: EditGroupNameProps): ReactElement | nul
       }),
     onSuccess: async () => {
       await queryClient.invalidateQueries({
-        queryKey: ['paymentPlanGroup', businessArea, programId, group.id],
+        queryKey: restQueryKey(
+          RestService.restBusinessAreasProgramsPaymentPlanGroupsRetrieve,
+        ),
       });
       setOpen(false);
       showMessage(t('Group name updated'));

--- a/src/frontend/src/containers/pages/paymentmodule/Groups/actions/GroupExportXlsxDialog.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/Groups/actions/GroupExportXlsxDialog.tsx
@@ -76,7 +76,14 @@ export function GroupExportXlsxDialog({
   const queryClient = useQueryClient();
 
   const { data: templatesData } = useQuery({
-    queryKey: ['fspXlsxTemplates', businessArea, programId],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsPaymentPlansFspXlsxTemplateListList,
+      {
+        businessAreaSlug: businessArea,
+        programCode: programId,
+        limit: 200,
+      },
+    ),
     queryFn: () =>
       RestService.restBusinessAreasProgramsPaymentPlansFspXlsxTemplateListList({
         businessAreaSlug: businessArea,

--- a/src/frontend/src/containers/pages/paymentmodule/Groups/actions/GroupExportXlsxDialog.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/Groups/actions/GroupExportXlsxDialog.tsx
@@ -16,6 +16,7 @@ import {
 import { PlanTypeEnum } from '@restgenerated/models/PlanTypeEnum';
 import { RestService } from '@restgenerated/services/RestService';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { showApiErrorMessages } from '@utils/utils';
 import { ReactElement, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -106,7 +107,9 @@ export function GroupExportXlsxDialog({
     onSuccess: () => {
       showMessage(t('Export started'));
       queryClient.invalidateQueries({
-        queryKey: ['paymentPlanGroup', businessArea, programId, groupId],
+        queryKey: restQueryKey(
+          RestService.restBusinessAreasProgramsPaymentPlanGroupsRetrieve,
+        ),
       });
       setOpen(false);
       setSelectedTemplate(null);

--- a/src/frontend/src/containers/pages/paymentmodule/Groups/actions/SendToPaymentGatewayGroupButton.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/Groups/actions/SendToPaymentGatewayGroupButton.tsx
@@ -4,6 +4,7 @@ import { usePermissions } from '@hooks/usePermissions';
 import { useSnackbar } from '@hooks/useSnackBar';
 import { Box } from '@mui/material';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
 import { hasPermissions, PERMISSIONS } from '../../../../../config/permissions';
@@ -37,7 +38,9 @@ export function SendToPaymentGatewayGroupButton({
       onSuccess: () => {
         showMessage(t('Sending to Payment Gateway started'));
         queryClient.invalidateQueries({
-          queryKey: ['paymentPlanGroup', businessArea, programId, group.id],
+          queryKey: restQueryKey(
+            RestService.restBusinessAreasProgramsPaymentPlanGroupsRetrieve,
+          ),
         });
       },
       onError: (error) => {

--- a/src/frontend/src/containers/pages/paymentmodule/PaymentDetailsPage.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/PaymentDetailsPage.tsx
@@ -14,6 +14,7 @@ import { Box } from '@mui/material';
 import { PaymentDetail } from '@restgenerated/models/PaymentDetail';
 import { RestService } from '@restgenerated/services/RestService';
 import { useQuery } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams, useLocation } from 'react-router-dom';
@@ -29,7 +30,15 @@ function PaymentDetailsPage(): ReactElement {
   const { businessArea, programId } = useBaseUrl();
 
   const { data: payment, isLoading: loading } = useQuery<PaymentDetail>({
-    queryKey: ['payment', businessArea, paymentId, programId, paymentPlanId],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsPaymentPlansPaymentsRetrieve,
+      {
+        businessAreaSlug: businessArea,
+        paymentId: paymentId,
+        programCode: programId,
+        paymentPlanPk: paymentPlanId,
+      },
+    ),
     queryFn: () =>
       RestService.restBusinessAreasProgramsPaymentPlansPaymentsRetrieve({
         businessAreaSlug: businessArea,

--- a/src/frontend/src/containers/pages/paymentmodule/ProgramCycle/CreatePaymentPlanPage.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/ProgramCycle/CreatePaymentPlanPage.tsx
@@ -50,9 +50,6 @@ export const CreatePaymentPlanPage = (): ReactElement => {
         queryClient.invalidateQueries({
           queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansList),
         });
-        queryClient.invalidateQueries({
-          queryKey: ['businessAreasPaymentPlans'],
-        });
       },
     });
 

--- a/src/frontend/src/containers/pages/paymentmodule/ProgramCycle/CreatePaymentPlanPage.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/ProgramCycle/CreatePaymentPlanPage.tsx
@@ -11,6 +11,7 @@ import { useSnackbar } from '@hooks/useSnackBar';
 import { PaginatedTargetPopulationListList } from '@restgenerated/models/PaginatedTargetPopulationListList';
 import { RestService } from '@restgenerated/services/RestService';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { format, parseISO } from 'date-fns';
 import { Form, Formik } from 'formik';
 import { ReactElement } from 'react';
@@ -47,7 +48,7 @@ export const CreatePaymentPlanPage = (): ReactElement => {
         }),
       onSuccess: () => {
         queryClient.invalidateQueries({
-          queryKey: ['businessAreasProgramsPaymentPlansList'],
+          queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansList),
         });
         queryClient.invalidateQueries({
           queryKey: ['businessAreasPaymentPlans'],

--- a/src/frontend/src/containers/pages/paymentmodule/ProgramCycle/CreatePaymentPlanPage.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/ProgramCycle/CreatePaymentPlanPage.tsx
@@ -60,12 +60,15 @@ export const CreatePaymentPlanPage = (): ReactElement => {
     data: allTargetPopulationsData,
     isLoading: loadingTargetPopulations,
   } = useQuery<PaginatedTargetPopulationListList>({
-    queryKey: [
-      'businessAreasProgramsTargetPopulationsList',
-      businessArea,
-      programId,
-      programCycleId,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsTargetPopulationsList,
+      {
+        businessAreaSlug: businessArea,
+        programCode: programId,
+        status: 'DRAFT',
+        programCycle: programCycleId,
+      },
+    ),
     queryFn: () => {
       return RestService.restBusinessAreasProgramsTargetPopulationsList({
         businessAreaSlug: businessArea,

--- a/src/frontend/src/containers/pages/paymentmodule/ProgramCycle/CreatePaymentPlanPage.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/ProgramCycle/CreatePaymentPlanPage.tsx
@@ -10,7 +10,7 @@ import { usePermissions } from '@hooks/usePermissions';
 import { useSnackbar } from '@hooks/useSnackBar';
 import { PaginatedTargetPopulationListList } from '@restgenerated/models/PaginatedTargetPopulationListList';
 import { RestService } from '@restgenerated/services/RestService';
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { format, parseISO } from 'date-fns';
 import { Form, Formik } from 'formik';
 import { ReactElement } from 'react';
@@ -27,6 +27,7 @@ export const CreatePaymentPlanPage = (): ReactElement => {
   const { showMessage } = useSnackbar();
   const permissions = usePermissions();
   const { programCycleId } = useParams();
+  const queryClient = useQueryClient();
 
   const { mutateAsync: createPaymentPlan, isPending: loadingCreate } =
     useMutation({
@@ -44,6 +45,14 @@ export const CreatePaymentPlanPage = (): ReactElement => {
           programCode,
           requestBody,
         }),
+      onSuccess: () => {
+        queryClient.invalidateQueries({
+          queryKey: ['businessAreasProgramsPaymentPlansList'],
+        });
+        queryClient.invalidateQueries({
+          queryKey: ['businessAreasPaymentPlans'],
+        });
+      },
     });
 
   const {

--- a/src/frontend/src/containers/pages/paymentmodule/ProgramCycle/PaymentPlanDetails/PaymentPlanDetailsHeader.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/ProgramCycle/PaymentPlanDetails/PaymentPlanDetailsHeader.tsx
@@ -17,6 +17,7 @@ import { PaymentPlanDetail } from '@restgenerated/models/PaymentPlanDetail';
 import { ProgramCycleList } from '@restgenerated/models/ProgramCycleList';
 import { RestService } from '@restgenerated/services/RestService';
 import { useQuery } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import {
   paymentPlanBackgroundActionStatusToColor,
   paymentPlanStatusToColor,
@@ -40,7 +41,11 @@ export const PaymentPlanDetailsHeader = ({
   const { businessArea, programId } = useBaseUrl();
   const programCycleId = paymentPlan.programCycle?.id;
   const { data: programCycleData } = useQuery<ProgramCycleList>({
-    queryKey: ['programCyclesDetails', businessArea, programCycleId, programId],
+    queryKey: restQueryKey(RestService.restBusinessAreasProgramsCyclesRetrieve, {
+      businessAreaSlug: businessArea,
+      id: programCycleId,
+      programCode: programId,
+    }),
     queryFn: () => {
       return RestService.restBusinessAreasProgramsCyclesRetrieve({
         businessAreaSlug: businessArea,

--- a/src/frontend/src/containers/pages/paymentmodule/ProgramCycle/PaymentPlanDetails/PaymentPlanDetailsPage.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/ProgramCycle/PaymentPlanDetails/PaymentPlanDetailsPage.tsx
@@ -19,6 +19,7 @@ import { hasPermissions, PERMISSIONS } from '../../../../../config/permissions';
 import PaymentsTable from '@containers/tables/paymentmodule/PaymentsTable/PaymentsTable';
 import ExcludeSection from '@components/paymentmodule/PaymentPlanDetails/ExcludeSection/ExcludeSection';
 import { useQuery } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { RestService } from '@restgenerated/services/RestService';
 import { PaymentPlanDetail } from '@restgenerated/models/PaymentPlanDetail';
 import FundsCommitmentSection from '@components/paymentmodule/PaymentPlanDetails/FundsCommitment/FundsCommitmentSection';
@@ -36,7 +37,7 @@ const PaymentPlanDetailsPage = (): ReactElement => {
     isLoading,
     error,
   } = useQuery<PaymentPlanDetail>({
-    queryKey: ['paymentPlan', businessArea, paymentPlanId, programId],
+    queryKey: restQueryKey(RestService.restBusinessAreasProgramsPaymentPlansRetrieve, { businessAreaSlug: businessArea, id: paymentPlanId, programCode: programId }),
     queryFn: () =>
       RestService.restBusinessAreasProgramsPaymentPlansRetrieve({
         businessAreaSlug: businessArea,

--- a/src/frontend/src/containers/pages/paymentmodule/ProgramCycle/PaymentPlanDetails/PaymentPlanDetailsPage.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/ProgramCycle/PaymentPlanDetails/PaymentPlanDetailsPage.tsx
@@ -60,7 +60,6 @@ const PaymentPlanDetailsPage = (): ReactElement => {
       }
       return false;
     },
-    refetchIntervalInBackground: true,
   });
 
   if (isLoading) return <LoadingComponent />;

--- a/src/frontend/src/containers/pages/paymentmodule/ProgramCycle/ProgramCycleDetails/PaymentPlansFilters.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/ProgramCycle/ProgramCycleDetails/PaymentPlansFilters.tsx
@@ -10,6 +10,7 @@ import { Box } from '@mui/system';
 import { PaymentPlanStatusEnum } from '@restgenerated/models/PaymentPlanStatusEnum';
 import { RestService } from '@restgenerated/services/RestService';
 import { useQuery } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { createHandleApplyFilterChange, formatFigure } from '@utils/utils';
 import moment from 'moment';
 import { ReactElement } from 'react';
@@ -55,7 +56,7 @@ export const PaymentPlansFilters = ({
   };
 
   const { data: statusChoicesData } = useQuery({
-    queryKey: ['choicesPaymentPlanStatusList'],
+    queryKey: restQueryKey(RestService.restChoicesPaymentPlanStatusList),
     queryFn: () => RestService.restChoicesPaymentPlanStatusList(),
   });
 

--- a/src/frontend/src/containers/pages/paymentmodule/ProgramCycle/ProgramCycleDetails/PaymentPlansTable.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/ProgramCycle/ProgramCycleDetails/PaymentPlansTable.tsx
@@ -10,6 +10,7 @@ import { PaymentPlanList } from '@restgenerated/models/PaymentPlanList';
 import { ProgramCycleList } from '@restgenerated/models/ProgramCycleList';
 import { RestService } from '@restgenerated/services/RestService';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { createApiParams } from '@utils/apiUtils';
 import { adjustHeadCells } from '@utils/utils';
 import React, { ReactElement, useEffect, useState } from 'react';
@@ -74,43 +75,41 @@ export const PaymentPlansTable = ({
 
   const [page, setPage] = useState(0);
 
+  const paymentPlansParams = createApiParams(
+    { businessAreaSlug: businessArea, programCode: programId },
+    queryVariables,
+    { withPagination: true },
+  );
+
   const {
     data: dataPaymentPlans,
     isLoading: isLoadingPaymentPlans,
     isFetching: isFetchingPaymentPlans,
     error: errorPaymentPlans,
   } = useQuery<PaginatedPaymentPlanListList>({
-    queryKey: [
-      'businessAreasPaymentPlans',
-      queryVariables,
-      programId,
-      businessArea,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsPaymentPlansList,
+      paymentPlansParams,
+    ),
     queryFn: () =>
-      RestService.restBusinessAreasProgramsPaymentPlansList(
-        createApiParams(
-          { businessAreaSlug: businessArea, programCode: programId },
-          queryVariables,
-          { withPagination: true },
-        ),
-      ),
+      RestService.restBusinessAreasProgramsPaymentPlansList(paymentPlansParams),
     placeholderData: keepPreviousData,
     enabled: !!businessArea && !!programId,
   });
 
+  const paymentPlansCountParams = createApiParams(
+    { businessAreaSlug: businessArea, programCode: programId },
+    queryVariables,
+  );
+
   const { data: dataPaymentPlansCount } = useQuery<CountResponse>({
-    queryKey: [
-      'businessAreasProgramsPaymentPlansCountRetrieve',
-      queryVariables,
-      programId,
-      businessArea,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsPaymentPlansCountRetrieve,
+      paymentPlansCountParams,
+    ),
     queryFn: () =>
       RestService.restBusinessAreasProgramsPaymentPlansCountRetrieve(
-        createApiParams(
-          { businessAreaSlug: businessArea, programCode: programId },
-          queryVariables,
-        ),
+        paymentPlansCountParams,
       ),
     enabled: !!businessArea && !!programId && page === 0,
   });

--- a/src/frontend/src/containers/pages/paymentmodule/ProgramCycle/ProgramCycleDetails/PaymentPlansTable.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/ProgramCycle/ProgramCycleDetails/PaymentPlansTable.tsx
@@ -9,7 +9,7 @@ import { PaginatedPaymentPlanListList } from '@restgenerated/models/PaginatedPay
 import { PaymentPlanList } from '@restgenerated/models/PaymentPlanList';
 import { ProgramCycleList } from '@restgenerated/models/ProgramCycleList';
 import { RestService } from '@restgenerated/services/RestService';
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { createApiParams } from '@utils/apiUtils';
 import { adjustHeadCells } from '@utils/utils';
 import React, { ReactElement, useEffect, useState } from 'react';
@@ -93,6 +93,7 @@ export const PaymentPlansTable = ({
           { withPagination: true },
         ),
       ),
+    placeholderData: keepPreviousData,
     enabled: !!businessArea && !!programId,
   });
 

--- a/src/frontend/src/containers/pages/paymentmodule/ProgramCycle/ProgramCycleDetails/PaymentPlansTable.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/ProgramCycle/ProgramCycleDetails/PaymentPlansTable.tsx
@@ -77,6 +77,7 @@ export const PaymentPlansTable = ({
   const {
     data: dataPaymentPlans,
     isLoading: isLoadingPaymentPlans,
+    isFetching: isFetchingPaymentPlans,
     error: errorPaymentPlans,
   } = useQuery<PaginatedPaymentPlanListList>({
     queryKey: [
@@ -140,6 +141,7 @@ export const PaymentPlansTable = ({
       data={dataPaymentPlans}
       error={errorPaymentPlans}
       isLoading={isLoadingPaymentPlans}
+      isFetching={isFetchingPaymentPlans}
       setQueryVariables={setQueryVariables}
       itemsCount={itemsCount}
       page={page}
@@ -152,7 +154,10 @@ export const PaymentPlansTable = ({
         return (
           <>
             {isNewGroup && (
-              <GroupHeaderRow name={row.paymentPlanGroup?.name} id={row.paymentPlanGroup?.id} />
+              <GroupHeaderRow
+                name={row.paymentPlanGroup?.name}
+                id={row.paymentPlanGroup?.id}
+              />
             )}
             <PaymentPlanTableRow
               key={row.id}

--- a/src/frontend/src/containers/pages/paymentmodule/ProgramCycle/ProgramCycleDetails/ProgramCycleDetailsHeader.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/ProgramCycle/ProgramCycleDetails/ProgramCycleDetailsHeader.tsx
@@ -58,12 +58,9 @@ export const ProgramCycleDetailsHeader = ({
         }),
       onSuccess: async () => {
         await queryClient.invalidateQueries({
-          queryKey: [
-            'programCyclesDetails',
-            businessArea,
-            programCycle.id,
-            programId,
-          ],
+          queryKey: restQueryKey(
+            RestService.restBusinessAreasProgramsCyclesRetrieve,
+          ),
         });
         showMessage(t('Programme Cycle Finished'));
       },
@@ -90,12 +87,9 @@ export const ProgramCycleDetailsHeader = ({
         }),
       onSuccess: async () => {
         await queryClient.invalidateQueries({
-          queryKey: [
-            'programCyclesDetails',
-            businessArea,
-            programCycle.id,
-            programId,
-          ],
+          queryKey: restQueryKey(
+            RestService.restBusinessAreasProgramsCyclesRetrieve,
+          ),
         });
       },
     });

--- a/src/frontend/src/containers/pages/paymentmodule/ProgramCycle/ProgramCycleDetails/ProgramCycleDetailsHeader.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/ProgramCycle/ProgramCycleDetails/ProgramCycleDetailsHeader.tsx
@@ -18,6 +18,7 @@ import { PaymentPlanGroupCreate } from '@restgenerated/models/PaymentPlanGroupCr
 import { ProgramCycleList } from '@restgenerated/models/ProgramCycleList';
 import { RestService } from '@restgenerated/index';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { showApiErrorMessages } from '@utils/utils';
 import { ReactElement, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -113,7 +114,9 @@ export const ProgramCycleDetailsHeader = ({
       }),
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: ['paymentPlanGroupsList', businessArea, programId],
+        queryKey: restQueryKey(
+          RestService.restBusinessAreasProgramsPaymentPlanGroupsList,
+        ),
       });
     },
   });

--- a/src/frontend/src/containers/pages/paymentmodule/ProgramCycle/ProgramCycleDetails/ProgramCycleDetailsPage.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/ProgramCycle/ProgramCycleDetails/ProgramCycleDetailsPage.tsx
@@ -9,6 +9,7 @@ import { usePermissions } from '@hooks/usePermissions';
 import { ProgramCycleList } from '@restgenerated/models/ProgramCycleList';
 import { RestService } from '@restgenerated/services/RestService';
 import { useQuery } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { getFilterFromQueryParams } from '@utils/utils';
 import { ReactElement, useState, useRef } from 'react';
 import { useScrollToRefOnChange } from '@hooks/useScrollToRefOnChange';
@@ -31,7 +32,11 @@ export const ProgramCycleDetailsPage = (): ReactElement => {
   const permissions = usePermissions();
 
   const { data, isLoading } = useQuery<ProgramCycleList>({
-    queryKey: ['programCyclesDetails', businessArea, programCycleId, programId],
+    queryKey: restQueryKey(RestService.restBusinessAreasProgramsCyclesRetrieve, {
+      businessAreaSlug: businessArea,
+      id: programCycleId,
+      programCode: programId,
+    }),
     queryFn: () => {
       return RestService.restBusinessAreasProgramsCyclesRetrieve({
         businessAreaSlug: businessArea,

--- a/src/frontend/src/containers/pages/paymentmodule/ProgramCycle/ProgramCyclePage.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/ProgramCycle/ProgramCyclePage.tsx
@@ -16,6 +16,7 @@ import { headCells } from '@containers/tables/ProgramCyclesTablePaymentModule/He
 import withErrorBoundary from '@components/core/withErrorBoundary';
 import { useQuery } from '@tanstack/react-query';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { ProgramChoices } from '@restgenerated/models/ProgramChoices';
 
 const initialFilter = {
@@ -48,7 +49,9 @@ export const ProgramCyclePage = (): ReactElement => {
   );
 
   const { data: programChoicesData } = useQuery<ProgramChoices>({
-    queryKey: ['programChoices', businessArea],
+    queryKey: restQueryKey(RestService.restBusinessAreasProgramsChoicesRetrieve, {
+      businessAreaSlug: businessArea,
+    }),
     queryFn: () =>
       RestService.restBusinessAreasProgramsChoicesRetrieve({
         businessAreaSlug: businessArea,

--- a/src/frontend/src/containers/pages/payments/PaymentPlanVerificationDetailsPage.tsx
+++ b/src/frontend/src/containers/pages/payments/PaymentPlanVerificationDetailsPage.tsx
@@ -17,6 +17,7 @@ import { Choice } from '@restgenerated/models/Choice';
 import { PaymentVerificationPlanDetails } from '@restgenerated/models/PaymentVerificationPlanDetails';
 import { RestService } from '@restgenerated/services/RestService';
 import { useQuery } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import {
   decodeIdString,
   getFilterFromQueryParams,
@@ -83,12 +84,14 @@ function PaymentPlanVerificationDetailsPage(): ReactElement {
     isLoading,
     error,
   } = useQuery<PaymentVerificationPlanDetails>({
-    queryKey: [
-      'PaymentVerificationPlanDetails',
-      businessArea,
-      paymentPlanId,
-      programId,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsPaymentVerificationsRetrieve,
+      {
+        businessAreaSlug: businessArea,
+        id: paymentPlanId,
+        programCode: programId,
+      },
+    ),
     queryFn: () =>
       RestService.restBusinessAreasProgramsPaymentVerificationsRetrieve({
         businessAreaSlug: businessArea,
@@ -100,7 +103,9 @@ function PaymentPlanVerificationDetailsPage(): ReactElement {
   const { data: choicesData, isLoading: choicesLoading } = useQuery<
     Array<Choice>
   >({
-    queryKey: ['samplingChoices', businessArea],
+    queryKey: restQueryKey(
+      RestService.restChoicesPaymentVerificationPlanSamplingList,
+    ),
     queryFn: () => RestService.restChoicesPaymentVerificationPlanSamplingList(),
   });
 

--- a/src/frontend/src/containers/pages/payments/VerificationPaymentDetailsPage.tsx
+++ b/src/frontend/src/containers/pages/payments/VerificationPaymentDetailsPage.tsx
@@ -11,6 +11,7 @@ import { useBaseUrl } from '@hooks/useBaseUrl';
 import { usePermissions } from '@hooks/usePermissions';
 import { RestService } from '@restgenerated/services/RestService';
 import { useQuery } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { isPermissionDeniedError } from '@utils/utils';
 import { ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -28,7 +29,15 @@ function VerificationPaymentDetailsPage(): ReactElement {
     isLoading: loading,
     error,
   } = useQuery<PaymentDetail>({
-    queryKey: ['payment', businessArea, id, programId, paymentPlanId],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsPaymentVerificationsVerificationsRetrieve,
+      {
+        businessAreaSlug: businessArea,
+        paymentVerificationPk: paymentPlanId,
+        id,
+        programCode: programId,
+      },
+    ),
     queryFn: () =>
       RestService.restBusinessAreasProgramsPaymentVerificationsVerificationsRetrieve(
         {

--- a/src/frontend/src/containers/pages/people/PeopleDetailsPage.tsx
+++ b/src/frontend/src/containers/pages/people/PeopleDetailsPage.tsx
@@ -29,6 +29,7 @@ import { IndividualChoices } from '@restgenerated/models/IndividualChoices';
 import { IndividualDetail } from '@restgenerated/models/IndividualDetail';
 import { FieldsAttributesService } from '@restgenerated/services/FieldsAttributesService';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useQuery } from '@tanstack/react-query';
 import {
   formatCurrencyWithSymbol,
@@ -88,7 +89,10 @@ const PeopleDetailsPage = (): ReactElement => {
 
   const { data: individualChoicesData, isLoading: individualChoicesLoading } =
     useQuery<IndividualChoices>({
-      queryKey: ['individualChoices', businessArea],
+      queryKey: restQueryKey(
+        RestService.restBusinessAreasIndividualsChoicesRetrieve,
+        { businessAreaSlug: businessArea },
+      ),
       queryFn: () =>
         RestService.restBusinessAreasIndividualsChoicesRetrieve({
           businessAreaSlug: businessArea,
@@ -96,7 +100,7 @@ const PeopleDetailsPage = (): ReactElement => {
     });
 
   const { data: flexFieldsData, isLoading: flexFieldsDataLoading } = useQuery({
-    queryKey: ['fieldsAttributes'],
+    queryKey: restQueryKey(FieldsAttributesService.fieldsAttributesRetrieve),
     queryFn: async () => {
       const data = await FieldsAttributesService.fieldsAttributesRetrieve();
       return { allIndividualsFlexFieldsAttributes: data };
@@ -105,7 +109,10 @@ const PeopleDetailsPage = (): ReactElement => {
 
   const { data: grievancesChoices, isLoading: grievancesChoicesLoading } =
     useQuery({
-      queryKey: ['businessAreasGrievanceTicketsChoices', businessArea],
+      queryKey: restQueryKey(
+        RestService.restBusinessAreasGrievanceTicketsChoicesRetrieve,
+        { businessAreaSlug: businessArea },
+      ),
       queryFn: () =>
         RestService.restBusinessAreasGrievanceTicketsChoicesRetrieve({
           businessAreaSlug: businessArea,
@@ -114,7 +121,10 @@ const PeopleDetailsPage = (): ReactElement => {
 
   const { data: periodicFieldsData, isLoading: periodicFieldsLoading } =
     useQuery({
-      queryKey: ['periodicFields', businessArea, programId],
+      queryKey: restQueryKey(
+        RestService.restBusinessAreasProgramsPeriodicFieldsList,
+        { businessAreaSlug: businessArea, programCode: programId, limit: 1000 },
+      ),
       queryFn: () =>
         RestService.restBusinessAreasProgramsPeriodicFieldsList({
           businessAreaSlug: businessArea,

--- a/src/frontend/src/containers/pages/people/PeoplePage.tsx
+++ b/src/frontend/src/containers/pages/people/PeoplePage.tsx
@@ -11,6 +11,7 @@ import { Box, Fade, Tab, Tabs, Tooltip } from '@mui/material';
 import { HouseholdChoices } from '@restgenerated/models/HouseholdChoices';
 import { IndividualChoices } from '@restgenerated/models/IndividualChoices';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useQuery } from '@tanstack/react-query';
 import { getFilterFromQueryParams } from '@utils/utils';
 import { ReactElement, useState, useEffect, useRef } from 'react';
@@ -29,7 +30,10 @@ const PeoplePage = (): ReactElement => {
   const permissions = usePermissions();
   const { data: householdChoicesData, isLoading: householdChoicesLoading } =
     useQuery<HouseholdChoices>({
-      queryKey: ['householdChoices', businessArea],
+      queryKey: restQueryKey(
+        RestService.restBusinessAreasHouseholdsChoicesRetrieve,
+        { businessAreaSlug: businessArea },
+      ),
       queryFn: () =>
         RestService.restBusinessAreasHouseholdsChoicesRetrieve({
           businessAreaSlug: businessArea,
@@ -38,7 +42,10 @@ const PeoplePage = (): ReactElement => {
 
   const { data: individualChoicesData, isLoading: individualChoicesLoading } =
     useQuery<IndividualChoices>({
-      queryKey: ['individualChoices', businessArea],
+      queryKey: restQueryKey(
+        RestService.restBusinessAreasIndividualsChoicesRetrieve,
+        { businessAreaSlug: businessArea },
+      ),
       queryFn: () =>
         RestService.restBusinessAreasIndividualsChoicesRetrieve({
           businessAreaSlug: businessArea,

--- a/src/frontend/src/containers/pages/population/HouseholdMembersPage.tsx
+++ b/src/frontend/src/containers/pages/population/HouseholdMembersPage.tsx
@@ -10,6 +10,7 @@ import { usePermissions } from '@hooks/usePermissions';
 import { Box, Fade, Tooltip } from '@mui/material';
 import { IndividualChoices } from '@restgenerated/models/IndividualChoices';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useQuery } from '@tanstack/react-query';
 import { getFilterFromQueryParams } from '@utils/utils';
 import { ReactElement, useState, useEffect, useRef } from 'react';
@@ -33,7 +34,10 @@ export const HouseholdMembersPage = (): ReactElement => {
 
   const { data: individualChoicesData, isLoading: individualChoicesLoading } =
     useQuery<IndividualChoices>({
-      queryKey: ['individualChoices', businessArea],
+      queryKey: restQueryKey(
+        RestService.restBusinessAreasIndividualsChoicesRetrieve,
+        { businessAreaSlug: businessArea },
+      ),
       queryFn: () =>
         RestService.restBusinessAreasIndividualsChoicesRetrieve({
           businessAreaSlug: businessArea,

--- a/src/frontend/src/containers/pages/population/NewOfflineTemplatePage.tsx
+++ b/src/frontend/src/containers/pages/population/NewOfflineTemplatePage.tsx
@@ -12,6 +12,7 @@ import { usePermissions } from '@hooks/usePermissions';
 import { useSnackbar } from '@hooks/useSnackBar';
 import { Box, Button, Step, StepLabel, Stepper } from '@mui/material';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useQuery } from '@tanstack/react-query';
 import { showApiErrorMessages } from '@utils/utils';
 import { Formik } from 'formik';
@@ -63,7 +64,10 @@ const NewOfflineTemplatePage = (): ReactElement => {
 
   const { data: periodicFieldsData, isLoading: periodicFieldsLoading } =
     useQuery({
-      queryKey: ['periodicFields', businessArea, programId],
+      queryKey: restQueryKey(
+        RestService.restBusinessAreasProgramsPeriodicFieldsList,
+        { businessAreaSlug: businessArea, programCode: programId },
+      ),
       queryFn: () =>
         RestService.restBusinessAreasProgramsPeriodicFieldsList({
           businessAreaSlug: businessArea,

--- a/src/frontend/src/containers/pages/population/NewOfflineTemplatePage.tsx
+++ b/src/frontend/src/containers/pages/population/NewOfflineTemplatePage.tsx
@@ -63,7 +63,7 @@ const NewOfflineTemplatePage = (): ReactElement => {
 
   const { data: periodicFieldsData, isLoading: periodicFieldsLoading } =
     useQuery({
-      queryKey: ['periodicFields', businessArea, programId, programId],
+      queryKey: ['periodicFields', businessArea, programId],
       queryFn: () =>
         RestService.restBusinessAreasProgramsPeriodicFieldsList({
           businessAreaSlug: businessArea,

--- a/src/frontend/src/containers/pages/population/NewOnlineTemplatePage.tsx
+++ b/src/frontend/src/containers/pages/population/NewOnlineTemplatePage.tsx
@@ -47,7 +47,10 @@ const NewOnlineTemplatePage = (): ReactElement => {
       ),
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: ['periodicFields', businessArea, programId, programId],
+        queryKey: ['periodicFields', businessArea, programId],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ['periodicDataUpdateOnlineEdits'],
       });
       showMessage(t('Template created successfully.'));
       navigate(
@@ -88,7 +91,7 @@ const NewOnlineTemplatePage = (): ReactElement => {
 
   const { data: periodicFieldsData, isLoading: periodicFieldsLoading } =
     useQuery({
-      queryKey: ['periodicFields', businessArea, programId, programId],
+      queryKey: ['periodicFields', businessArea, programId],
       queryFn: () =>
         RestService.restBusinessAreasProgramsPeriodicFieldsList({
           businessAreaSlug: businessArea,

--- a/src/frontend/src/containers/pages/population/NewOnlineTemplatePage.tsx
+++ b/src/frontend/src/containers/pages/population/NewOnlineTemplatePage.tsx
@@ -48,7 +48,9 @@ const NewOnlineTemplatePage = (): ReactElement => {
       ),
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: ['periodicFields', businessArea, programId],
+        queryKey: restQueryKey(
+          RestService.restBusinessAreasProgramsPeriodicFieldsList,
+        ),
       });
       queryClient.invalidateQueries({
         queryKey: restQueryKey(
@@ -94,7 +96,10 @@ const NewOnlineTemplatePage = (): ReactElement => {
 
   const { data: periodicFieldsData, isLoading: periodicFieldsLoading } =
     useQuery({
-      queryKey: ['periodicFields', businessArea, programId],
+      queryKey: restQueryKey(
+        RestService.restBusinessAreasProgramsPeriodicFieldsList,
+        { businessAreaSlug: businessArea, programCode: programId },
+      ),
       queryFn: () =>
         RestService.restBusinessAreasProgramsPeriodicFieldsList({
           businessAreaSlug: businessArea,

--- a/src/frontend/src/containers/pages/population/NewOnlineTemplatePage.tsx
+++ b/src/frontend/src/containers/pages/population/NewOnlineTemplatePage.tsx
@@ -14,6 +14,7 @@ import { Box, Button, Step, StepLabel, Stepper } from '@mui/material';
 import { PDUOnlineEditCreate } from '@restgenerated/models/PDUOnlineEditCreate';
 import { RestService } from '@restgenerated/services/RestService';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { showApiErrorMessages } from '@utils/utils';
 import { Formik } from 'formik';
 import moment from 'moment';
@@ -50,7 +51,9 @@ const NewOnlineTemplatePage = (): ReactElement => {
         queryKey: ['periodicFields', businessArea, programId],
       });
       queryClient.invalidateQueries({
-        queryKey: ['periodicDataUpdateOnlineEdits'],
+        queryKey: restQueryKey(
+          RestService.restBusinessAreasProgramsPeriodicDataUpdateOnlineEditsList,
+        ),
       });
       showMessage(t('Template created successfully.'));
       navigate(

--- a/src/frontend/src/containers/pages/population/PopulationHouseholdDetailsPage.tsx
+++ b/src/frontend/src/containers/pages/population/PopulationHouseholdDetailsPage.tsx
@@ -24,6 +24,7 @@ import Paper from '@mui/material/Paper';
 import { Theme } from '@mui/material/styles';
 import { IndividualChoices } from '@restgenerated/models/IndividualChoices';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useQuery } from '@tanstack/react-query';
 import { isPermissionDeniedError, renderSomethingOrDash } from '@utils/utils';
 import { ReactElement } from 'react';
@@ -81,7 +82,10 @@ const PopulationHouseholdDetailsPage = (): ReactElement => {
   );
 
   const { data: flexFieldsData, isLoading: flexFieldsDataLoading } = useQuery({
-    queryKey: ['fieldsAttributes', businessArea, programId],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsHouseholdsAllFlexFieldsAttributesList,
+      { businessAreaSlug: businessArea, programCode: programId },
+    ),
     queryFn: async () => {
       const data =
         await RestService.restBusinessAreasProgramsHouseholdsAllFlexFieldsAttributesList(
@@ -96,7 +100,10 @@ const PopulationHouseholdDetailsPage = (): ReactElement => {
 
   const { data: individualChoicesData, isLoading: individualChoicesLoading } =
     useQuery<IndividualChoices>({
-      queryKey: ['individualChoices', businessArea],
+      queryKey: restQueryKey(
+        RestService.restBusinessAreasIndividualsChoicesRetrieve,
+        { businessAreaSlug: businessArea },
+      ),
       queryFn: () =>
         RestService.restBusinessAreasIndividualsChoicesRetrieve({
           businessAreaSlug: businessArea,
@@ -105,7 +112,10 @@ const PopulationHouseholdDetailsPage = (): ReactElement => {
 
   const { data: grievancesChoices, isLoading: grievancesChoicesLoading } =
     useQuery({
-      queryKey: ['businessAreasGrievanceTicketsChoices', businessArea],
+      queryKey: restQueryKey(
+        RestService.restBusinessAreasGrievanceTicketsChoicesRetrieve,
+        { businessAreaSlug: businessArea },
+      ),
       queryFn: () =>
         RestService.restBusinessAreasGrievanceTicketsChoicesRetrieve({
           businessAreaSlug: businessArea,

--- a/src/frontend/src/containers/pages/population/PopulationHouseholdPage.tsx
+++ b/src/frontend/src/containers/pages/population/PopulationHouseholdPage.tsx
@@ -14,6 +14,7 @@ import { HouseholdTable } from '@containers/tables/population/HouseholdTable/Hou
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { HouseholdChoices } from '@restgenerated/models/HouseholdChoices';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useQuery } from '@tanstack/react-query';
 import { useScrollToRefOnChange } from '@hooks/useScrollToRefOnChange';
 
@@ -25,7 +26,10 @@ function PopulationHouseholdPage(): ReactElement {
 
   const { data: choicesData, isLoading: choicesLoading } =
     useQuery<HouseholdChoices>({
-      queryKey: ['householdChoices', businessArea],
+      queryKey: restQueryKey(
+        RestService.restBusinessAreasHouseholdsChoicesRetrieve,
+        { businessAreaSlug: businessArea },
+      ),
       queryFn: () =>
         RestService.restBusinessAreasHouseholdsChoicesRetrieve({
           businessAreaSlug: businessArea,

--- a/src/frontend/src/containers/pages/population/PopulationIndividualsDetailsPage.tsx
+++ b/src/frontend/src/containers/pages/population/PopulationIndividualsDetailsPage.tsx
@@ -13,6 +13,7 @@ import { Box } from '@mui/material';
 import { IndividualChoices } from '@restgenerated/models/IndividualChoices';
 import { IndividualDetail } from '@restgenerated/models/IndividualDetail';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useQuery } from '@tanstack/react-query';
 import { isPermissionDeniedError } from '@utils/utils';
 import { ReactElement } from 'react';
@@ -59,7 +60,10 @@ const PopulationIndividualsDetailsPage = (): ReactElement => {
 
   const { data: choicesData, isLoading: choicesLoading } =
     useQuery<IndividualChoices>({
-      queryKey: ['individualChoices', businessArea],
+      queryKey: restQueryKey(
+        RestService.restBusinessAreasIndividualsChoicesRetrieve,
+        { businessAreaSlug: businessArea },
+      ),
       queryFn: () =>
         RestService.restBusinessAreasIndividualsChoicesRetrieve({
           businessAreaSlug: businessArea,
@@ -67,7 +71,10 @@ const PopulationIndividualsDetailsPage = (): ReactElement => {
     });
 
   const { data: flexFieldsData, isLoading: flexFieldsDataLoading } = useQuery({
-    queryKey: ['fieldsAttributes', businessArea, programId],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsIndividualsAllFlexFieldsAttributesList,
+      { businessAreaSlug: businessArea, programCode: programId },
+    ),
     queryFn: async () => {
       const data =
         await RestService.restBusinessAreasProgramsIndividualsAllFlexFieldsAttributesList(
@@ -82,7 +89,10 @@ const PopulationIndividualsDetailsPage = (): ReactElement => {
 
   const { data: grievancesChoices, isLoading: grievancesChoicesLoading } =
     useQuery({
-      queryKey: ['businessAreasGrievanceTicketsChoices', businessArea],
+      queryKey: restQueryKey(
+        RestService.restBusinessAreasGrievanceTicketsChoicesRetrieve,
+        { businessAreaSlug: businessArea },
+      ),
       queryFn: () =>
         RestService.restBusinessAreasGrievanceTicketsChoicesRetrieve({
           businessAreaSlug: businessArea,
@@ -91,7 +101,10 @@ const PopulationIndividualsDetailsPage = (): ReactElement => {
 
   const { data: periodicFieldsData, isLoading: periodicFieldsLoading } =
     useQuery({
-      queryKey: ['periodicFields', businessArea, programId],
+      queryKey: restQueryKey(
+        RestService.restBusinessAreasProgramsPeriodicFieldsList,
+        { businessAreaSlug: businessArea, programCode: programId, limit: 1000 },
+      ),
       queryFn: () =>
         RestService.restBusinessAreasProgramsPeriodicFieldsList({
           businessAreaSlug: businessArea,

--- a/src/frontend/src/containers/pages/program/CreateProgramPage.tsx
+++ b/src/frontend/src/containers/pages/program/CreateProgramPage.tsx
@@ -88,7 +88,7 @@ export const CreateProgramPage = (): ReactElement => {
     },
     onSuccess: async () => {
       await queryClient.invalidateQueries({
-        queryKey: ['programs', businessArea],
+        queryKey: ['businessAreasProgramsList'],
       });
       await queryClient.invalidateQueries({
         queryKey: ['programChoices', businessArea],

--- a/src/frontend/src/containers/pages/program/CreateProgramPage.tsx
+++ b/src/frontend/src/containers/pages/program/CreateProgramPage.tsx
@@ -47,7 +47,9 @@ export const CreateProgramPage = (): ReactElement => {
   const beneficiaryGroup = selectedProgram?.beneficiaryGroup;
 
   const { data: treeData } = useQuery<AreaTree[]>({
-    queryKey: ['allAreasTree', businessArea],
+    queryKey: restQueryKey(RestService.restBusinessAreasGeoAreasAllAreasTreeList, {
+      businessAreaSlug: businessArea,
+    }),
     queryFn: () =>
       RestService.restBusinessAreasGeoAreasAllAreasTreeList({
         businessAreaSlug: businessArea,
@@ -56,7 +58,9 @@ export const CreateProgramPage = (): ReactElement => {
 
   const { data: userPartnerChoicesData, isLoading: userPartnerChoicesLoading } =
     useQuery<UserChoices>({
-      queryKey: ['userChoices', businessArea],
+      queryKey: restQueryKey(RestService.restBusinessAreasUsersChoicesRetrieve, {
+        businessAreaSlug: businessArea,
+      }),
       queryFn: () =>
         RestService.restBusinessAreasUsersChoicesRetrieve({
           businessAreaSlug: businessArea,
@@ -65,7 +69,9 @@ export const CreateProgramPage = (): ReactElement => {
 
   const { data: choicesData, isLoading: choicesLoading } =
     useQuery<ProgramChoices>({
-      queryKey: ['programChoices', businessArea],
+      queryKey: restQueryKey(RestService.restBusinessAreasProgramsChoicesRetrieve, {
+        businessAreaSlug: businessArea,
+      }),
       queryFn: () =>
         RestService.restBusinessAreasProgramsChoicesRetrieve({
           businessAreaSlug: businessArea,
@@ -92,7 +98,9 @@ export const CreateProgramPage = (): ReactElement => {
         queryKey: restQueryKey(RestService.restBusinessAreasProgramsList),
       });
       await queryClient.invalidateQueries({
-        queryKey: ['programChoices', businessArea],
+        queryKey: restQueryKey(
+          RestService.restBusinessAreasProgramsChoicesRetrieve,
+        ),
       });
     },
   });

--- a/src/frontend/src/containers/pages/program/CreateProgramPage.tsx
+++ b/src/frontend/src/containers/pages/program/CreateProgramPage.tsx
@@ -22,6 +22,7 @@ import { UserChoices } from '@restgenerated/models/UserChoices';
 import { RestService } from '@restgenerated/services/RestService';
 import type { DefaultError } from '@tanstack/query-core';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import {
   deepUnderscore,
   mapPartnerChoicesFromChoicesWithoutUnicef,
@@ -88,7 +89,7 @@ export const CreateProgramPage = (): ReactElement => {
     },
     onSuccess: async () => {
       await queryClient.invalidateQueries({
-        queryKey: ['businessAreasProgramsList'],
+        queryKey: restQueryKey(RestService.restBusinessAreasProgramsList),
       });
       await queryClient.invalidateQueries({
         queryKey: ['programChoices', businessArea],

--- a/src/frontend/src/containers/pages/program/DuplicateProgramPage.tsx
+++ b/src/frontend/src/containers/pages/program/DuplicateProgramPage.tsx
@@ -57,7 +57,7 @@ const DuplicateProgramPage = (): ReactElement => {
     },
     onSuccess: async () => {
       await queryClient.invalidateQueries({
-        queryKey: ['businessAreaPrograms', businessArea],
+        queryKey: ['businessAreasProgramsList'],
       });
     },
   });

--- a/src/frontend/src/containers/pages/program/DuplicateProgramPage.tsx
+++ b/src/frontend/src/containers/pages/program/DuplicateProgramPage.tsx
@@ -23,6 +23,7 @@ import { ProgramDetail } from '@restgenerated/models/ProgramDetail';
 import { UserChoices } from '@restgenerated/models/UserChoices';
 import { RestService } from '@restgenerated/services/RestService';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import {
   deepUnderscore,
   isPartnerVisible,
@@ -57,7 +58,7 @@ const DuplicateProgramPage = (): ReactElement => {
     },
     onSuccess: async () => {
       await queryClient.invalidateQueries({
-        queryKey: ['businessAreasProgramsList'],
+        queryKey: restQueryKey(RestService.restBusinessAreasProgramsList),
       });
     },
   });
@@ -70,7 +71,10 @@ const DuplicateProgramPage = (): ReactElement => {
       }),
   });
   const { data: program, isLoading: loadingProgram } = useQuery<ProgramDetail>({
-    queryKey: ['businessAreaProgram', businessArea, id],
+    queryKey: restQueryKey(RestService.restBusinessAreasProgramsRetrieve, {
+      businessAreaSlug: businessArea,
+      code: id,
+    }),
     queryFn: () =>
       RestService.restBusinessAreasProgramsRetrieve({
         businessAreaSlug: businessArea,

--- a/src/frontend/src/containers/pages/program/DuplicateProgramPage.tsx
+++ b/src/frontend/src/containers/pages/program/DuplicateProgramPage.tsx
@@ -64,7 +64,9 @@ const DuplicateProgramPage = (): ReactElement => {
   });
 
   const { data: treeData, isLoading: treeLoading } = useQuery<AreaTree[]>({
-    queryKey: ['allAreasTree', businessArea],
+    queryKey: restQueryKey(RestService.restBusinessAreasGeoAreasAllAreasTreeList, {
+      businessAreaSlug: businessArea,
+    }),
     queryFn: () =>
       RestService.restBusinessAreasGeoAreasAllAreasTreeList({
         businessAreaSlug: businessArea,
@@ -84,7 +86,9 @@ const DuplicateProgramPage = (): ReactElement => {
 
   const { data: userPartnerChoicesData, isLoading: userPartnerChoicesLoading } =
     useQuery<UserChoices>({
-      queryKey: ['userChoices', businessArea],
+      queryKey: restQueryKey(RestService.restBusinessAreasUsersChoicesRetrieve, {
+        businessAreaSlug: businessArea,
+      }),
       queryFn: () =>
         RestService.restBusinessAreasUsersChoicesRetrieve({
           businessAreaSlug: businessArea,
@@ -93,7 +97,9 @@ const DuplicateProgramPage = (): ReactElement => {
 
   const { data: choicesData, isLoading: choicesLoading } =
     useQuery<ProgramChoices>({
-      queryKey: ['programChoices', businessArea],
+      queryKey: restQueryKey(RestService.restBusinessAreasProgramsChoicesRetrieve, {
+        businessAreaSlug: businessArea,
+      }),
       queryFn: () =>
         RestService.restBusinessAreasProgramsChoicesRetrieve({
           businessAreaSlug: businessArea,

--- a/src/frontend/src/containers/pages/program/EditProgramPage.tsx
+++ b/src/frontend/src/containers/pages/program/EditProgramPage.tsx
@@ -29,7 +29,6 @@ import { RestService } from '@restgenerated/services/RestService';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { restQueryKey } from '@utils/queryKeys';
 import {
-  decodeIdString,
   deepUnderscore,
   isPartnerVisible,
   mapPartnerChoicesFromChoicesWithoutUnicef,
@@ -55,7 +54,9 @@ const EditProgramPage = (): ReactElement => {
   const { showMessage } = useSnackbar();
   const { baseUrl, businessArea } = useBaseUrl();
   const { data: treeData } = useQuery<AreaTree[]>({
-    queryKey: ['allAreasTree', businessArea],
+    queryKey: restQueryKey(RestService.restBusinessAreasGeoAreasAllAreasTreeList, {
+      businessAreaSlug: businessArea,
+    }),
     queryFn: () =>
       RestService.restBusinessAreasGeoAreasAllAreasTreeList({
         businessAreaSlug: businessArea,
@@ -76,7 +77,9 @@ const EditProgramPage = (): ReactElement => {
 
   const { data: choicesData, isLoading: choicesLoading } =
     useQuery<ProgramChoices>({
-      queryKey: ['programChoices', businessArea],
+      queryKey: restQueryKey(RestService.restBusinessAreasProgramsChoicesRetrieve, {
+        businessAreaSlug: businessArea,
+      }),
       queryFn: () =>
         RestService.restBusinessAreasProgramsChoicesRetrieve({
           businessAreaSlug: businessArea,
@@ -87,7 +90,9 @@ const EditProgramPage = (): ReactElement => {
 
   const { data: userPartnerChoicesData, isLoading: userPartnerChoicesLoading } =
     useQuery<UserChoices>({
-      queryKey: ['userChoices', businessArea],
+      queryKey: restQueryKey(RestService.restBusinessAreasUsersChoicesRetrieve, {
+        businessAreaSlug: businessArea,
+      }),
       queryFn: () =>
         RestService.restBusinessAreasUsersChoicesRetrieve({
           businessAreaSlug: businessArea,
@@ -135,7 +140,7 @@ const EditProgramPage = (): ReactElement => {
       });
       // Invalidate activity logs cache
       await queryClient.invalidateQueries({
-        queryKey: ['activityLogs', businessArea, decodeIdString(id)],
+        queryKey: restQueryKey(RestService.restBusinessAreasActivityLogsList),
       });
     },
   });

--- a/src/frontend/src/containers/pages/program/EditProgramPage.tsx
+++ b/src/frontend/src/containers/pages/program/EditProgramPage.tsx
@@ -106,7 +106,10 @@ const EditProgramPage = (): ReactElement => {
           queryKey: ['businessAreaProgram', businessArea, id],
         });
         await queryClient.invalidateQueries({
-          queryKey: ['businessAreaPrograms', businessArea],
+          queryKey: ['program', businessArea, id],
+        });
+        await queryClient.invalidateQueries({
+          queryKey: ['businessAreasProgramsList'],
         });
       },
     });
@@ -127,7 +130,10 @@ const EditProgramPage = (): ReactElement => {
         queryKey: ['businessAreaProgram', businessArea, id],
       });
       await queryClient.invalidateQueries({
-        queryKey: ['businessAreaPrograms', businessArea],
+        queryKey: ['program', businessArea, id],
+      });
+      await queryClient.invalidateQueries({
+        queryKey: ['businessAreasProgramsList'],
       });
       // Invalidate activity logs cache
       await queryClient.invalidateQueries({

--- a/src/frontend/src/containers/pages/program/EditProgramPage.tsx
+++ b/src/frontend/src/containers/pages/program/EditProgramPage.tsx
@@ -27,6 +27,7 @@ import { ProgramUpdatePartnerAccess } from '@restgenerated/models/ProgramUpdateP
 import { UserChoices } from '@restgenerated/models/UserChoices';
 import { RestService } from '@restgenerated/services/RestService';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import {
   decodeIdString,
   deepUnderscore,
@@ -62,7 +63,10 @@ const EditProgramPage = (): ReactElement => {
   });
 
   const { data: program, isLoading: loadingProgram } = useQuery<ProgramDetail>({
-    queryKey: ['businessAreaProgram', businessArea, id],
+    queryKey: restQueryKey(RestService.restBusinessAreasProgramsRetrieve, {
+      businessAreaSlug: businessArea,
+      code: id,
+    }),
     queryFn: () =>
       RestService.restBusinessAreasProgramsRetrieve({
         businessAreaSlug: businessArea,
@@ -103,13 +107,10 @@ const EditProgramPage = (): ReactElement => {
       },
       onSuccess: async () => {
         await queryClient.invalidateQueries({
-          queryKey: ['businessAreaProgram', businessArea, id],
+          queryKey: restQueryKey(RestService.restBusinessAreasProgramsRetrieve),
         });
         await queryClient.invalidateQueries({
-          queryKey: ['program', businessArea, id],
-        });
-        await queryClient.invalidateQueries({
-          queryKey: ['businessAreasProgramsList'],
+          queryKey: restQueryKey(RestService.restBusinessAreasProgramsList),
         });
       },
     });
@@ -127,13 +128,10 @@ const EditProgramPage = (): ReactElement => {
     },
     onSuccess: async () => {
       await queryClient.invalidateQueries({
-        queryKey: ['businessAreaProgram', businessArea, id],
+        queryKey: restQueryKey(RestService.restBusinessAreasProgramsRetrieve),
       });
       await queryClient.invalidateQueries({
-        queryKey: ['program', businessArea, id],
-      });
-      await queryClient.invalidateQueries({
-        queryKey: ['businessAreasProgramsList'],
+        queryKey: restQueryKey(RestService.restBusinessAreasProgramsList),
       });
       // Invalidate activity logs cache
       await queryClient.invalidateQueries({

--- a/src/frontend/src/containers/pages/program/ProgramDetailsPage.tsx
+++ b/src/frontend/src/containers/pages/program/ProgramDetailsPage.tsx
@@ -10,6 +10,7 @@ import { ProgramDetail } from '@restgenerated/models/ProgramDetail';
 import { ProgramStatusEnum } from '@restgenerated/models/ProgramStatusEnum';
 import { RestService } from '@restgenerated/services/RestService';
 import { useQuery } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { isPermissionDeniedError } from '@utils/utils';
 import { ReactElement, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -57,7 +58,10 @@ function ProgramDetailsPage(): ReactElement {
     isLoading: loading,
     error,
   } = useQuery<ProgramDetail>({
-    queryKey: ['program', businessArea, id],
+    queryKey: restQueryKey(RestService.restBusinessAreasProgramsRetrieve, {
+      businessAreaSlug: businessArea,
+      code: id,
+    }),
     queryFn: async () => {
       try {
         return await RestService.restBusinessAreasProgramsRetrieve({

--- a/src/frontend/src/containers/pages/program/ProgramDetailsPage.tsx
+++ b/src/frontend/src/containers/pages/program/ProgramDetailsPage.tsx
@@ -82,7 +82,9 @@ function ProgramDetailsPage(): ReactElement {
 
   const { data: businessAreaData, isLoading: businessAreaDataLoading } =
     useQuery<BusinessArea>({
-      queryKey: ['businessArea', businessArea],
+      queryKey: restQueryKey(RestService.restBusinessAreasRetrieve, {
+        slug: businessArea,
+      }),
       queryFn: () =>
         RestService.restBusinessAreasRetrieve({
           slug: businessArea,
@@ -91,7 +93,9 @@ function ProgramDetailsPage(): ReactElement {
 
   const { data: choices, isLoading: choicesLoading } = useQuery<ProgramChoices>(
     {
-      queryKey: ['programChoices', businessArea],
+      queryKey: restQueryKey(RestService.restBusinessAreasProgramsChoicesRetrieve, {
+        businessAreaSlug: businessArea,
+      }),
       queryFn: () =>
         RestService.restBusinessAreasProgramsChoicesRetrieve({
           businessAreaSlug: businessArea,

--- a/src/frontend/src/containers/pages/program/ProgramsPage.tsx
+++ b/src/frontend/src/containers/pages/program/ProgramsPage.tsx
@@ -7,6 +7,7 @@ import { Button } from '@mui/material';
 import { ProgramChoices } from '@restgenerated/models/ProgramChoices';
 import { RestService } from '@restgenerated/services/RestService';
 import { useQuery } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { getFilterFromQueryParams } from '@utils/utils';
 import { ReactElement, useState, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -47,7 +48,9 @@ function ProgramsPage(): ReactElement {
   const permissions = usePermissions();
 
   const { data: choicesData } = useQuery<ProgramChoices>({
-    queryKey: ['programChoices', businessArea],
+    queryKey: restQueryKey(RestService.restBusinessAreasProgramsChoicesRetrieve, {
+      businessAreaSlug: businessArea,
+    }),
     queryFn: () =>
       RestService.restBusinessAreasProgramsChoicesRetrieve({
         businessAreaSlug: businessArea,

--- a/src/frontend/src/containers/pages/rdi/RegistrationDataImportPage.tsx
+++ b/src/frontend/src/containers/pages/rdi/RegistrationDataImportPage.tsx
@@ -11,6 +11,7 @@ import { useSnackbar } from '@hooks/useSnackBar';
 import { Box } from '@mui/material';
 import { RestService } from '@restgenerated/services/RestService';
 import { useMutation, useQuery } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { getFilterFromQueryParams, showApiErrorMessages } from '@utils/utils';
 import { ReactElement, useState, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -37,7 +38,10 @@ function RegistrationDataImportPage(): ReactElement {
   const { businessArea, programId } = useBaseUrl();
   const { showMessage } = useSnackbar();
   const { data: deduplicationFlags, isLoading: loading } = useQuery({
-    queryKey: ['deduplicationFlags', businessArea, programId],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsDeduplicationFlagsRetrieve,
+      { businessAreaSlug: businessArea, code: programId },
+    ),
     queryFn: () =>
       RestService.restBusinessAreasProgramsDeduplicationFlagsRetrieve({
         businessAreaSlug: businessArea,
@@ -45,7 +49,9 @@ function RegistrationDataImportPage(): ReactElement {
       }),
   });
   const { data: businessAreaData } = useQuery<BusinessArea>({
-    queryKey: ['businessArea', businessArea],
+    queryKey: restQueryKey(RestService.restBusinessAreasRetrieve, {
+      slug: businessArea,
+    }),
     queryFn: () =>
       RestService.restBusinessAreasRetrieve({
         slug: businessArea,

--- a/src/frontend/src/containers/pages/rdi/RegistrationDataImportPage.tsx
+++ b/src/frontend/src/containers/pages/rdi/RegistrationDataImportPage.tsx
@@ -10,7 +10,7 @@ import { usePermissions } from '@hooks/usePermissions';
 import { useSnackbar } from '@hooks/useSnackBar';
 import { Box } from '@mui/material';
 import { RestService } from '@restgenerated/services/RestService';
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { restQueryKey } from '@utils/queryKeys';
 import { getFilterFromQueryParams, showApiErrorMessages } from '@utils/utils';
 import { ReactElement, useState, useRef } from 'react';
@@ -70,11 +70,18 @@ function RegistrationDataImportPage(): ReactElement {
     setShouldScroll(false),
   );
 
+  const queryClient = useQueryClient();
+
   const { mutateAsync } = useMutation({
     mutationFn: async () =>
       runDeduplicationDataImports(businessArea, programId),
     onSuccess: () => {
       showMessage('Deduplication process started');
+      queryClient.invalidateQueries({
+        queryKey: restQueryKey(
+          RestService.restBusinessAreasProgramsRegistrationDataImportsList,
+        ),
+      });
     },
   });
 

--- a/src/frontend/src/containers/pages/rdi/people/PeopleRegistrationDataImportDetailsPage.tsx
+++ b/src/frontend/src/containers/pages/rdi/people/PeopleRegistrationDataImportDetailsPage.tsx
@@ -11,6 +11,7 @@ import { Tab, Tabs } from '@core/Tabs';
 import { RegistrationDataImportStatusEnum } from '@restgenerated/models/RegistrationDataImportStatusEnum';
 import { RegistrationDataImportDetail } from '@restgenerated/models/RegistrationDataImportDetail';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { usePermissions } from '@hooks/usePermissions';
 import { Typography } from '@mui/material';
@@ -66,7 +67,10 @@ export const PeopleRegistrationDataImportDetailsPage = (): ReactElement => {
     isLoading: loading,
     error,
   } = useQuery<RegistrationDataImportDetail>({
-    queryKey: ['registrationDataImport', businessArea, programCode, id],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsRegistrationDataImportsRetrieve,
+      { businessAreaSlug: businessArea, programCode, id },
+    ),
     queryFn: () =>
       RestService.restBusinessAreasProgramsRegistrationDataImportsRetrieve({
         businessAreaSlug: businessArea,
@@ -94,7 +98,9 @@ export const PeopleRegistrationDataImportDetailsPage = (): ReactElement => {
 
   const { data: choicesData, isLoading: choicesLoading } =
     useQuery<IndividualChoices>({
-      queryKey: ['individualChoices', businessArea],
+      queryKey: restQueryKey(RestService.restBusinessAreasIndividualsChoicesRetrieve, {
+        businessAreaSlug: businessArea,
+      }),
       queryFn: () =>
         RestService.restBusinessAreasIndividualsChoicesRetrieve({
           businessAreaSlug: businessArea,

--- a/src/frontend/src/containers/pages/rdi/people/PeopleRegistrationDataImportPage.tsx
+++ b/src/frontend/src/containers/pages/rdi/people/PeopleRegistrationDataImportPage.tsx
@@ -10,7 +10,7 @@ import { useBaseUrl } from '@hooks/useBaseUrl';
 import { usePermissions } from '@hooks/usePermissions';
 import { useSnackbar } from '@hooks/useSnackBar';
 import { Box } from '@mui/material';
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { RestService } from '@restgenerated/services/RestService';
 import { restQueryKey } from '@utils/queryKeys';
 import { getFilterFromQueryParams, showApiErrorMessages } from '@utils/utils';
@@ -73,11 +73,18 @@ function PeopleRegistrationDataImportPage(): ReactElement {
     setShouldScroll(false),
   );
 
+  const queryClient = useQueryClient();
+
   const { mutateAsync } = useMutation({
     mutationFn: async () =>
       runDeduplicationDataImports(businessArea, programId),
     onSuccess: () => {
       showMessage('Deduplication process started');
+      queryClient.invalidateQueries({
+        queryKey: restQueryKey(
+          RestService.restBusinessAreasProgramsRegistrationDataImportsList,
+        ),
+      });
     },
   });
 

--- a/src/frontend/src/containers/pages/rdi/people/PeopleRegistrationDataImportPage.tsx
+++ b/src/frontend/src/containers/pages/rdi/people/PeopleRegistrationDataImportPage.tsx
@@ -12,6 +12,7 @@ import { useSnackbar } from '@hooks/useSnackBar';
 import { Box } from '@mui/material';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { getFilterFromQueryParams, showApiErrorMessages } from '@utils/utils';
 import { ReactElement, useState, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -39,7 +40,10 @@ function PeopleRegistrationDataImportPage(): ReactElement {
   const { showMessage } = useSnackbar();
 
   const { data: deduplicationFlags, isLoading: loading } = useQuery({
-    queryKey: ['deduplicationFlags', businessAreaSlug, programCode],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsDeduplicationFlagsRetrieve,
+      { businessAreaSlug, code: programCode },
+    ),
     queryFn: () =>
       RestService.restBusinessAreasProgramsDeduplicationFlagsRetrieve({
         businessAreaSlug,
@@ -48,7 +52,9 @@ function PeopleRegistrationDataImportPage(): ReactElement {
   });
 
   const { data: businessAreaData } = useQuery<BusinessArea>({
-    queryKey: ['businessArea', businessAreaSlug],
+    queryKey: restQueryKey(RestService.restBusinessAreasRetrieve, {
+      slug: businessAreaSlug,
+    }),
     queryFn: () =>
       RestService.restBusinessAreasRetrieve({
         slug: businessAreaSlug,

--- a/src/frontend/src/containers/pages/rdi/people/PeopleRegistrationDetailsPage.tsx
+++ b/src/frontend/src/containers/pages/rdi/people/PeopleRegistrationDetailsPage.tsx
@@ -12,6 +12,7 @@ import { IndividualDetail } from '@restgenerated/models/IndividualDetail';
 import { FieldsAttributesService } from '@restgenerated/services/FieldsAttributesService';
 import { RestService } from '@restgenerated/services/RestService';
 import { useQuery } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { isPermissionDeniedError } from '@utils/utils';
 import { ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -40,7 +41,7 @@ const PeopleRegistrationDetailsPage = (): ReactElement => {
     isLoading: flexFieldsDataLoading,
     error,
   } = useQuery({
-    queryKey: ['fieldsAttributes'],
+    queryKey: restQueryKey(FieldsAttributesService.fieldsAttributesRetrieve),
     queryFn: async () => {
       const data = await FieldsAttributesService.fieldsAttributesRetrieve();
       return { allIndividualsFlexFieldsAttributes: data };
@@ -48,7 +49,10 @@ const PeopleRegistrationDetailsPage = (): ReactElement => {
   });
   const { data: individual, isLoading: loadingIndividual } =
     useQuery<IndividualDetail>({
-      queryKey: ['businessAreaProgramIndividual', businessArea, programId, id],
+      queryKey: restQueryKey(
+        RestService.restBusinessAreasProgramsIndividualsRetrieve,
+        { businessAreaSlug: businessArea, programCode: programId, id },
+      ),
       queryFn: () =>
         RestService.restBusinessAreasProgramsIndividualsRetrieve({
           businessAreaSlug: businessArea,
@@ -59,7 +63,9 @@ const PeopleRegistrationDetailsPage = (): ReactElement => {
 
   const { data: choicesData, isLoading: choicesLoading } =
     useQuery<IndividualChoices>({
-      queryKey: ['individualChoices', businessArea],
+      queryKey: restQueryKey(RestService.restBusinessAreasIndividualsChoicesRetrieve, {
+        businessAreaSlug: businessArea,
+      }),
       queryFn: () =>
         RestService.restBusinessAreasIndividualsChoicesRetrieve({
           businessAreaSlug: businessArea,

--- a/src/frontend/src/containers/pages/targeting/CreateTargetPopulationPage.tsx
+++ b/src/frontend/src/containers/pages/targeting/CreateTargetPopulationPage.tsx
@@ -69,9 +69,6 @@ const CreateTargetPopulationPage = (): ReactElement => {
           requestBody,
         }),
       onSuccess: () => {
-        // Invalidate the list and detail queries for target populations and program.
-        // Both the table and the autocomplete read under
-        // `businessAreasProgramsTargetPopulationsList`, so the bare prefix covers both.
         queryClient.invalidateQueries({
           queryKey: restQueryKey(
             RestService.restBusinessAreasProgramsTargetPopulationsList,

--- a/src/frontend/src/containers/pages/targeting/CreateTargetPopulationPage.tsx
+++ b/src/frontend/src/containers/pages/targeting/CreateTargetPopulationPage.tsx
@@ -68,7 +68,12 @@ const CreateTargetPopulationPage = (): ReactElement => {
           requestBody,
         }),
       onSuccess: () => {
-        // Invalidate the list and detail queries for target populations and program
+        // Invalidate the list and detail queries for target populations and program.
+        // The table reads under `businessAreasProgramsTargetPopulationsList`; the
+        // `targetPopulations` key only backs the autocomplete.
+        queryClient.invalidateQueries({
+          queryKey: ['businessAreasProgramsTargetPopulationsList'],
+        });
         queryClient.invalidateQueries({
           queryKey: ['targetPopulations', businessAreaSlug, programCode],
         });

--- a/src/frontend/src/containers/pages/targeting/CreateTargetPopulationPage.tsx
+++ b/src/frontend/src/containers/pages/targeting/CreateTargetPopulationPage.tsx
@@ -17,6 +17,7 @@ import { FormikChipAutocomplete } from '@shared/Formik/FormikChipAutocomplete/Fo
 import { PaymentPlanGroupAutocompleteRest } from '@shared/autocompletes/rest/PaymentPlanGroupAutocompleteRest';
 import { ProgramCycleAutocompleteRest } from '@shared/autocompletes/rest/ProgramCycleAutocompleteRest';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import {
   getTargetingCriteriaVariables,
   HhIndIdValidation,
@@ -72,13 +73,15 @@ const CreateTargetPopulationPage = (): ReactElement => {
         // The table reads under `businessAreasProgramsTargetPopulationsList`; the
         // `targetPopulations` key only backs the autocomplete.
         queryClient.invalidateQueries({
-          queryKey: ['businessAreasProgramsTargetPopulationsList'],
+          queryKey: restQueryKey(
+            RestService.restBusinessAreasProgramsTargetPopulationsList,
+          ),
         });
         queryClient.invalidateQueries({
           queryKey: ['targetPopulations', businessAreaSlug, programCode],
         });
         queryClient.invalidateQueries({
-          queryKey: ['program', businessAreaSlug, programCode],
+          queryKey: restQueryKey(RestService.restBusinessAreasProgramsRetrieve),
         });
       },
     });
@@ -94,7 +97,10 @@ const CreateTargetPopulationPage = (): ReactElement => {
       }),
   });
   const { data: program } = useQuery<ProgramDetail>({
-    queryKey: ['program', businessAreaSlug, programCode],
+    queryKey: restQueryKey(RestService.restBusinessAreasProgramsRetrieve, {
+      businessAreaSlug,
+      code: programCode,
+    }),
     queryFn: () =>
       RestService.restBusinessAreasProgramsRetrieve({
         businessAreaSlug,

--- a/src/frontend/src/containers/pages/targeting/CreateTargetPopulationPage.tsx
+++ b/src/frontend/src/containers/pages/targeting/CreateTargetPopulationPage.tsx
@@ -70,15 +70,12 @@ const CreateTargetPopulationPage = (): ReactElement => {
         }),
       onSuccess: () => {
         // Invalidate the list and detail queries for target populations and program.
-        // The table reads under `businessAreasProgramsTargetPopulationsList`; the
-        // `targetPopulations` key only backs the autocomplete.
+        // Both the table and the autocomplete read under
+        // `businessAreasProgramsTargetPopulationsList`, so the bare prefix covers both.
         queryClient.invalidateQueries({
           queryKey: restQueryKey(
             RestService.restBusinessAreasProgramsTargetPopulationsList,
           ),
-        });
-        queryClient.invalidateQueries({
-          queryKey: ['targetPopulations', businessAreaSlug, programCode],
         });
         queryClient.invalidateQueries({
           queryKey: restQueryKey(RestService.restBusinessAreasProgramsRetrieve),
@@ -90,7 +87,9 @@ const CreateTargetPopulationPage = (): ReactElement => {
   const navigate = useNavigate();
 
   const { data: businessAreaData } = useQuery<BusinessArea>({
-    queryKey: ['businessArea', businessAreaSlug],
+    queryKey: restQueryKey(RestService.restBusinessAreasRetrieve, {
+      slug: businessAreaSlug,
+    }),
     queryFn: () =>
       RestService.restBusinessAreasRetrieve({
         slug: businessAreaSlug,

--- a/src/frontend/src/containers/pages/targeting/EditTargetPopulationPage.tsx
+++ b/src/frontend/src/containers/pages/targeting/EditTargetPopulationPage.tsx
@@ -7,6 +7,7 @@ import { usePermissions } from '@hooks/usePermissions';
 import { TargetPopulationDetail } from '@restgenerated/models/TargetPopulationDetail';
 import { RestService } from '@restgenerated/services/RestService';
 import { useQuery } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { isPermissionDeniedError } from '@utils/utils';
 import { useParams } from 'react-router-dom';
 import { useBaseUrl } from '@hooks/useBaseUrl';
@@ -22,7 +23,14 @@ const EditTargetPopulationPage = (): ReactElement => {
     isLoading: loading,
     error,
   } = useQuery<TargetPopulationDetail>({
-    queryKey: ['targetPopulation', businessArea, id, programCode],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsTargetPopulationsRetrieve,
+      {
+        businessAreaSlug: businessArea,
+        id: id,
+        programCode,
+      },
+    ),
     queryFn: () =>
       RestService.restBusinessAreasProgramsTargetPopulationsRetrieve({
         businessAreaSlug: businessArea,

--- a/src/frontend/src/containers/pages/targeting/TargetPopulationDetailsPage.tsx
+++ b/src/frontend/src/containers/pages/targeting/TargetPopulationDetailsPage.tsx
@@ -39,7 +39,6 @@ export const TargetPopulationDetailsPage = (): ReactElement => {
 
       return false;
     },
-    refetchIntervalInBackground: true,
   });
 
   if (loading && !paymentPlan) return <LoadingComponent />;

--- a/src/frontend/src/containers/pages/targeting/TargetPopulationDetailsPage.tsx
+++ b/src/frontend/src/containers/pages/targeting/TargetPopulationDetailsPage.tsx
@@ -8,6 +8,7 @@ import { usePermissions } from '@hooks/usePermissions';
 import { TargetPopulationDetail } from '@restgenerated/models/TargetPopulationDetail';
 import { RestService } from '@restgenerated/services/RestService';
 import { useQuery } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { isPermissionDeniedError } from '@utils/utils';
 import { ReactElement } from 'react';
 import { useParams } from 'react-router-dom';
@@ -24,7 +25,14 @@ export const TargetPopulationDetailsPage = (): ReactElement => {
     isLoading: loading,
     error,
   } = useQuery<TargetPopulationDetail>({
-    queryKey: ['targetPopulation', businessAreaSlug, id, programCode],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsTargetPopulationsRetrieve,
+      {
+        businessAreaSlug: businessAreaSlug,
+        id: id,
+        programCode,
+      },
+    ),
     queryFn: () =>
       RestService.restBusinessAreasProgramsTargetPopulationsRetrieve({
         businessAreaSlug: businessAreaSlug,

--- a/src/frontend/src/containers/routers/BaseHomeRouter.tsx
+++ b/src/frontend/src/containers/routers/BaseHomeRouter.tsx
@@ -10,6 +10,7 @@ import { theme } from 'src/theme';
 import { FC, useState } from 'react';
 import { RestService } from '@restgenerated/index';
 import { useQuery } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 
 const Root = styled.div`
   display: flex;
@@ -41,21 +42,26 @@ export const BaseHomeRouter: FC = () => {
     setOpen(false);
   };
 
+  const profileParams = {
+    businessAreaSlug: businessArea,
+    program: programCode === 'all' ? undefined : programCode,
+  };
+
   const {
     data: businessAreaData,
     isLoading: businessAreaLoading,
     isError: businessAreaError,
   } = useQuery({
-    queryKey: ['businessAreasProfile', businessArea, programCode],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasUsersProfileRetrieve,
+      profileParams,
+    ),
     queryFn: () => {
-      return RestService.restBusinessAreasUsersProfileRetrieve({
-        businessAreaSlug: businessArea,
-        program: programCode === 'all' ? undefined : programCode,
-      });
+      return RestService.restBusinessAreasUsersProfileRetrieve(profileParams);
     },
     retry: false,
-    staleTime: 15 * 60 * 1000, // Data is considered fresh for 15 minutes (business areas don't change often)
-    gcTime: 60 * 60 * 1000, // Keep unused data in cache for 1 hour
+    staleTime: 5 * 60 * 1000, // Data is considered fresh for 5 minutes
+    gcTime: 30 * 60 * 1000, // Keep unused data in cache for 30 minutes
     refetchOnWindowFocus: false, // Don't refetch when window regains focus
   });
 

--- a/src/frontend/src/containers/tables/Communication/CommunicationTable/CommunicationTable.tsx
+++ b/src/frontend/src/containers/tables/Communication/CommunicationTable/CommunicationTable.tsx
@@ -54,23 +54,24 @@ function CommunicationTable({
 
   const [page, setPage] = useState(0);
 
-  const { data, isLoading, error } = useQuery<PaginatedMessageListList>({
-    queryKey: [
-      'businessAreasProgramsMessagesList',
-      queryVariables,
-      programId,
-      businessArea,
-    ],
-    queryFn: () =>
-      RestService.restBusinessAreasProgramsMessagesList(
-        createApiParams(
-          { businessAreaSlug: businessArea, programCode: programId },
-          queryVariables,
-          { withPagination: true },
+  const { data, isLoading, isFetching, error } =
+    useQuery<PaginatedMessageListList>({
+      queryKey: [
+        'businessAreasProgramsMessagesList',
+        queryVariables,
+        programId,
+        businessArea,
+      ],
+      queryFn: () =>
+        RestService.restBusinessAreasProgramsMessagesList(
+          createApiParams(
+            { businessAreaSlug: businessArea, programCode: programId },
+            queryVariables,
+            { withPagination: true },
+          ),
         ),
-      ),
-    placeholderData: keepPreviousData,
-  });
+      placeholderData: keepPreviousData,
+    });
 
   const { data: countData } = useQuery<CountResponse>({
     queryKey: [
@@ -107,6 +108,7 @@ function CommunicationTable({
         data={data}
         error={error}
         isLoading={isLoading}
+        isFetching={isFetching}
         queryVariables={queryVariables}
         setQueryVariables={setQueryVariables}
         itemsCount={itemsCount}

--- a/src/frontend/src/containers/tables/Communication/CommunicationTable/CommunicationTable.tsx
+++ b/src/frontend/src/containers/tables/Communication/CommunicationTable/CommunicationTable.tsx
@@ -1,6 +1,6 @@
 import { ReactElement, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { RestService } from '@restgenerated/services/RestService';
 import type { MessageList } from '@restgenerated/models/MessageList';
 import type { PaginatedMessageListList } from '@restgenerated/models/PaginatedMessageListList';
@@ -69,6 +69,7 @@ function CommunicationTable({
           { withPagination: true },
         ),
       ),
+    placeholderData: keepPreviousData,
   });
 
   const { data: countData } = useQuery<CountResponse>({

--- a/src/frontend/src/containers/tables/Communication/CommunicationTable/CommunicationTable.tsx
+++ b/src/frontend/src/containers/tables/Communication/CommunicationTable/CommunicationTable.tsx
@@ -2,6 +2,7 @@ import { ReactElement, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import type { MessageList } from '@restgenerated/models/MessageList';
 import type { PaginatedMessageListList } from '@restgenerated/models/PaginatedMessageListList';
 import type { CountResponse } from '@restgenerated/models/CountResponse';
@@ -56,12 +57,14 @@ function CommunicationTable({
 
   const { data, isLoading, isFetching, error } =
     useQuery<PaginatedMessageListList>({
-      queryKey: [
-        'businessAreasProgramsMessagesList',
-        queryVariables,
-        programId,
-        businessArea,
-      ],
+      queryKey: restQueryKey(
+        RestService.restBusinessAreasProgramsMessagesList,
+        createApiParams(
+          { businessAreaSlug: businessArea, programCode: programId },
+          queryVariables,
+          { withPagination: true },
+        ),
+      ),
       queryFn: () =>
         RestService.restBusinessAreasProgramsMessagesList(
           createApiParams(
@@ -74,12 +77,13 @@ function CommunicationTable({
     });
 
   const { data: countData } = useQuery<CountResponse>({
-    queryKey: [
-      'businessAreasProgramsMessagesCount',
-      programId,
-      businessArea,
-      queryVariables,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsMessagesCountRetrieve,
+      createApiParams(
+        { businessAreaSlug: businessArea, programCode: programId },
+        queryVariables,
+      ),
+    ),
     queryFn: () =>
       RestService.restBusinessAreasProgramsMessagesCountRetrieve(
         createApiParams(

--- a/src/frontend/src/containers/tables/Communication/LookUpHouseholdTableCommunication/LookUpHouseholdTableCommunication.tsx
+++ b/src/frontend/src/containers/tables/Communication/LookUpHouseholdTableCommunication/LookUpHouseholdTableCommunication.tsx
@@ -2,6 +2,7 @@ import { TableWrapper } from '@components/core/TableWrapper';
 import withErrorBoundary from '@components/core/withErrorBoundary';
 import { UniversalRestTable } from '@components/rest/UniversalRestTable/UniversalRestTable';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { adjustHeadCells } from '@utils/utils';
 import { createApiParams } from '@utils/apiUtils';
@@ -101,21 +102,20 @@ function LookUpHouseholdTableCommunication({
 
   const [page, setPage] = useState(0);
 
+  const householdsListParams = createApiParams(
+    { businessAreaSlug: businessArea, programCode: programId },
+    queryVariables,
+    { withPagination: true },
+  );
   const { data, isLoading, isFetching, error } =
     useQuery<PaginatedHouseholdListList>({
-      queryKey: [
-        'businessAreasProgramsHouseholdsList',
-        queryVariables,
-        businessArea,
-        programId,
-      ],
+      queryKey: restQueryKey(
+        RestService.restBusinessAreasProgramsHouseholdsList,
+        householdsListParams,
+      ),
       queryFn: () =>
         RestService.restBusinessAreasProgramsHouseholdsList(
-          createApiParams(
-            { businessAreaSlug: businessArea, programCode: programId },
-            queryVariables,
-            { withPagination: true },
-          ),
+          householdsListParams,
         ),
       placeholderData: keepPreviousData,
     });

--- a/src/frontend/src/containers/tables/Communication/LookUpHouseholdTableCommunication/LookUpHouseholdTableCommunication.tsx
+++ b/src/frontend/src/containers/tables/Communication/LookUpHouseholdTableCommunication/LookUpHouseholdTableCommunication.tsx
@@ -2,7 +2,7 @@ import { TableWrapper } from '@components/core/TableWrapper';
 import withErrorBoundary from '@components/core/withErrorBoundary';
 import { UniversalRestTable } from '@components/rest/UniversalRestTable/UniversalRestTable';
 import { RestService } from '@restgenerated/services/RestService';
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { adjustHeadCells } from '@utils/utils';
 import { createApiParams } from '@utils/apiUtils';
 import { MouseEvent, ReactElement, useEffect, useMemo, useState } from 'react';
@@ -116,6 +116,7 @@ function LookUpHouseholdTableCommunication({
           { withPagination: true },
         ),
       ),
+    placeholderData: keepPreviousData,
   });
 
   const [selected, setSelected] = useState<string[]>(

--- a/src/frontend/src/containers/tables/Communication/LookUpHouseholdTableCommunication/LookUpHouseholdTableCommunication.tsx
+++ b/src/frontend/src/containers/tables/Communication/LookUpHouseholdTableCommunication/LookUpHouseholdTableCommunication.tsx
@@ -101,23 +101,24 @@ function LookUpHouseholdTableCommunication({
 
   const [page, setPage] = useState(0);
 
-  const { data, isLoading, error } = useQuery<PaginatedHouseholdListList>({
-    queryKey: [
-      'businessAreasProgramsHouseholdsList',
-      queryVariables,
-      businessArea,
-      programId,
-    ],
-    queryFn: () =>
-      RestService.restBusinessAreasProgramsHouseholdsList(
-        createApiParams(
-          { businessAreaSlug: businessArea, programCode: programId },
-          queryVariables,
-          { withPagination: true },
+  const { data, isLoading, isFetching, error } =
+    useQuery<PaginatedHouseholdListList>({
+      queryKey: [
+        'businessAreasProgramsHouseholdsList',
+        queryVariables,
+        businessArea,
+        programId,
+      ],
+      queryFn: () =>
+        RestService.restBusinessAreasProgramsHouseholdsList(
+          createApiParams(
+            { businessAreaSlug: businessArea, programCode: programId },
+            queryVariables,
+            { withPagination: true },
+          ),
         ),
-      ),
-    placeholderData: keepPreviousData,
-  });
+      placeholderData: keepPreviousData,
+    });
 
   const [selected, setSelected] = useState<string[]>(
     householdMultiSelect ? [...selectedHousehold] : [selectedHousehold],
@@ -205,6 +206,7 @@ function LookUpHouseholdTableCommunication({
       setQueryVariables={setQueryVariables}
       data={data}
       isLoading={isLoading}
+      isFetching={isFetching}
       error={error}
       page={page}
       setPage={setPage}

--- a/src/frontend/src/containers/tables/Communication/LookUpRegistrationDataImportTableCommunication/LookUpRegistrationDataImportTableCommunication.tsx
+++ b/src/frontend/src/containers/tables/Communication/LookUpRegistrationDataImportTableCommunication/LookUpRegistrationDataImportTableCommunication.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import styled from 'styled-components';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import type { RegistrationDataImportList } from '@restgenerated/models/RegistrationDataImportList';
 import type { PaginatedRegistrationDataImportListList } from '@restgenerated/models/PaginatedRegistrationDataImportListList';
 import type { CountResponse } from '@restgenerated/models/CountResponse';
@@ -82,38 +83,36 @@ function LookUpRegistrationDataImportTableCommunication({
 
   const [page, setPage] = useState(0);
 
+  const registrationDataImportsListParams = createApiParams(
+    { businessAreaSlug: businessArea, programCode: programId },
+    queryVariables,
+    { withPagination: true },
+  );
   const { data, isLoading, isFetching, error } =
     useQuery<PaginatedRegistrationDataImportListList>({
-      queryKey: [
-        'businessAreasProgramsRegistrationDataImportsList',
-        queryVariables,
-        programId,
-        businessArea,
-      ],
+      queryKey: restQueryKey(
+        RestService.restBusinessAreasProgramsRegistrationDataImportsList,
+        registrationDataImportsListParams,
+      ),
       queryFn: () =>
         RestService.restBusinessAreasProgramsRegistrationDataImportsList(
-          createApiParams(
-            { businessAreaSlug: businessArea, programCode: programId },
-            queryVariables,
-            { withPagination: true },
-          ),
+          registrationDataImportsListParams,
         ),
       placeholderData: keepPreviousData,
     });
 
+  const registrationDataImportsCountParams = createApiParams(
+    { businessAreaSlug: businessArea, programCode: programId },
+    queryVariables,
+  );
   const { data: countData } = useQuery<CountResponse>({
-    queryKey: [
-      'businessAreasProgramsRegistrationDataImportsCount',
-      programId,
-      businessArea,
-      queryVariables,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsRegistrationDataImportsCountRetrieve,
+      registrationDataImportsCountParams,
+    ),
     queryFn: () =>
       RestService.restBusinessAreasProgramsRegistrationDataImportsCountRetrieve(
-        createApiParams(
-          { businessAreaSlug: businessArea, programCode: programId },
-          queryVariables,
-        ),
+        registrationDataImportsCountParams,
       ),
     enabled: !!businessArea && !!programId && page === 0,
   });

--- a/src/frontend/src/containers/tables/Communication/LookUpRegistrationDataImportTableCommunication/LookUpRegistrationDataImportTableCommunication.tsx
+++ b/src/frontend/src/containers/tables/Communication/LookUpRegistrationDataImportTableCommunication/LookUpRegistrationDataImportTableCommunication.tsx
@@ -1,6 +1,6 @@
 import { ReactElement, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import styled from 'styled-components';
 import { RestService } from '@restgenerated/services/RestService';
 import type { RegistrationDataImportList } from '@restgenerated/models/RegistrationDataImportList';
@@ -98,6 +98,7 @@ function LookUpRegistrationDataImportTableCommunication({
             { withPagination: true },
           ),
         ),
+      placeholderData: keepPreviousData,
     });
 
   const { data: countData } = useQuery<CountResponse>({

--- a/src/frontend/src/containers/tables/Communication/LookUpRegistrationDataImportTableCommunication/LookUpRegistrationDataImportTableCommunication.tsx
+++ b/src/frontend/src/containers/tables/Communication/LookUpRegistrationDataImportTableCommunication/LookUpRegistrationDataImportTableCommunication.tsx
@@ -82,7 +82,7 @@ function LookUpRegistrationDataImportTableCommunication({
 
   const [page, setPage] = useState(0);
 
-  const { data, isLoading, error } =
+  const { data, isLoading, isFetching, error } =
     useQuery<PaginatedRegistrationDataImportListList>({
       queryKey: [
         'businessAreasProgramsRegistrationDataImportsList',
@@ -145,6 +145,7 @@ function LookUpRegistrationDataImportTableCommunication({
         data={data}
         error={error}
         isLoading={isLoading}
+        isFetching={isFetching}
         queryVariables={queryVariables}
         setQueryVariables={setQueryVariables}
         itemsCount={itemsCount}

--- a/src/frontend/src/containers/tables/Communication/LookUpTargetPopulationTableCommunication/LookUpTargetPopulationTableCommunication.tsx
+++ b/src/frontend/src/containers/tables/Communication/LookUpTargetPopulationTableCommunication/LookUpTargetPopulationTableCommunication.tsx
@@ -81,6 +81,7 @@ const LookUpTargetPopulationTableCommunication = ({
   const {
     data: paymentPlansData,
     isLoading,
+    isFetching,
     error,
   } = useQuery<PaginatedTargetPopulationListList>({
     queryKey: [
@@ -115,6 +116,7 @@ const LookUpTargetPopulationTableCommunication = ({
         defaultOrderDirection="desc"
         data={paymentPlansData}
         isLoading={isLoading}
+        isFetching={isFetching}
         error={error}
         queryVariables={queryVariables}
         setQueryVariables={setQueryVariables}

--- a/src/frontend/src/containers/tables/Communication/LookUpTargetPopulationTableCommunication/LookUpTargetPopulationTableCommunication.tsx
+++ b/src/frontend/src/containers/tables/Communication/LookUpTargetPopulationTableCommunication/LookUpTargetPopulationTableCommunication.tsx
@@ -7,7 +7,7 @@ import { UniversalRestTable } from '@components/rest/UniversalRestTable/Universa
 import { headCells } from './LookUpTargetPopulationTableHeadCellsCommunication';
 import { LookUpTargetPopulationTableRowCommunication } from './LookUpTargetPopulationTableRowCommunication';
 import { PaymentPlanStatusEnum } from '@restgenerated/models/PaymentPlanStatusEnum';
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { RestService } from '@restgenerated/services/RestService';
 import { createApiParams } from '@utils/apiUtils';
 import { PaginatedTargetPopulationListList } from '@restgenerated/models/PaginatedTargetPopulationListList';
@@ -98,6 +98,7 @@ const LookUpTargetPopulationTableCommunication = ({
         ),
       );
     },
+    placeholderData: keepPreviousData,
   });
 
   const handleRadioChange = (id: string): void => {

--- a/src/frontend/src/containers/tables/Communication/LookUpTargetPopulationTableCommunication/LookUpTargetPopulationTableCommunication.tsx
+++ b/src/frontend/src/containers/tables/Communication/LookUpTargetPopulationTableCommunication/LookUpTargetPopulationTableCommunication.tsx
@@ -9,6 +9,7 @@ import { LookUpTargetPopulationTableRowCommunication } from './LookUpTargetPopul
 import { PaymentPlanStatusEnum } from '@restgenerated/models/PaymentPlanStatusEnum';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { createApiParams } from '@utils/apiUtils';
 import { PaginatedTargetPopulationListList } from '@restgenerated/models/PaginatedTargetPopulationListList';
 import { TargetPopulationList } from '@restgenerated/models/TargetPopulationList';
@@ -78,25 +79,24 @@ const LookUpTargetPopulationTableCommunication = ({
 
   const [page, setPage] = useState(0);
 
+  const targetPopulationsListParams = createApiParams(
+    { businessAreaSlug: businessArea, programCode: programId },
+    queryVariables,
+    { withPagination: true },
+  );
   const {
     data: paymentPlansData,
     isLoading,
     isFetching,
     error,
   } = useQuery<PaginatedTargetPopulationListList>({
-    queryKey: [
-      'businessAreasProgramsTargetPopulationsList',
-      queryVariables,
-      businessArea,
-      programId,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsTargetPopulationsList,
+      targetPopulationsListParams,
+    ),
     queryFn: () => {
       return RestService.restBusinessAreasProgramsTargetPopulationsList(
-        createApiParams(
-          { businessAreaSlug: businessArea, programCode: programId },
-          queryVariables,
-          { withPagination: true },
-        ),
+        targetPopulationsListParams,
       );
     },
     placeholderData: keepPreviousData,

--- a/src/frontend/src/containers/tables/Communication/RecipientsTable/RecipientsTable.tsx
+++ b/src/frontend/src/containers/tables/Communication/RecipientsTable/RecipientsTable.tsx
@@ -4,6 +4,7 @@ import { useBaseUrl } from '@hooks/useBaseUrl';
 import { UniversalRestTable } from '@components/rest/UniversalRestTable/UniversalRestTable';
 import { useQuery } from '@tanstack/react-query';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { headCells } from './RecipientsTableHeadCells';
 import { RecipientsTableRow } from './RecipientsTableRow';
 import { useProgramContext } from 'src/programContext';
@@ -42,10 +43,10 @@ function RecipientsTable({
   const [page, setPage] = useState(0);
 
   const { data, isLoading, error } = useQuery({
-    queryKey: [
-      'businessAreasProgramsHouseholdsAllAccountabilityCommunicationMessageRecipientsList',
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsHouseholdsAllAccountabilityCommunicationMessageRecipientsList,
       queryVariables,
-    ],
+    ),
     queryFn: () =>
       RestService.restBusinessAreasProgramsHouseholdsAllAccountabilityCommunicationMessageRecipientsList(
         queryVariables,

--- a/src/frontend/src/containers/tables/Feedback/FeedbackTable.tsx
+++ b/src/frontend/src/containers/tables/Feedback/FeedbackTable.tsx
@@ -40,7 +40,8 @@ function FeedbackTable({
       createdAtBefore: dateToIsoString(filter.createdAtBefore, 'startOfDay'),
       createdAtAfter: dateToIsoString(filter.createdAtAfter, 'endOfDay'),
       program: isAllPrograms ? filter.program : null,
-      isActiveProgram: filter.programState === PROGRAM_STATE_FILTER.ACTIVE ? true : null,
+      isActiveProgram:
+        filter.programState === PROGRAM_STATE_FILTER.ACTIVE ? true : null,
       businessAreaSlug: businessArea,
       programCode: isAllPrograms ? null : programId,
     }),
@@ -72,6 +73,7 @@ function FeedbackTable({
     data: selectedProgramFeedbacksData,
     error: errorSelectedProgram,
     isLoading: isLoadingSelectedProgram,
+    isFetching: isFetchingSelectedProgram,
   } = useQuery<PaginatedFeedbackListList>({
     queryKey: [
       'businessAreasProgramsFeedbacksList',
@@ -114,6 +116,7 @@ function FeedbackTable({
     data: allProgramsFeedbacksData,
     error: errorAllPrograms,
     isLoading: isLoadingAllPrograms,
+    isFetching: isFetchingAllPrograms,
   } = useQuery<PaginatedFeedbackListList>({
     queryKey: ['businessAreasFeedbacksList', queryVariables, businessArea],
     queryFn: () => {
@@ -188,6 +191,9 @@ function FeedbackTable({
         error={isAllPrograms ? errorAllPrograms : errorSelectedProgram}
         isLoading={
           isAllPrograms ? isLoadingAllPrograms : isLoadingSelectedProgram
+        }
+        isFetching={
+          isAllPrograms ? isFetchingAllPrograms : isFetchingSelectedProgram
         }
         itemsCount={itemsCount}
         page={page}

--- a/src/frontend/src/containers/tables/Feedback/FeedbackTable.tsx
+++ b/src/frontend/src/containers/tables/Feedback/FeedbackTable.tsx
@@ -9,7 +9,7 @@ import { useProgramContext } from 'src/programContext';
 import withErrorBoundary from '@components/core/withErrorBoundary';
 import { UniversalRestTable } from '@components/rest/UniversalRestTable/UniversalRestTable';
 import { RestService } from '@restgenerated/services/RestService';
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { createApiParams } from '@utils/apiUtils';
 import { PROGRAM_STATE_FILTER } from '@utils/constants';
 import { PaginatedFeedbackListList } from '@restgenerated/models/PaginatedFeedbackListList';
@@ -88,6 +88,7 @@ function FeedbackTable({
         ),
       ),
     enabled: !isAllPrograms,
+    placeholderData: keepPreviousData,
   });
 
   // Selected Program Count
@@ -123,6 +124,7 @@ function FeedbackTable({
       );
     },
     enabled: isAllPrograms,
+    placeholderData: keepPreviousData,
   });
 
   // All Programs Count

--- a/src/frontend/src/containers/tables/Feedback/FeedbackTable.tsx
+++ b/src/frontend/src/containers/tables/Feedback/FeedbackTable.tsx
@@ -10,6 +10,7 @@ import withErrorBoundary from '@components/core/withErrorBoundary';
 import { UniversalRestTable } from '@components/rest/UniversalRestTable/UniversalRestTable';
 import { RestService } from '@restgenerated/services/RestService';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { createApiParams } from '@utils/apiUtils';
 import { PROGRAM_STATE_FILTER } from '@utils/constants';
 import { PaginatedFeedbackListList } from '@restgenerated/models/PaginatedFeedbackListList';
@@ -75,12 +76,14 @@ function FeedbackTable({
     isLoading: isLoadingSelectedProgram,
     isFetching: isFetchingSelectedProgram,
   } = useQuery<PaginatedFeedbackListList>({
-    queryKey: [
-      'businessAreasProgramsFeedbacksList',
-      queryVariables,
-      programId,
-      businessArea,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsFeedbacksList,
+      createApiParams(
+        { businessAreaSlug: businessArea, programCode: programId },
+        queryVariables,
+        { withPagination: true },
+      ),
+    ),
     queryFn: () =>
       RestService.restBusinessAreasProgramsFeedbacksList(
         createApiParams(
@@ -95,12 +98,13 @@ function FeedbackTable({
 
   // Selected Program Count
   const { data: selectedProgramFeedbacksCount } = useQuery<CountResponse>({
-    queryKey: [
-      'businessAreasProgramsFeedbacksCountRetrieve',
-      businessArea,
-      programId,
-      queryVariables,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsFeedbacksCountRetrieve,
+      createApiParams(
+        { businessAreaSlug: businessArea, programCode: programId },
+        queryVariables,
+      ),
+    ),
     queryFn: () =>
       RestService.restBusinessAreasProgramsFeedbacksCountRetrieve(
         createApiParams(
@@ -118,7 +122,12 @@ function FeedbackTable({
     isLoading: isLoadingAllPrograms,
     isFetching: isFetchingAllPrograms,
   } = useQuery<PaginatedFeedbackListList>({
-    queryKey: ['businessAreasFeedbacksList', queryVariables, businessArea],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasFeedbacksList,
+      createApiParams({ businessAreaSlug: businessArea }, queryVariables, {
+        withPagination: true,
+      }),
+    ),
     queryFn: () => {
       return RestService.restBusinessAreasFeedbacksList(
         createApiParams({ businessAreaSlug: businessArea }, queryVariables, {
@@ -132,11 +141,10 @@ function FeedbackTable({
 
   // All Programs Count
   const { data: allProgramsFeedbacksCount } = useQuery<CountResponse>({
-    queryKey: [
-      'businessAreasFeedbacksCountRetrieve',
-      businessArea,
-      queryVariables,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasFeedbacksCountRetrieve,
+      createApiParams({ businessAreaSlug: businessArea }, queryVariables),
+    ),
     queryFn: () =>
       RestService.restBusinessAreasFeedbacksCountRetrieve(
         createApiParams({ businessAreaSlug: businessArea }, queryVariables),

--- a/src/frontend/src/containers/tables/ProgramCycle/DeleteProgramCycle.tsx
+++ b/src/frontend/src/containers/tables/ProgramCycle/DeleteProgramCycle.tsx
@@ -1,4 +1,5 @@
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import withErrorBoundary from '@components/core/withErrorBoundary';
 import { DialogDescription } from '@containers/dialogs/DialogDescription';
 import { DialogFooter } from '@containers/dialogs/DialogFooter';
@@ -68,7 +69,7 @@ const DeleteProgramCycle = ({
       }
     }
     await queryClient.invalidateQueries({
-      queryKey: ['programCycles', businessArea, program.code],
+      queryKey: restQueryKey(RestService.restBusinessAreasProgramsCyclesList),
       exact: false,
     });
     setOpen(false);

--- a/src/frontend/src/containers/tables/ProgramCycle/EditProgramCycle.tsx
+++ b/src/frontend/src/containers/tables/ProgramCycle/EditProgramCycle.tsx
@@ -24,6 +24,7 @@ import CalendarTodayRoundedIcon from '@mui/icons-material/CalendarTodayRounded';
 import { DialogFooter } from '@containers/dialogs/DialogFooter';
 import { LoadingButton } from '@core/LoadingButton';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { useSnackbar } from '@hooks/useSnackBar';
@@ -61,7 +62,7 @@ const EditProgramCycle = ({
     },
     onSuccess: async () => {
       await queryClient.invalidateQueries({
-        queryKey: ['programCycles', businessArea, program.code],
+        queryKey: restQueryKey(RestService.restBusinessAreasProgramsCyclesList),
       });
       setOpen(false);
     },

--- a/src/frontend/src/containers/tables/ProgramCycle/NewProgramCycle/AddNewProgramCycle.tsx
+++ b/src/frontend/src/containers/tables/ProgramCycle/NewProgramCycle/AddNewProgramCycle.tsx
@@ -8,6 +8,8 @@ import { Dialog } from '@mui/material';
 import { ProgramCycleList } from '@restgenerated/models/ProgramCycleList';
 import { ProgramDetail } from '@restgenerated/models/ProgramDetail';
 import { ProgramStatusEnum } from '@restgenerated/models/ProgramStatusEnum';
+import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useQueryClient } from '@tanstack/react-query';
 import { ReactElement, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -34,7 +36,7 @@ const AddNewProgramCycle = ({
 
   const handleClose = async () => {
     await queryClient.invalidateQueries({
-      queryKey: ['programCycles'],
+      queryKey: restQueryKey(RestService.restBusinessAreasProgramsCyclesList),
       exact: false,
     });
     setOpen(false);

--- a/src/frontend/src/containers/tables/ProgramCycle/NewProgramCycle/CreateProgramCycle.tsx
+++ b/src/frontend/src/containers/tables/ProgramCycle/NewProgramCycle/CreateProgramCycle.tsx
@@ -19,6 +19,7 @@ import {
 import { ProgramCycleCreate } from '@restgenerated/models/ProgramCycleCreate';
 import { ProgramDetail } from '@restgenerated/models/ProgramDetail';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { FormikDateField } from '@shared/Formik/FormikDateField';
 import { FormikTextField } from '@shared/Formik/FormikTextField';
 import type { DefaultError } from '@tanstack/query-core';
@@ -106,7 +107,7 @@ const CreateProgramCycle = ({
     },
     onSuccess: async () => {
       await queryClient.invalidateQueries({
-        queryKey: ['programCycles'],
+        queryKey: restQueryKey(RestService.restBusinessAreasProgramsCyclesList),
         exact: false,
       });
       onSubmit();

--- a/src/frontend/src/containers/tables/ProgramCycle/ProgramCyclesTableProgramDetails.tsx
+++ b/src/frontend/src/containers/tables/ProgramCycle/ProgramCyclesTableProgramDetails.tsx
@@ -10,7 +10,7 @@ import { UniversalMoment } from '@core/UniversalMoment';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { usePermissions } from '@hooks/usePermissions';
 import TableCell from '@mui/material/TableCell';
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { programCycleStatusToColor, formatFigure } from '@utils/utils';
 import React, { ReactElement, useState } from 'react';
 import { usePersistedCount } from '@hooks/usePersistedCount';
@@ -57,6 +57,7 @@ const ProgramCyclesTableProgramDetails = ({
         ),
       );
     },
+    placeholderData: keepPreviousData,
   });
 
   const { data: dataProgramCyclesCount } = useQuery<CountResponse>({

--- a/src/frontend/src/containers/tables/ProgramCycle/ProgramCyclesTableProgramDetails.tsx
+++ b/src/frontend/src/containers/tables/ProgramCycle/ProgramCyclesTableProgramDetails.tsx
@@ -46,7 +46,7 @@ const ProgramCyclesTableProgramDetails = ({
   }, [page]);
   const { businessAreaSlug, baseUrl, programId } = useBaseUrl();
   const permissions = usePermissions();
-  const { data, error, isLoading } = useQuery({
+  const { data, error, isLoading, isFetching } = useQuery({
     queryKey: ['programCycles', businessAreaSlug, program.code, queryVariables],
     queryFn: () => {
       return RestService.restBusinessAreasProgramsCyclesList(
@@ -175,6 +175,7 @@ const ProgramCyclesTableProgramDetails = ({
       data={data}
       error={error}
       isLoading={isLoading}
+      isFetching={isFetching}
       queryVariables={queryVariables}
       setQueryVariables={setQueryVariables}
       actions={actions}

--- a/src/frontend/src/containers/tables/ProgramCycle/ProgramCyclesTableProgramDetails.tsx
+++ b/src/frontend/src/containers/tables/ProgramCycle/ProgramCyclesTableProgramDetails.tsx
@@ -18,6 +18,7 @@ import { hasPermissions, PERMISSIONS } from '../../../config/permissions';
 import withErrorBoundary from '@components/core/withErrorBoundary';
 import { ProgramDetail } from '@restgenerated/models/ProgramDetail';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { ProgramCycleList } from '@restgenerated/models/ProgramCycleList';
 import { createApiParams } from '@utils/apiUtils';
 import { CountResponse } from '@restgenerated/models/CountResponse';
@@ -46,33 +47,36 @@ const ProgramCyclesTableProgramDetails = ({
   }, [page]);
   const { businessAreaSlug, baseUrl, programId } = useBaseUrl();
   const permissions = usePermissions();
+  const programCyclesListParams = createApiParams(
+    { businessAreaSlug, programCode: program.code },
+    queryVariables,
+    { withPagination: true },
+  );
   const { data, error, isLoading, isFetching } = useQuery({
-    queryKey: ['programCycles', businessAreaSlug, program.code, queryVariables],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsCyclesList,
+      programCyclesListParams,
+    ),
     queryFn: () => {
       return RestService.restBusinessAreasProgramsCyclesList(
-        createApiParams(
-          { businessAreaSlug, programCode: program.code },
-          queryVariables,
-          { withPagination: true },
-        ),
+        programCyclesListParams,
       );
     },
     placeholderData: keepPreviousData,
   });
 
+  const programCyclesCountParams = createApiParams(
+    { businessAreaSlug, programCode: program.code },
+    queryVariables,
+  );
   const { data: dataProgramCyclesCount } = useQuery<CountResponse>({
-    queryKey: [
-      'businessAreasProgramsCyclesCountRetrieve',
-      program.code,
-      businessAreaSlug,
-      queryVariables,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsCyclesCountRetrieve,
+      programCyclesCountParams,
+    ),
     queryFn: () =>
       RestService.restBusinessAreasProgramsCyclesCountRetrieve(
-        createApiParams(
-          { businessAreaSlug, programCode: program.code },
-          queryVariables,
-        ),
+        programCyclesCountParams,
       ),
     enabled: page === 0,
   });

--- a/src/frontend/src/containers/tables/ProgramCyclesTablePaymentModule/ProgramCyclesTablePaymentModule.tsx
+++ b/src/frontend/src/containers/tables/ProgramCyclesTablePaymentModule/ProgramCyclesTablePaymentModule.tsx
@@ -11,7 +11,12 @@ import { CountResponse } from '@restgenerated/models/CountResponse';
 import { PaginatedProgramCycleListList } from '@restgenerated/models/PaginatedProgramCycleListList';
 import { ProgramCycleList } from '@restgenerated/models/ProgramCycleList';
 import { RestService } from '@restgenerated/services/RestService';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  keepPreviousData,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
 import { createApiParams } from '@utils/apiUtils';
 import {
   programCycleStatusToColor,
@@ -76,6 +81,7 @@ export const ProgramCyclesTablePaymentModule = ({
           ),
         );
       },
+      placeholderData: keepPreviousData,
       enabled: shouldFetchData,
     });
 

--- a/src/frontend/src/containers/tables/ProgramCyclesTablePaymentModule/ProgramCyclesTablePaymentModule.tsx
+++ b/src/frontend/src/containers/tables/ProgramCyclesTablePaymentModule/ProgramCyclesTablePaymentModule.tsx
@@ -11,6 +11,7 @@ import { CountResponse } from '@restgenerated/models/CountResponse';
 import { PaginatedProgramCycleListList } from '@restgenerated/models/PaginatedProgramCycleListList';
 import { ProgramCycleList } from '@restgenerated/models/ProgramCycleList';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import {
   keepPreviousData,
   useMutation,
@@ -62,43 +63,38 @@ export const ProgramCyclesTablePaymentModule = ({
     queryVariables && typeof queryVariables.limit === 'number'
       ? queryVariables.limit
       : 5;
+  const programCyclesListParams = createApiParams(
+    { businessAreaSlug: businessArea, programCode: programId },
+    { ...queryVariables, offset: page * rowsPerPage },
+    { withPagination: true },
+  );
   const { data, refetch, error, isLoading, isFetching } =
     useQuery<PaginatedProgramCycleListList>({
-      queryKey: [
-        'programCycles',
-        queryVariables,
-        businessArea,
-        programId,
-        page,
-        rowsPerPage,
-      ],
+      queryKey: restQueryKey(
+        RestService.restBusinessAreasProgramsCyclesList,
+        programCyclesListParams,
+      ),
       queryFn: () => {
         return RestService.restBusinessAreasProgramsCyclesList(
-          createApiParams(
-            { businessAreaSlug: businessArea, programCode: programId },
-            { ...queryVariables, offset: page * rowsPerPage },
-            { withPagination: true },
-          ),
+          programCyclesListParams,
         );
       },
       placeholderData: keepPreviousData,
       enabled: shouldFetchData,
     });
 
+  const programCyclesCountParams = createApiParams(
+    { businessAreaSlug: businessArea, programCode: programId },
+    queryVariables,
+  );
   const { data: dataProgramCyclesCount } = useQuery<CountResponse>({
-    queryKey: [
-      'businessAreasProgramsCyclesCountRetrieve',
-      programId,
-      businessArea,
-      queryVariables,
-      page,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsCyclesCountRetrieve,
+      programCyclesCountParams,
+    ),
     queryFn: () =>
       RestService.restBusinessAreasProgramsCyclesCountRetrieve(
-        createApiParams(
-          { businessAreaSlug: businessArea, programCode: programId },
-          queryVariables,
-        ),
+        programCyclesCountParams,
       ),
     enabled: page === 0,
   });
@@ -123,7 +119,9 @@ export const ProgramCyclesTablePaymentModule = ({
         }),
       onSuccess: async () => {
         await queryClient.invalidateQueries({
-          queryKey: ['programCycles', businessArea, program.code],
+          queryKey: restQueryKey(
+            RestService.restBusinessAreasProgramsCyclesList,
+          ),
           exact: false,
         });
       },
@@ -148,7 +146,9 @@ export const ProgramCyclesTablePaymentModule = ({
         }),
       onSuccess: async () => {
         await queryClient.invalidateQueries({
-          queryKey: ['programCycles', businessArea, program.code],
+          queryKey: restQueryKey(
+            RestService.restBusinessAreasProgramsCyclesList,
+          ),
           exact: false,
         });
       },

--- a/src/frontend/src/containers/tables/ProgramCyclesTablePaymentModule/ProgramCyclesTablePaymentModule.tsx
+++ b/src/frontend/src/containers/tables/ProgramCyclesTablePaymentModule/ProgramCyclesTablePaymentModule.tsx
@@ -126,10 +126,6 @@ export const ProgramCyclesTablePaymentModule = ({
           queryKey: ['programCycles', businessArea, program.code],
           exact: false,
         });
-        await queryClient.invalidateQueries({
-          queryKey: ['programCycles', queryVariables, businessArea, programId],
-          exact: false,
-        });
       },
       mutationKey: ['finishProgramCycle', businessArea, program.id],
     });
@@ -153,10 +149,6 @@ export const ProgramCyclesTablePaymentModule = ({
       onSuccess: async () => {
         await queryClient.invalidateQueries({
           queryKey: ['programCycles', businessArea, program.code],
-          exact: false,
-        });
-        await queryClient.invalidateQueries({
-          queryKey: ['programCycles', queryVariables, businessArea, programId],
           exact: false,
         });
       },

--- a/src/frontend/src/containers/tables/ProgramCyclesTablePaymentModule/ProgramCyclesTablePaymentModule.tsx
+++ b/src/frontend/src/containers/tables/ProgramCyclesTablePaymentModule/ProgramCyclesTablePaymentModule.tsx
@@ -62,7 +62,7 @@ export const ProgramCyclesTablePaymentModule = ({
     queryVariables && typeof queryVariables.limit === 'number'
       ? queryVariables.limit
       : 5;
-  const { data, refetch, error, isLoading } =
+  const { data, refetch, error, isLoading, isFetching } =
     useQuery<PaginatedProgramCycleListList>({
       queryKey: [
         'programCycles',
@@ -261,6 +261,7 @@ export const ProgramCyclesTablePaymentModule = ({
       data={data}
       error={error}
       isLoading={isLoading}
+      isFetching={isFetching}
       queryVariables={queryVariables}
       setQueryVariables={setQueryVariables}
       page={page}

--- a/src/frontend/src/containers/tables/ProgrammesTable/ProgrammesTable.tsx
+++ b/src/frontend/src/containers/tables/ProgrammesTable/ProgrammesTable.tsx
@@ -7,7 +7,7 @@ import { useBaseUrl } from '@hooks/useBaseUrl';
 import { CountResponse } from '@restgenerated/models/CountResponse';
 import { PaginatedProgramListList } from '@restgenerated/models/PaginatedProgramListList';
 import { RestService } from '@restgenerated/services/RestService';
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { ReactElement, useEffect, useMemo, useState } from 'react';
 import { usePersistedCount } from '@hooks/usePersistedCount';
 import { useTranslation } from 'react-i18next';
@@ -86,6 +86,7 @@ function ProgrammesTable({
           withPagination: true,
         }),
       ),
+    placeholderData: keepPreviousData,
     enabled: !!queryVariables.businessAreaSlug,
   });
 

--- a/src/frontend/src/containers/tables/ProgrammesTable/ProgrammesTable.tsx
+++ b/src/frontend/src/containers/tables/ProgrammesTable/ProgrammesTable.tsx
@@ -3,6 +3,7 @@ import withErrorBoundary from '@components/core/withErrorBoundary';
 import { UniversalRestTable } from '@components/rest/UniversalRestTable/UniversalRestTable';
 import { ProgramChoices } from '@restgenerated/models/ProgramChoices';
 import { createApiParams } from '@utils/apiUtils';
+import { restQueryKey } from '@utils/queryKeys';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { CountResponse } from '@restgenerated/models/CountResponse';
 import { PaginatedProgramListList } from '@restgenerated/models/PaginatedProgramListList';
@@ -69,34 +70,38 @@ function ProgrammesTable({
 
   const [page, setPage] = useState(0);
 
+  const programsListParams = createApiParams(
+    { businessAreaSlug: businessArea },
+    queryVariables,
+    { withPagination: true },
+  );
   const {
     data: dataPrograms,
     isLoading: isLoadingPrograms,
     isFetching: isFetchingPrograms,
     error: errorPrograms,
   } = useQuery<PaginatedProgramListList>({
-    queryKey: [
-      'businessAreasProgramsList',
-      queryVariables,
-      businessArea,
-      programId,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsList,
+      programsListParams,
+    ),
     queryFn: () =>
-      RestService.restBusinessAreasProgramsList(
-        createApiParams({ businessAreaSlug: businessArea }, queryVariables, {
-          withPagination: true,
-        }),
-      ),
+      RestService.restBusinessAreasProgramsList(programsListParams),
     placeholderData: keepPreviousData,
     enabled: !!queryVariables.businessAreaSlug,
   });
 
+  const programsCountParams = createApiParams(
+    { businessAreaSlug: businessArea },
+    queryVariables,
+  );
   const { data: dataProgramsCount } = useQuery<CountResponse>({
-    queryKey: ['businessAreasProgramsCount', businessArea, queryVariables],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsCountRetrieve,
+      programsCountParams,
+    ),
     queryFn: () =>
-      RestService.restBusinessAreasProgramsCountRetrieve(
-        createApiParams({ businessAreaSlug: businessArea }, queryVariables),
-      ),
+      RestService.restBusinessAreasProgramsCountRetrieve(programsCountParams),
     enabled: page === 0,
   });
 

--- a/src/frontend/src/containers/tables/ProgrammesTable/ProgrammesTable.tsx
+++ b/src/frontend/src/containers/tables/ProgrammesTable/ProgrammesTable.tsx
@@ -72,6 +72,7 @@ function ProgrammesTable({
   const {
     data: dataPrograms,
     isLoading: isLoadingPrograms,
+    isFetching: isFetchingPrograms,
     error: errorPrograms,
   } = useQuery<PaginatedProgramListList>({
     queryKey: [
@@ -111,6 +112,7 @@ function ProgrammesTable({
           setQueryVariables={setQueryVariables}
           data={dataPrograms}
           isLoading={isLoadingPrograms}
+          isFetching={isFetchingPrograms}
           error={errorPrograms}
           itemsCount={itemsCount}
           renderRow={(row: ProgramList) => (

--- a/src/frontend/src/containers/tables/Surveys/LookUpProgrammesTableSurveys/LookUpProgrammesTableSurveys.tsx
+++ b/src/frontend/src/containers/tables/Surveys/LookUpProgrammesTableSurveys/LookUpProgrammesTableSurveys.tsx
@@ -10,6 +10,7 @@ import { adjustHeadCells } from '@utils/utils';
 import { useProgramContext } from 'src/programContext';
 import { PaginatedProgramListList } from '@restgenerated/models/PaginatedProgramListList';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { createApiParams } from '@utils/apiUtils';
 import { ProgramList } from '@restgenerated/models/ProgramList';
@@ -81,29 +82,37 @@ export function LookUpProgrammesTableSurveys({
     setQueryVariables(initialQueryVariables);
   }, [initialQueryVariables]);
 
+  const programsListParams = createApiParams(
+    { businessAreaSlug: businessArea },
+    queryVariables,
+    { withPagination: true },
+  );
   const {
     data: dataPrograms,
     isLoading: isLoadingPrograms,
     isFetching: isFetchingPrograms,
     error: errorPrograms,
   } = useQuery<PaginatedProgramListList>({
-    queryKey: ['businessAreasProgramsList', queryVariables, businessArea],
-    queryFn: () =>
-      RestService.restBusinessAreasProgramsList(
-        createApiParams({ businessAreaSlug: businessArea }, queryVariables, {
-          withPagination: true,
-        }),
-      ),
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsList,
+      programsListParams,
+    ),
+    queryFn: () => RestService.restBusinessAreasProgramsList(programsListParams),
     placeholderData: keepPreviousData,
     enabled: !!queryVariables.businessAreaSlug,
   });
 
+  const programsCountParams = createApiParams(
+    { businessAreaSlug: businessArea },
+    queryVariables,
+  );
   const { data: countData } = useQuery({
-    queryKey: ['businessAreasProgramsCount', queryVariables, businessArea],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsCountRetrieve,
+      programsCountParams,
+    ),
     queryFn: () =>
-      RestService.restBusinessAreasProgramsCountRetrieve(
-        createApiParams({ businessAreaSlug: businessArea }, queryVariables),
-      ),
+      RestService.restBusinessAreasProgramsCountRetrieve(programsCountParams),
     enabled: page === 0,
   });
 

--- a/src/frontend/src/containers/tables/Surveys/LookUpProgrammesTableSurveys/LookUpProgrammesTableSurveys.tsx
+++ b/src/frontend/src/containers/tables/Surveys/LookUpProgrammesTableSurveys/LookUpProgrammesTableSurveys.tsx
@@ -10,7 +10,7 @@ import { adjustHeadCells } from '@utils/utils';
 import { useProgramContext } from 'src/programContext';
 import { PaginatedProgramListList } from '@restgenerated/models/PaginatedProgramListList';
 import { RestService } from '@restgenerated/services/RestService';
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { createApiParams } from '@utils/apiUtils';
 import { ProgramList } from '@restgenerated/models/ProgramList';
 
@@ -93,6 +93,7 @@ export function LookUpProgrammesTableSurveys({
           withPagination: true,
         }),
       ),
+    placeholderData: keepPreviousData,
     enabled: !!queryVariables.businessAreaSlug,
   });
 

--- a/src/frontend/src/containers/tables/Surveys/LookUpProgrammesTableSurveys/LookUpProgrammesTableSurveys.tsx
+++ b/src/frontend/src/containers/tables/Surveys/LookUpProgrammesTableSurveys/LookUpProgrammesTableSurveys.tsx
@@ -84,6 +84,7 @@ export function LookUpProgrammesTableSurveys({
   const {
     data: dataPrograms,
     isLoading: isLoadingPrograms,
+    isFetching: isFetchingPrograms,
     error: errorPrograms,
   } = useQuery<PaginatedProgramListList>({
     queryKey: ['businessAreasProgramsList', queryVariables, businessArea],
@@ -134,6 +135,7 @@ export function LookUpProgrammesTableSurveys({
           defaultOrderBy="startDate"
           data={dataPrograms}
           isLoading={isLoadingPrograms}
+          isFetching={isFetchingPrograms}
           error={errorPrograms}
           itemsCount={itemsCount}
           page={page}

--- a/src/frontend/src/containers/tables/Surveys/LookUpTargetPopulationTableSurveys/LookUpTargetPopulationTableSurveys.tsx
+++ b/src/frontend/src/containers/tables/Surveys/LookUpTargetPopulationTableSurveys/LookUpTargetPopulationTableSurveys.tsx
@@ -4,7 +4,7 @@ import { PaymentPlanStatusEnum } from '@restgenerated/models/PaymentPlanStatusEn
 import { createApiParams } from '@utils/apiUtils';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { RestService } from '@restgenerated/services/RestService';
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { ReactElement, useEffect, useMemo, useState } from 'react';
 import { usePersistedCount } from '@hooks/usePersistedCount';
 import { useTranslation } from 'react-i18next';
@@ -100,6 +100,7 @@ export function LookUpTargetPopulationTableSurveys({
         ),
       );
     },
+    placeholderData: keepPreviousData,
   });
 
   // Count query, enabled only on page 0

--- a/src/frontend/src/containers/tables/Surveys/LookUpTargetPopulationTableSurveys/LookUpTargetPopulationTableSurveys.tsx
+++ b/src/frontend/src/containers/tables/Surveys/LookUpTargetPopulationTableSurveys/LookUpTargetPopulationTableSurveys.tsx
@@ -83,6 +83,7 @@ export function LookUpTargetPopulationTableSurveys({
   const {
     data: paymentPlansData,
     isLoading,
+    isFetching,
     error,
   } = useQuery<PaginatedTargetPopulationListList>({
     queryKey: [
@@ -137,6 +138,7 @@ export function LookUpTargetPopulationTableSurveys({
         defaultOrderDirection="desc"
         data={paymentPlansData}
         isLoading={isLoading}
+        isFetching={isFetching}
         error={error}
         queryVariables={queryVariables}
         setQueryVariables={setQueryVariables}

--- a/src/frontend/src/containers/tables/Surveys/LookUpTargetPopulationTableSurveys/LookUpTargetPopulationTableSurveys.tsx
+++ b/src/frontend/src/containers/tables/Surveys/LookUpTargetPopulationTableSurveys/LookUpTargetPopulationTableSurveys.tsx
@@ -2,6 +2,7 @@ import { TableWrapper } from '@components/core/TableWrapper';
 import { UniversalRestTable } from '@components/rest/UniversalRestTable/UniversalRestTable';
 import { PaymentPlanStatusEnum } from '@restgenerated/models/PaymentPlanStatusEnum';
 import { createApiParams } from '@utils/apiUtils';
+import { restQueryKey } from '@utils/queryKeys';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { RestService } from '@restgenerated/services/RestService';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
@@ -80,44 +81,42 @@ export function LookUpTargetPopulationTableSurveys({
     setQueryVariables(initialQueryVariables);
   }, [initialQueryVariables]);
 
+  const targetPopulationsListParams = createApiParams(
+    { businessAreaSlug: businessArea, programCode: programId },
+    queryVariables,
+    { withPagination: true },
+  );
   const {
     data: paymentPlansData,
     isLoading,
     isFetching,
     error,
   } = useQuery<PaginatedTargetPopulationListList>({
-    queryKey: [
-      'businessAreasProgramsTargetPopulationsList',
-      queryVariables,
-      businessArea,
-      programId,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsTargetPopulationsList,
+      targetPopulationsListParams,
+    ),
     queryFn: () => {
       return RestService.restBusinessAreasProgramsTargetPopulationsList(
-        createApiParams(
-          { businessAreaSlug: businessArea, programCode: programId },
-          queryVariables,
-          { withPagination: true },
-        ),
+        targetPopulationsListParams,
       );
     },
     placeholderData: keepPreviousData,
   });
 
   // Count query, enabled only on page 0
+  const targetPopulationsCountParams = createApiParams(
+    { businessAreaSlug: businessArea, programCode: programId },
+    queryVariables,
+  );
   const { data: countData } = useQuery({
-    queryKey: [
-      'businessAreasProgramsTargetPopulationsCount',
-      queryVariables,
-      businessArea,
-      programId,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsTargetPopulationsCountRetrieve,
+      targetPopulationsCountParams,
+    ),
     queryFn: () =>
       RestService.restBusinessAreasProgramsTargetPopulationsCountRetrieve(
-        createApiParams(
-          { businessAreaSlug: businessArea, programCode: programId },
-          queryVariables,
-        ),
+        targetPopulationsCountParams,
       ),
     enabled: page === 0,
   });

--- a/src/frontend/src/containers/tables/Surveys/RecipientsTable/RecipientsTable.tsx
+++ b/src/frontend/src/containers/tables/Surveys/RecipientsTable/RecipientsTable.tsx
@@ -3,6 +3,7 @@ import { TableWrapper } from '@components/core/TableWrapper';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { UniversalRestTable } from '@components/rest/UniversalRestTable/UniversalRestTable';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { headCells } from './RecipientsTableHeadCells';
 import { RecipientsTableRow } from './RecipientsTableRow';
 import { ReactElement, useMemo, useState, useEffect } from 'react';
@@ -40,10 +41,10 @@ function RecipientsTable({
   }, [initialQueryVariables]);
 
   const { data, isLoading, error } = useQuery({
-    queryKey: [
-      'businessAreasProgramsHouseholdsAllAccountabilityCommunicationMessageRecipientsList',
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsHouseholdsAllAccountabilityCommunicationMessageRecipientsList,
       queryVariables,
-    ],
+    ),
     queryFn: () =>
       RestService.restBusinessAreasProgramsHouseholdsAllAccountabilityCommunicationMessageRecipientsList(
         queryVariables,

--- a/src/frontend/src/containers/tables/Surveys/SurveysTable/SurveysTable.tsx
+++ b/src/frontend/src/containers/tables/Surveys/SurveysTable/SurveysTable.tsx
@@ -64,6 +64,7 @@ function SurveysTable({
   const {
     data: dataSurveys,
     isLoading: isLoadingSurveys,
+    isFetching: isFetchingSurveys,
     error: errorSurveys,
   } = useQuery<PaginatedSurveyList>({
     queryKey: ['businessAreasProgramsSurveysList', queryVariables],
@@ -104,7 +105,6 @@ function SurveysTable({
 
   const itemsCount = usePersistedCount(page, dataSurveysCount);
 
-
   return (
     <TableWrapper>
       <UniversalRestTable
@@ -112,6 +112,7 @@ function SurveysTable({
         title={t('Surveys List')}
         data={dataSurveys}
         isLoading={isLoadingSurveys}
+        isFetching={isFetchingSurveys}
         error={errorSurveys}
         queryVariables={queryVariables}
         setQueryVariables={setQueryVariables}

--- a/src/frontend/src/containers/tables/Surveys/SurveysTable/SurveysTable.tsx
+++ b/src/frontend/src/containers/tables/Surveys/SurveysTable/SurveysTable.tsx
@@ -9,6 +9,7 @@ import { SurveysTableRow } from './SurveysTableRow';
 import { UniversalRestTable } from '@components/rest/UniversalRestTable/UniversalRestTable';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { createApiParams } from '@utils/apiUtils';
 import { PaginatedSurveyList } from '@restgenerated/models/PaginatedSurveyList';
 import { Survey } from '@restgenerated/models/Survey';
@@ -67,7 +68,17 @@ function SurveysTable({
     isFetching: isFetchingSurveys,
     error: errorSurveys,
   } = useQuery<PaginatedSurveyList>({
-    queryKey: ['businessAreasProgramsSurveysList', queryVariables],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsSurveysList,
+      createApiParams(
+        {
+          businessAreaSlug: queryVariables.businessAreaSlug,
+          programCode: queryVariables.programCode,
+        },
+        queryVariables,
+        { withPagination: true },
+      ),
+    ),
     queryFn: () =>
       RestService.restBusinessAreasProgramsSurveysList(
         createApiParams(
@@ -84,12 +95,16 @@ function SurveysTable({
   });
 
   const { data: dataSurveysCount } = useQuery<CountResponse>({
-    queryKey: [
-      'businessAreasProgramsSurveysCount',
-      businessAreaSlug,
-      programId,
-      queryVariables,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsSurveysCountRetrieve,
+      createApiParams(
+        {
+          businessAreaSlug: queryVariables.businessAreaSlug,
+          programCode: queryVariables.programCode,
+        },
+        queryVariables,
+      ),
+    ),
     queryFn: () =>
       RestService.restBusinessAreasProgramsSurveysCountRetrieve(
         createApiParams(

--- a/src/frontend/src/containers/tables/Surveys/SurveysTable/SurveysTable.tsx
+++ b/src/frontend/src/containers/tables/Surveys/SurveysTable/SurveysTable.tsx
@@ -7,7 +7,7 @@ import { useBaseUrl } from '@hooks/useBaseUrl';
 import { headCells } from './SurveysTableHeadCells';
 import { SurveysTableRow } from './SurveysTableRow';
 import { UniversalRestTable } from '@components/rest/UniversalRestTable/UniversalRestTable';
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { RestService } from '@restgenerated/services/RestService';
 import { createApiParams } from '@utils/apiUtils';
 import { PaginatedSurveyList } from '@restgenerated/models/PaginatedSurveyList';
@@ -78,6 +78,7 @@ function SurveysTable({
           { withPagination: true },
         ),
       ),
+    placeholderData: keepPreviousData,
     enabled: !!queryVariables.businessAreaSlug && !!queryVariables.programCode,
   });
 

--- a/src/frontend/src/containers/tables/UniversalActivityLogTable.tsx
+++ b/src/frontend/src/containers/tables/UniversalActivityLogTable.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { ActivityLogTable } from '@components/core/ActivityLogTable/ActivityLogTable';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { RestService } from 'src/restgenerated';
+import { restQueryKey } from '@utils/queryKeys';
 import { ActivityLogEntry } from '@components/core/ActivityLogTable/types';
 import { useQuery } from '@tanstack/react-query';
 
@@ -25,24 +26,32 @@ export function UniversalActivityLogTable({
   const { businessAreaSlug } = useBaseUrl();
   const [rowsPerPage, setRowsPerPage] = useState(5);
 
+  const activityLogsParams = {
+    businessAreaSlug,
+    objectId: objectId,
+    limit: rowsPerPage,
+    offset: page * rowsPerPage,
+  };
   const { data: logsData } = useQuery({
-    queryKey: ['activityLogs', businessAreaSlug, objectId, page, rowsPerPage],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasActivityLogsList,
+      activityLogsParams,
+    ),
     queryFn: () =>
-      RestService.restBusinessAreasActivityLogsList({
-        businessAreaSlug,
-        objectId: objectId,
-        limit: rowsPerPage,
-        offset: page * rowsPerPage,
-      }),
+      RestService.restBusinessAreasActivityLogsList(activityLogsParams),
     enabled: !!(businessAreaSlug && objectId),
   });
 
+  const activityLogsCountParams = { businessAreaSlug };
   const { data: countData } = useQuery({
-    queryKey: ['activityLogsCount', businessAreaSlug],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasActivityLogsCountRetrieve,
+      activityLogsCountParams,
+    ),
     queryFn: () =>
-      RestService.restBusinessAreasActivityLogsCountRetrieve({
-        businessAreaSlug,
-      }),
+      RestService.restBusinessAreasActivityLogsCountRetrieve(
+        activityLogsCountParams,
+      ),
     enabled: !!businessAreaSlug,
   });
 

--- a/src/frontend/src/containers/tables/UniversalActivityLogTablePaymentVerification.tsx
+++ b/src/frontend/src/containers/tables/UniversalActivityLogTablePaymentVerification.tsx
@@ -2,6 +2,7 @@ import { ReactElement, useState } from 'react';
 import { ActivityLogTablePaymentVerification } from '@components/core/ActivityLogTablePaymentVerification/ActivityLogTablePaymentVerification';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { RestService } from '@restgenerated/index';
+import { restQueryKey } from '@utils/queryKeys';
 import { useQuery } from '@tanstack/react-query';
 
 interface UniversalActivityLogTablePaymentVerificationProps {
@@ -14,24 +15,32 @@ export function UniversalActivityLogTablePaymentVerification({
   const { businessAreaSlug } = useBaseUrl();
   const [rowsPerPage, setRowsPerPage] = useState(5);
 
+  const activityLogsParams = {
+    businessAreaSlug,
+    objectId: objectId,
+    limit: rowsPerPage,
+    offset: page * rowsPerPage,
+  };
   const { data: logData } = useQuery({
-    queryKey: ['activityLogs', businessAreaSlug, objectId, page, rowsPerPage],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasActivityLogsList,
+      activityLogsParams,
+    ),
     queryFn: () =>
-      RestService.restBusinessAreasActivityLogsList({
-        businessAreaSlug,
-        objectId: objectId,
-        limit: rowsPerPage,
-        offset: page * rowsPerPage,
-      }),
+      RestService.restBusinessAreasActivityLogsList(activityLogsParams),
     enabled: !!(businessAreaSlug && objectId),
   });
 
+  const activityLogsCountParams = { businessAreaSlug };
   const { data: countData } = useQuery({
-    queryKey: ['activityLogsCount', businessAreaSlug],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasActivityLogsCountRetrieve,
+      activityLogsCountParams,
+    ),
     queryFn: () =>
-      RestService.restBusinessAreasActivityLogsCountRetrieve({
-        businessAreaSlug,
-      }),
+      RestService.restBusinessAreasActivityLogsCountRetrieve(
+        activityLogsCountParams,
+      ),
     enabled: !!businessAreaSlug,
   });
 

--- a/src/frontend/src/containers/tables/UsersTable/UsersTable.tsx
+++ b/src/frontend/src/containers/tables/UsersTable/UsersTable.tsx
@@ -6,6 +6,7 @@ import { headCells } from './UsersTableHeadCells';
 import { UsersTableRow } from './UsersTableRow';
 import { PaginatedUserList } from '@restgenerated/models/PaginatedUserList';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { UniversalRestTable } from '@components/rest/UniversalRestTable/UniversalRestTable';
 import { useQuery } from '@tanstack/react-query';
 import { CountResponse } from '@restgenerated/models/CountResponse';
@@ -64,13 +65,19 @@ export const UsersTable = ({ filter }: UsersTableProps): ReactElement => {
     isLoading: isLoadingUsers,
     error: errorUsers,
   } = useQuery<PaginatedUserList>({
-    queryKey: ['businessAreasUsersList', filteredQueryVariables],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasUsersList,
+      filteredQueryVariables,
+    ),
     queryFn: () =>
       RestService.restBusinessAreasUsersList(filteredQueryVariables),
   });
 
   const { data: dataUsersCount } = useQuery<CountResponse>({
-    queryKey: ['businessAreasUsersCount', businessArea, filteredQueryVariables],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasUsersCountRetrieve,
+      filteredQueryVariables,
+    ),
     queryFn: () =>
       RestService.restBusinessAreasUsersCountRetrieve(filteredQueryVariables),
     enabled: page === 0,

--- a/src/frontend/src/containers/tables/paymentmodule/PaymentPlansTable/PaymentPlansFilters.tsx
+++ b/src/frontend/src/containers/tables/paymentmodule/PaymentPlansTable/PaymentPlansFilters.tsx
@@ -13,6 +13,7 @@ import { ReactElement } from 'react';
 import { PaymentPlan } from '@restgenerated/models/PaymentPlan';
 import { Choice } from '@restgenerated/models/Choice';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useQuery } from '@tanstack/react-query';
 
 export type FilterProps = Partial<PaymentPlan>;
@@ -72,7 +73,7 @@ export function PaymentPlansFilters({
     clearFilter();
   };
   const { data: statusChoicesData } = useQuery<Array<Choice>>({
-    queryKey: ['choicesPaymentVerificationPlanStatusList'],
+    queryKey: restQueryKey(RestService.restChoicesPaymentPlanStatusList),
     queryFn: () => RestService.restChoicesPaymentPlanStatusList(),
   });
 
@@ -82,7 +83,7 @@ export function PaymentPlansFilters({
     ) || [];
 
   const { data: planTypeChoicesData } = useQuery<Array<Choice>>({
-    queryKey: ['choicesPaymentPlanTypeList'],
+    queryKey: restQueryKey(RestService.restChoicesPaymentPlanTypeList),
     queryFn: () => RestService.restChoicesPaymentPlanTypeList(),
   });
 

--- a/src/frontend/src/containers/tables/paymentmodule/PaymentPlansTable/PaymentPlansTable.tsx
+++ b/src/frontend/src/containers/tables/paymentmodule/PaymentPlansTable/PaymentPlansTable.tsx
@@ -8,7 +8,7 @@ import { adjustHeadCells } from '@utils/utils';
 import withErrorBoundary from '@components/core/withErrorBoundary';
 import { createApiParams } from '@utils/apiUtils';
 import { UniversalRestTable } from '@components/rest/UniversalRestTable/UniversalRestTable';
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { RestService } from '@restgenerated/services/RestService';
 import { PaginatedPaymentPlanListList } from '@restgenerated/models/PaginatedPaymentPlanListList';
 import { PaymentPlanList } from '@restgenerated/models/PaymentPlanList';
@@ -83,6 +83,7 @@ function PaymentPlansTable({
         ),
       );
     },
+    placeholderData: keepPreviousData,
   });
 
   const { data: dataPaymentPlansCount } = useQuery<CountResponse>({

--- a/src/frontend/src/containers/tables/paymentmodule/PaymentPlansTable/PaymentPlansTable.tsx
+++ b/src/frontend/src/containers/tables/paymentmodule/PaymentPlansTable/PaymentPlansTable.tsx
@@ -66,6 +66,7 @@ function PaymentPlansTable({
   const {
     data: paymentPlansData,
     isLoading,
+    isFetching,
     error,
   } = useQuery<PaginatedPaymentPlanListList>({
     queryKey: [
@@ -121,7 +122,10 @@ function PaymentPlansTable({
     const rows = paymentPlansData?.results ?? [];
     rows.forEach((row, idx) => {
       const prev = rows[idx - 1];
-      if (idx === 0 || prev?.paymentPlanGroup?.id !== row.paymentPlanGroup?.id) {
+      if (
+        idx === 0 ||
+        prev?.paymentPlanGroup?.id !== row.paymentPlanGroup?.id
+      ) {
         ids.add(row.id);
       }
     });
@@ -135,6 +139,7 @@ function PaymentPlansTable({
       headCells={adjustedHeadCells as any}
       data={paymentPlansData}
       isLoading={isLoading}
+      isFetching={isFetching}
       error={error}
       queryVariables={queryVariables}
       setQueryVariables={setQueryVariables}

--- a/src/frontend/src/containers/tables/paymentmodule/PaymentPlansTable/PaymentPlansTable.tsx
+++ b/src/frontend/src/containers/tables/paymentmodule/PaymentPlansTable/PaymentPlansTable.tsx
@@ -9,6 +9,7 @@ import withErrorBoundary from '@components/core/withErrorBoundary';
 import { createApiParams } from '@utils/apiUtils';
 import { UniversalRestTable } from '@components/rest/UniversalRestTable/UniversalRestTable';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { RestService } from '@restgenerated/services/RestService';
 import { PaginatedPaymentPlanListList } from '@restgenerated/models/PaginatedPaymentPlanListList';
 import { PaymentPlanList } from '@restgenerated/models/PaymentPlanList';
@@ -63,43 +64,41 @@ function PaymentPlansTable({
 
   const [page, setPage] = useState(0);
 
+  const paymentPlansListParams = createApiParams(
+    { businessAreaSlug: businessArea, programCode: programId },
+    queryVariables,
+    { withPagination: true },
+  );
   const {
     data: paymentPlansData,
     isLoading,
     isFetching,
     error,
   } = useQuery<PaginatedPaymentPlanListList>({
-    queryKey: [
-      'businessAreasProgramsPaymentPlansList',
-      queryVariables,
-      businessArea,
-      programId,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsPaymentPlansList,
+      paymentPlansListParams,
+    ),
     queryFn: () => {
       return RestService.restBusinessAreasProgramsPaymentPlansList(
-        createApiParams(
-          { businessAreaSlug: businessArea, programCode: programId },
-          queryVariables,
-          { withPagination: true },
-        ),
+        paymentPlansListParams,
       );
     },
     placeholderData: keepPreviousData,
   });
 
+  const paymentPlansCountParams = createApiParams(
+    { businessAreaSlug: businessArea, programCode: programId },
+    queryVariables,
+  );
   const { data: dataPaymentPlansCount } = useQuery<CountResponse>({
-    queryKey: [
-      'businessAreasProgramsPaymentPlansCountRetrieve',
-      programId,
-      businessArea,
-      queryVariables,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsPaymentPlansCountRetrieve,
+      paymentPlansCountParams,
+    ),
     queryFn: () =>
       RestService.restBusinessAreasProgramsPaymentPlansCountRetrieve(
-        createApiParams(
-          { businessAreaSlug: businessArea, programCode: programId },
-          queryVariables,
-        ),
+        paymentPlansCountParams,
       ),
     enabled: !!businessArea && !!programId && page === 0,
   });

--- a/src/frontend/src/containers/tables/paymentmodule/PaymentsTable/PaymentsTable.tsx
+++ b/src/frontend/src/containers/tables/paymentmodule/PaymentsTable/PaymentsTable.tsx
@@ -93,6 +93,7 @@ const PaymentsTable = ({
   const {
     data: paymentsData,
     isLoading,
+    isFetching,
     error,
   } = useQuery<PaginatedPaymentListList>({
     queryKey: [
@@ -206,6 +207,7 @@ const PaymentsTable = ({
               defaultOrderBy="createdAt"
               defaultOrderDirection="desc"
               isLoading={isLoading}
+              isFetching={isFetching}
               error={error}
               queryVariables={queryVariables}
               setQueryVariables={setQueryVariables}

--- a/src/frontend/src/containers/tables/paymentmodule/PaymentsTable/PaymentsTable.tsx
+++ b/src/frontend/src/containers/tables/paymentmodule/PaymentsTable/PaymentsTable.tsx
@@ -8,6 +8,7 @@ import { PaginatedPaymentListList } from '@restgenerated/models/PaginatedPayment
 import { CountResponse } from '@restgenerated/models/CountResponse';
 import { PaymentPlanDetail } from '@restgenerated/models/PaymentPlanDetail';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { usePersistedCount } from '@hooks/usePersistedCount';
 import { adjustHeadCells, getFilterFromQueryParams } from '@utils/utils';
@@ -90,54 +91,50 @@ const PaymentsTable = ({
     setQueryVariables(initialQueryVariables);
   }, [initialQueryVariables]);
 
+  const paymentsListParams = createApiParams(
+    {
+      businessAreaSlug: businessArea,
+      programCode: programId,
+      paymentPlanPk: paymentPlan.id,
+    },
+    queryVariables,
+    { withPagination: true },
+  );
   const {
     data: paymentsData,
     isLoading,
     isFetching,
     error,
   } = useQuery<PaginatedPaymentListList>({
-    queryKey: [
-      'businessAreasProgramsPaymentPlansPaymentsList',
-      queryVariables,
-      businessArea,
-      programId,
-      paymentPlan.id,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsPaymentPlansPaymentsList,
+      paymentsListParams,
+    ),
     queryFn: () => {
       return RestService.restBusinessAreasProgramsPaymentPlansPaymentsList(
-        createApiParams(
-          {
-            businessAreaSlug: businessArea,
-            programCode: programId,
-            paymentPlanPk: paymentPlan.id,
-          },
-          queryVariables,
-          { withPagination: true },
-        ),
+        paymentsListParams,
       );
     },
     placeholderData: keepPreviousData,
   });
 
   // Payments count
+  const paymentsCountParams = createApiParams(
+    {
+      businessAreaSlug: businessArea,
+      programCode: programId,
+      paymentPlanPk: paymentPlan.id,
+    },
+    queryVariables,
+  );
   const { data: paymentsCount } = useQuery<CountResponse>({
-    queryKey: [
-      'businessAreasProgramsPaymentsCountRetrieve',
-      businessArea,
-      programId,
-      paymentPlan.id,
-      queryVariables,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsPaymentPlansPaymentsCountRetrieve,
+      paymentsCountParams,
+    ),
     queryFn: () =>
       RestService.restBusinessAreasProgramsPaymentPlansPaymentsCountRetrieve(
-        createApiParams(
-          {
-            businessAreaSlug: businessArea,
-            programCode: programId,
-            paymentPlanPk: paymentPlan.id,
-          },
-          queryVariables,
-        ),
+        paymentsCountParams,
       ),
     // fetch count only on the first page and persist it across pages
     enabled: !!businessArea && !!paymentPlan?.id && page === 0,

--- a/src/frontend/src/containers/tables/paymentmodule/PaymentsTable/PaymentsTable.tsx
+++ b/src/frontend/src/containers/tables/paymentmodule/PaymentsTable/PaymentsTable.tsx
@@ -8,7 +8,7 @@ import { PaginatedPaymentListList } from '@restgenerated/models/PaginatedPayment
 import { CountResponse } from '@restgenerated/models/CountResponse';
 import { PaymentPlanDetail } from '@restgenerated/models/PaymentPlanDetail';
 import { RestService } from '@restgenerated/services/RestService';
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { usePersistedCount } from '@hooks/usePersistedCount';
 import { adjustHeadCells, getFilterFromQueryParams } from '@utils/utils';
 import { ReactElement, useEffect, useMemo, useRef, useState } from 'react';
@@ -115,6 +115,7 @@ const PaymentsTable = ({
         ),
       );
     },
+    placeholderData: keepPreviousData,
   });
 
   // Payments count

--- a/src/frontend/src/containers/tables/payments/PaymentVerificationTable/PaymentVerificationFilters.tsx
+++ b/src/frontend/src/containers/tables/payments/PaymentVerificationTable/PaymentVerificationFilters.tsx
@@ -7,6 +7,7 @@ import MonetizationOnIcon from '@mui/icons-material/MonetizationOn';
 import { Grid, MenuItem } from '@mui/material';
 import { Choice } from '@restgenerated/models/Choice';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useQuery } from '@tanstack/react-query';
 import { createHandleApplyFilterChange } from '@utils/utils';
 import { ReactElement } from 'react';
@@ -47,12 +48,14 @@ const PaymentVerificationFilters = ({
   };
 
   const { data: statusChoicesData } = useQuery<Array<Choice>>({
-    queryKey: ['choicesPaymentVerificationSummaryStatusList'],
+    queryKey: restQueryKey(
+      RestService.restChoicesPaymentVerificationSummaryStatusList,
+    ),
     queryFn: () =>
       RestService.restChoicesPaymentVerificationSummaryStatusList(),
   });
   const { data: deliveryTypeChoicesData } = useQuery<Array<Choice>>({
-    queryKey: ['choicesPaymentRecordDeliveryTypeList'],
+    queryKey: restQueryKey(RestService.restChoicesPaymentRecordDeliveryTypeList),
     queryFn: () => RestService.restChoicesPaymentRecordDeliveryTypeList(),
   });
 

--- a/src/frontend/src/containers/tables/payments/PaymentVerificationTable/PaymentVerificationTable.tsx
+++ b/src/frontend/src/containers/tables/payments/PaymentVerificationTable/PaymentVerificationTable.tsx
@@ -4,7 +4,7 @@ import { useBaseUrl } from '@hooks/useBaseUrl';
 import { PaginatedPaymentVerificationPlanListList } from '@restgenerated/models/PaginatedPaymentVerificationPlanListList';
 import { RestService } from '@restgenerated/services/RestService';
 import { createApiParams } from '@utils/apiUtils';
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { ReactElement, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { headCells } from './PaymentVerificationHeadCells';
@@ -89,6 +89,7 @@ function PaymentVerificationTable({
         ),
       );
     },
+    placeholderData: keepPreviousData,
   });
 
   const itemsCount = usePersistedCount(page, countData);

--- a/src/frontend/src/containers/tables/payments/PaymentVerificationTable/PaymentVerificationTable.tsx
+++ b/src/frontend/src/containers/tables/payments/PaymentVerificationTable/PaymentVerificationTable.tsx
@@ -4,6 +4,7 @@ import { useBaseUrl } from '@hooks/useBaseUrl';
 import { PaginatedPaymentVerificationPlanListList } from '@restgenerated/models/PaginatedPaymentVerificationPlanListList';
 import { RestService } from '@restgenerated/services/RestService';
 import { createApiParams } from '@utils/apiUtils';
+import { restQueryKey } from '@utils/queryKeys';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { ReactElement, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -53,41 +54,39 @@ function PaymentVerificationTable({
   useEffect(() => {
     setQueryVariables(initialQueryVariables);
   }, [initialQueryVariables]);
+  const paymentVerificationsCountParams = createApiParams(
+    { businessAreaSlug: businessArea, programCode: programId },
+    queryVariables,
+  );
   const { data: countData } = useQuery<CountResponse>({
-    queryKey: [
-      'businessAreasProgramsHouseholdsCount',
-      programId,
-      businessArea,
-      queryVariables,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsPaymentVerificationsCountRetrieve,
+      paymentVerificationsCountParams,
+    ),
     queryFn: () =>
       RestService.restBusinessAreasProgramsPaymentVerificationsCountRetrieve(
-        createApiParams(
-          { businessAreaSlug: businessArea, programCode: programId },
-          queryVariables,
-        ),
+        paymentVerificationsCountParams,
       ),
     enabled: !!businessArea && !!programId && page === 0,
   });
+  const paymentVerificationsListParams = createApiParams(
+    { businessAreaSlug: businessArea, programCode: programId },
+    queryVariables,
+    { withPagination: true },
+  );
   const {
     data: paymentPlansData,
     isLoading,
     isFetching,
     error,
   } = useQuery<PaginatedPaymentVerificationPlanListList>({
-    queryKey: [
-      'businessAreasProgramsPaymentPlansList',
-      queryVariables,
-      businessArea,
-      programId,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsPaymentVerificationsList,
+      paymentVerificationsListParams,
+    ),
     queryFn: () => {
       return RestService.restBusinessAreasProgramsPaymentVerificationsList(
-        createApiParams(
-          { businessAreaSlug: businessArea, programCode: programId },
-          queryVariables,
-          { withPagination: true },
-        ),
+        paymentVerificationsListParams,
       );
     },
     placeholderData: keepPreviousData,

--- a/src/frontend/src/containers/tables/payments/PaymentVerificationTable/PaymentVerificationTable.tsx
+++ b/src/frontend/src/containers/tables/payments/PaymentVerificationTable/PaymentVerificationTable.tsx
@@ -72,6 +72,7 @@ function PaymentVerificationTable({
   const {
     data: paymentPlansData,
     isLoading,
+    isFetching,
     error,
   } = useQuery<PaginatedPaymentVerificationPlanListList>({
     queryKey: [
@@ -100,6 +101,7 @@ function PaymentVerificationTable({
       headCells={headCells}
       data={paymentPlansData}
       isLoading={isLoading}
+      isFetching={isFetching}
       error={error}
       queryVariables={queryVariables}
       setQueryVariables={setQueryVariables}

--- a/src/frontend/src/containers/tables/payments/PaymentsHouseholdTable/PaymentsHouseholdTable.tsx
+++ b/src/frontend/src/containers/tables/payments/PaymentsHouseholdTable/PaymentsHouseholdTable.tsx
@@ -41,6 +41,7 @@ function PaymentsHouseholdTable({
   const {
     data: paymentsData,
     isLoading,
+    isFetching,
     error,
   } = useQuery<PaginatedPaymentListList>({
     queryKey: [
@@ -111,6 +112,7 @@ function PaymentsHouseholdTable({
       data={paymentsData}
       error={error}
       isLoading={isLoading}
+      isFetching={isFetching}
       queryVariables={queryVariables}
       setQueryVariables={setQueryVariables}
       page={page}

--- a/src/frontend/src/containers/tables/payments/PaymentsHouseholdTable/PaymentsHouseholdTable.tsx
+++ b/src/frontend/src/containers/tables/payments/PaymentsHouseholdTable/PaymentsHouseholdTable.tsx
@@ -6,6 +6,7 @@ import { PaginatedPaymentListList } from '@restgenerated/models/PaginatedPayment
 import { PaymentList } from '@restgenerated/models/PaymentList';
 import { CountResponse } from '@restgenerated/models/CountResponse';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { createApiParams } from '@utils/apiUtils';
 import { adjustHeadCells } from '@utils/utils';
@@ -38,53 +39,49 @@ function PaymentsHouseholdTable({
   const [queryVariables, setQueryVariables] = useState(initialQueryVariables);
   const [page, setPage] = useState(0);
 
+  const paymentsListParams = createApiParams(
+    {
+      businessAreaSlug: businessArea,
+      programCode: programId,
+      id: household?.id,
+    },
+    queryVariables,
+    { withPagination: true },
+  );
   const {
     data: paymentsData,
     isLoading,
     isFetching,
     error,
   } = useQuery<PaginatedPaymentListList>({
-    queryKey: [
-      'businessAreasProgramsHouseholdsPaymentsList',
-      queryVariables,
-      household?.id,
-      businessArea,
-      programId,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsHouseholdsPaymentsList,
+      paymentsListParams,
+    ),
     queryFn: () => {
       return RestService.restBusinessAreasProgramsHouseholdsPaymentsList(
-        createApiParams(
-          {
-            businessAreaSlug: businessArea,
-            programCode: programId,
-            id: household?.id,
-          },
-          queryVariables,
-          { withPagination: true },
-        ),
+        paymentsListParams,
       );
     },
     placeholderData: keepPreviousData,
   });
 
+  const paymentsCountParams = createApiParams(
+    {
+      businessAreaSlug: businessArea,
+      programCode: programId,
+      id: household?.id,
+    },
+    queryVariables,
+  );
   const { data: countData } = useQuery<CountResponse>({
-    queryKey: [
-      'businessAreasProgramsHouseholdsPaymentsCount',
-      programId,
-      businessArea,
-      queryVariables,
-      household?.id,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsHouseholdsPaymentsCountRetrieve,
+      paymentsCountParams,
+    ),
     queryFn: () =>
       RestService.restBusinessAreasProgramsHouseholdsPaymentsCountRetrieve(
-        createApiParams(
-          {
-            businessAreaSlug: businessArea,
-            programCode: programId,
-            id: household?.id,
-          },
-          queryVariables,
-        ),
+        paymentsCountParams,
       ),
     enabled: page === 0,
   });

--- a/src/frontend/src/containers/tables/payments/PaymentsHouseholdTable/PaymentsHouseholdTable.tsx
+++ b/src/frontend/src/containers/tables/payments/PaymentsHouseholdTable/PaymentsHouseholdTable.tsx
@@ -6,7 +6,7 @@ import { PaginatedPaymentListList } from '@restgenerated/models/PaginatedPayment
 import { PaymentList } from '@restgenerated/models/PaymentList';
 import { CountResponse } from '@restgenerated/models/CountResponse';
 import { RestService } from '@restgenerated/services/RestService';
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { createApiParams } from '@utils/apiUtils';
 import { adjustHeadCells } from '@utils/utils';
 import { ReactElement, useState } from 'react';
@@ -63,6 +63,7 @@ function PaymentsHouseholdTable({
         ),
       );
     },
+    placeholderData: keepPreviousData,
   });
 
   const { data: countData } = useQuery<CountResponse>({

--- a/src/frontend/src/containers/tables/payments/VerificationRecordsTable/VerificationRecordsFilters.tsx
+++ b/src/frontend/src/containers/tables/payments/VerificationRecordsTable/VerificationRecordsFilters.tsx
@@ -7,6 +7,7 @@ import { SelectFilter } from '@components/core/SelectFilter';
 import { createHandleApplyFilterChange } from '@utils/utils';
 import { ReactElement } from 'react';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useQuery } from '@tanstack/react-query';
 import { Choice } from '@restgenerated/models/Choice';
 
@@ -48,7 +49,7 @@ export function VerificationRecordsFilters({
     clearFilter();
   };
   const { data: verificationStatusChoices } = useQuery<Array<Choice>>({
-    queryKey: ['verificationStatusChoices'],
+    queryKey: restQueryKey(RestService.restChoicesPaymentVerificationStatusList),
     queryFn: () => RestService.restChoicesPaymentVerificationStatusList(),
   });
 

--- a/src/frontend/src/containers/tables/payments/VerificationRecordsTable/VerificationsTable.tsx
+++ b/src/frontend/src/containers/tables/payments/VerificationRecordsTable/VerificationsTable.tsx
@@ -72,6 +72,7 @@ export function VerificationsTable({
   const {
     data: paymentsData,
     isLoading,
+    isFetching,
     error,
   } = useQuery<PaginatedPaymentListList>({
     queryKey: [
@@ -122,6 +123,7 @@ export function VerificationsTable({
       title={t('Verification Records')}
       headCells={adjustedHeadCells}
       isLoading={isLoading}
+      isFetching={isFetching}
       error={error}
       queryVariables={queryVariables}
       setQueryVariables={setQueryVariables}

--- a/src/frontend/src/containers/tables/payments/VerificationRecordsTable/VerificationsTable.tsx
+++ b/src/frontend/src/containers/tables/payments/VerificationRecordsTable/VerificationsTable.tsx
@@ -4,6 +4,7 @@ import { createApiParams } from '@utils/apiUtils';
 import { PaginatedPaymentListList } from '@restgenerated/models/PaginatedPaymentListList';
 import { PaymentList } from '@restgenerated/models/PaymentList';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { adjustHeadCells } from '@utils/utils';
 import { ReactElement, useEffect, useMemo, useState } from 'react';
@@ -44,22 +45,20 @@ export function VerificationsTable({
   const [page, setPage] = useState(0);
 
   // Add count query for verification records, only enabled on first page
+  const verificationsCountParams = {
+    businessAreaSlug: businessArea,
+    programCode: programId,
+    paymentVerificationPk: paymentPlanId,
+    ...queryVariables,
+  };
   const { data: verificationCountData } = useQuery({
-    queryKey: [
-      'businessAreasProgramsPaymentVerificationsVerificationsCount',
-      queryVariables,
-      businessArea,
-      programId,
-      paymentPlanId,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsPaymentVerificationsVerificationsCountRetrieve,
+      verificationsCountParams,
+    ),
     queryFn: () =>
       RestService.restBusinessAreasProgramsPaymentVerificationsVerificationsCountRetrieve(
-        {
-          businessAreaSlug: businessArea,
-          programCode: programId,
-          paymentVerificationPk: paymentPlanId,
-          ...queryVariables,
-        },
+        verificationsCountParams,
       ),
     enabled: page === 0,
   });
@@ -69,30 +68,28 @@ export function VerificationsTable({
     setQueryVariables(initialQueryVariables);
   }, [initialQueryVariables]);
 
+  const verificationsListParams = createApiParams(
+    {
+      businessAreaSlug: businessArea,
+      programCode: programId,
+      paymentVerificationPk: paymentPlanId,
+    },
+    queryVariables,
+    { withPagination: true },
+  );
   const {
     data: paymentsData,
     isLoading,
     isFetching,
     error,
   } = useQuery<PaginatedPaymentListList>({
-    queryKey: [
-      'businessAreasProgramsPaymentVerificationsVerificationsList',
-      queryVariables,
-      businessArea,
-      programId,
-      paymentPlanId,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsPaymentVerificationsVerificationsList,
+      verificationsListParams,
+    ),
     queryFn: () => {
       return RestService.restBusinessAreasProgramsPaymentVerificationsVerificationsList(
-        createApiParams(
-          {
-            businessAreaSlug: businessArea,
-            programCode: programId,
-            paymentVerificationPk: paymentPlanId,
-          },
-          queryVariables,
-          { withPagination: true },
-        ),
+        verificationsListParams,
       );
     },
     placeholderData: keepPreviousData,

--- a/src/frontend/src/containers/tables/payments/VerificationRecordsTable/VerificationsTable.tsx
+++ b/src/frontend/src/containers/tables/payments/VerificationRecordsTable/VerificationsTable.tsx
@@ -4,7 +4,7 @@ import { createApiParams } from '@utils/apiUtils';
 import { PaginatedPaymentListList } from '@restgenerated/models/PaginatedPaymentListList';
 import { PaymentList } from '@restgenerated/models/PaymentList';
 import { RestService } from '@restgenerated/services/RestService';
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { adjustHeadCells } from '@utils/utils';
 import { ReactElement, useEffect, useMemo, useState } from 'react';
 import { usePersistedCount } from '@hooks/usePersistedCount';
@@ -94,6 +94,7 @@ export function VerificationsTable({
         ),
       );
     },
+    placeholderData: keepPreviousData,
   });
 
   const { selectedProgram } = useProgramContext();

--- a/src/frontend/src/containers/tables/people/PeopleListTable/PeopleListTable.tsx
+++ b/src/frontend/src/containers/tables/people/PeopleListTable/PeopleListTable.tsx
@@ -5,7 +5,7 @@ import { useBaseUrl } from '@hooks/useBaseUrl';
 import { IndividualList } from '@restgenerated/models/IndividualList';
 import { RestService } from '@restgenerated/services/RestService';
 import { PaginatedIndividualListList } from '@restgenerated/models/PaginatedIndividualListList';
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { createApiParams } from '@utils/apiUtils';
 import { headCells } from './PeopleListTableHeadCells';
 import { PeopleListTableRow } from './PeopleListTableRow';
@@ -111,6 +111,7 @@ export const PeopleListTable = ({
           { withPagination: true },
         ),
       ),
+    placeholderData: keepPreviousData,
   });
 
   return (

--- a/src/frontend/src/containers/tables/people/PeopleListTable/PeopleListTable.tsx
+++ b/src/frontend/src/containers/tables/people/PeopleListTable/PeopleListTable.tsx
@@ -4,6 +4,7 @@ import { UniversalRestTable } from '@components/rest/UniversalRestTable/Universa
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { IndividualList } from '@restgenerated/models/IndividualList';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { PaginatedIndividualListList } from '@restgenerated/models/PaginatedIndividualListList';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { createApiParams } from '@utils/apiUtils';
@@ -76,41 +77,39 @@ export const PeopleListTable = ({
     setQueryVariables(initialQueryVariables);
   }, [initialQueryVariables]);
 
+  const individualsCountParams = createApiParams(
+    { businessAreaSlug: businessArea, programCode: programId },
+    queryVariables,
+    { withPagination: true },
+  );
   const { data: countData } = useQuery<CountResponse>({
-    queryKey: [
-      'businessAreasProgramsHouseholdsCount',
-      programId,
-      businessArea,
-      queryVariables,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsIndividualsCountRetrieve,
+      individualsCountParams,
+    ),
     queryFn: () =>
       RestService.restBusinessAreasProgramsIndividualsCountRetrieve(
-        createApiParams(
-          { businessAreaSlug: businessArea, programCode: programId },
-          queryVariables,
-          { withPagination: true },
-        ),
+        individualsCountParams,
       ),
     enabled: page === 0,
   });
 
   const itemsCount = usePersistedCount(page, countData);
 
+  const individualsListParams = createApiParams(
+    { businessAreaSlug: businessArea, programCode: programId },
+    queryVariables,
+    { withPagination: true },
+  );
   const { data, isLoading, isFetching, error } =
     useQuery<PaginatedIndividualListList>({
-      queryKey: [
-        'businessAreasProgramsIndividualsList',
-        queryVariables,
-        businessArea,
-        programId,
-      ],
+      queryKey: restQueryKey(
+        RestService.restBusinessAreasProgramsIndividualsList,
+        individualsListParams,
+      ),
       queryFn: () =>
         RestService.restBusinessAreasProgramsIndividualsList(
-          createApiParams(
-            { businessAreaSlug: businessArea, programCode: programId },
-            queryVariables,
-            { withPagination: true },
-          ),
+          individualsListParams,
         ),
       placeholderData: keepPreviousData,
     });

--- a/src/frontend/src/containers/tables/people/PeopleListTable/PeopleListTable.tsx
+++ b/src/frontend/src/containers/tables/people/PeopleListTable/PeopleListTable.tsx
@@ -96,23 +96,24 @@ export const PeopleListTable = ({
 
   const itemsCount = usePersistedCount(page, countData);
 
-  const { data, isLoading, error } = useQuery<PaginatedIndividualListList>({
-    queryKey: [
-      'businessAreasProgramsIndividualsList',
-      queryVariables,
-      businessArea,
-      programId,
-    ],
-    queryFn: () =>
-      RestService.restBusinessAreasProgramsIndividualsList(
-        createApiParams(
-          { businessAreaSlug: businessArea, programCode: programId },
-          queryVariables,
-          { withPagination: true },
+  const { data, isLoading, isFetching, error } =
+    useQuery<PaginatedIndividualListList>({
+      queryKey: [
+        'businessAreasProgramsIndividualsList',
+        queryVariables,
+        businessArea,
+        programId,
+      ],
+      queryFn: () =>
+        RestService.restBusinessAreasProgramsIndividualsList(
+          createApiParams(
+            { businessAreaSlug: businessArea, programCode: programId },
+            queryVariables,
+            { withPagination: true },
+          ),
         ),
-      ),
-    placeholderData: keepPreviousData,
-  });
+      placeholderData: keepPreviousData,
+    });
 
   return (
     <TableWrapper>
@@ -125,6 +126,7 @@ export const PeopleListTable = ({
         data={data}
         error={error}
         isLoading={isLoading}
+        isFetching={isFetching}
         allowSort={false}
         filterOrderBy={filter.orderBy}
         itemsCount={itemsCount}

--- a/src/frontend/src/containers/tables/population/CollectorsTable/CollectorsTable.tsx
+++ b/src/frontend/src/containers/tables/population/CollectorsTable/CollectorsTable.tsx
@@ -11,6 +11,7 @@ import { IndividualChoices } from '@restgenerated/models/IndividualChoices';
 import { IndividualSimple } from '@restgenerated/models/IndividualSimple';
 import { PaginatedHouseholdMemberList } from '@restgenerated/models/PaginatedHouseholdMemberList';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useQuery } from '@tanstack/react-query';
 import { adjustHeadCells, choicesToDict } from '@utils/utils';
 import { ReactElement, ReactNode, useState } from 'react';
@@ -75,19 +76,18 @@ export const CollectorsTable = ({
     choicesData?.relationshipChoices,
   );
 
+  const membersParams = {
+    businessAreaSlug: businessArea,
+    programCode: programId,
+    id: household.id,
+  };
   const { data, isLoading, error } = useQuery<PaginatedHouseholdMemberList>({
-    queryKey: [
-      'businessAreasProgramsHouseholdsMembers',
-      programId,
-      businessArea,
-      household.id,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsHouseholdsMembersList,
+      membersParams,
+    ),
     queryFn: () =>
-      RestService.restBusinessAreasProgramsHouseholdsMembersList({
-        businessAreaSlug: businessArea,
-        programCode: programId,
-        id: household.id,
-      }),
+      RestService.restBusinessAreasProgramsHouseholdsMembersList(membersParams),
     enabled: !!businessArea && !!programId && !!household?.id,
   });
 

--- a/src/frontend/src/containers/tables/population/HouseholdMembersTable/HouseholdMembersTable.tsx
+++ b/src/frontend/src/containers/tables/population/HouseholdMembersTable/HouseholdMembersTable.tsx
@@ -13,6 +13,7 @@ import { IndividualChoices } from '@restgenerated/models/IndividualChoices';
 import { IndividualList } from '@restgenerated/models/IndividualList';
 import { PaginatedHouseholdMemberList } from '@restgenerated/models/PaginatedHouseholdMemberList';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useQuery } from '@tanstack/react-query';
 import {
   adjustHeadCells,
@@ -112,19 +113,18 @@ export const HouseholdMembersTable = ({
     setQueryVariables(initialQueryVariables);
   }, [initialQueryVariables]);
 
+  const membersParams = {
+    businessAreaSlug: businessArea,
+    programCode: programId,
+    id: household.id,
+  };
   const { data, isLoading, error } = useQuery<PaginatedHouseholdMemberList>({
-    queryKey: [
-      'businessAreasProgramsHouseholdsMembers',
-      programId,
-      businessArea,
-      household.id,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsHouseholdsMembersList,
+      membersParams,
+    ),
     queryFn: () =>
-      RestService.restBusinessAreasProgramsHouseholdsMembersList({
-        businessAreaSlug: businessArea,
-        programCode: programId,
-        id: household.id,
-      }),
+      RestService.restBusinessAreasProgramsHouseholdsMembersList(membersParams),
     enabled: !!businessArea && !!programId,
   });
 

--- a/src/frontend/src/containers/tables/population/HouseholdTable/HouseholdTable.tsx
+++ b/src/frontend/src/containers/tables/population/HouseholdTable/HouseholdTable.tsx
@@ -12,7 +12,7 @@ import { createApiParams } from '@utils/apiUtils';
 import { TableCell } from '@mui/material';
 import { Box } from '@mui/system';
 import { RestService } from '@restgenerated/services/RestService';
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import {
   adjustHeadCells,
   formatCurrencyWithSymbol,
@@ -126,6 +126,7 @@ export const HouseholdTable = ({
           { withPagination: true },
         ),
       ),
+    placeholderData: keepPreviousData,
   });
 
   const { data: countData } = useQuery<CountResponse>({

--- a/src/frontend/src/containers/tables/population/HouseholdTable/HouseholdTable.tsx
+++ b/src/frontend/src/containers/tables/population/HouseholdTable/HouseholdTable.tsx
@@ -111,23 +111,24 @@ export const HouseholdTable = ({
     setQueryVariables(initialQueryVariables);
   }, [initialQueryVariables]);
 
-  const { data, isLoading, error } = useQuery<PaginatedHouseholdListList>({
-    queryKey: [
-      'businessAreasProgramsHouseholdsList',
-      queryVariables,
-      programId,
-      businessArea,
-    ],
-    queryFn: () =>
-      RestService.restBusinessAreasProgramsHouseholdsList(
-        createApiParams(
-          { businessAreaSlug: businessArea, programCode: programId },
-          queryVariables,
-          { withPagination: true },
+  const { data, isLoading, isFetching, error } =
+    useQuery<PaginatedHouseholdListList>({
+      queryKey: [
+        'businessAreasProgramsHouseholdsList',
+        queryVariables,
+        programId,
+        businessArea,
+      ],
+      queryFn: () =>
+        RestService.restBusinessAreasProgramsHouseholdsList(
+          createApiParams(
+            { businessAreaSlug: businessArea, programCode: programId },
+            queryVariables,
+            { withPagination: true },
+          ),
         ),
-      ),
-    placeholderData: keepPreviousData,
-  });
+      placeholderData: keepPreviousData,
+    });
 
   const { data: countData } = useQuery<CountResponse>({
     queryKey: [
@@ -255,6 +256,7 @@ export const HouseholdTable = ({
         data={data}
         error={error}
         isLoading={isLoading}
+        isFetching={isFetching}
         queryVariables={queryVariables}
         setQueryVariables={setQueryVariables}
         itemsCount={itemsCount}

--- a/src/frontend/src/containers/tables/population/HouseholdTable/HouseholdTable.tsx
+++ b/src/frontend/src/containers/tables/population/HouseholdTable/HouseholdTable.tsx
@@ -12,6 +12,7 @@ import { createApiParams } from '@utils/apiUtils';
 import { TableCell } from '@mui/material';
 import { Box } from '@mui/system';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import {
   adjustHeadCells,
@@ -111,38 +112,36 @@ export const HouseholdTable = ({
     setQueryVariables(initialQueryVariables);
   }, [initialQueryVariables]);
 
+  const householdsListParams = createApiParams(
+    { businessAreaSlug: businessArea, programCode: programId },
+    queryVariables,
+    { withPagination: true },
+  );
   const { data, isLoading, isFetching, error } =
     useQuery<PaginatedHouseholdListList>({
-      queryKey: [
-        'businessAreasProgramsHouseholdsList',
-        queryVariables,
-        programId,
-        businessArea,
-      ],
+      queryKey: restQueryKey(
+        RestService.restBusinessAreasProgramsHouseholdsList,
+        householdsListParams,
+      ),
       queryFn: () =>
         RestService.restBusinessAreasProgramsHouseholdsList(
-          createApiParams(
-            { businessAreaSlug: businessArea, programCode: programId },
-            queryVariables,
-            { withPagination: true },
-          ),
+          householdsListParams,
         ),
       placeholderData: keepPreviousData,
     });
 
+  const householdsCountParams = createApiParams(
+    { businessAreaSlug: businessArea, programCode: programId },
+    queryVariables,
+  );
   const { data: countData } = useQuery<CountResponse>({
-    queryKey: [
-      'businessAreasProgramsHouseholdsCount',
-      programId,
-      businessArea,
-      queryVariables,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsHouseholdsCountRetrieve,
+      householdsCountParams,
+    ),
     queryFn: () =>
       RestService.restBusinessAreasProgramsHouseholdsCountRetrieve(
-        createApiParams(
-          { businessAreaSlug: businessArea, programCode: programId },
-          queryVariables,
-        ),
+        householdsCountParams,
       ),
     enabled: page === 0,
   });

--- a/src/frontend/src/containers/tables/population/IndividualsListTable/IndividualsListTable.tsx
+++ b/src/frontend/src/containers/tables/population/IndividualsListTable/IndividualsListTable.tsx
@@ -113,23 +113,24 @@ export function IndividualsListTable({
     setQueryVariables(initialQueryVariables);
   }, [initialQueryVariables]);
 
-  const { data, isLoading, error } = useQuery<PaginatedIndividualListList>({
-    queryKey: [
-      'businessAreasProgramsIndividualsList',
-      queryVariables,
-      businessArea,
-      programId,
-    ],
-    queryFn: () =>
-      RestService.restBusinessAreasProgramsIndividualsList(
-        createApiParams(
-          { businessAreaSlug: businessArea, programCode: programId },
-          queryVariables,
-          { withPagination: true },
+  const { data, isLoading, isFetching, error } =
+    useQuery<PaginatedIndividualListList>({
+      queryKey: [
+        'businessAreasProgramsIndividualsList',
+        queryVariables,
+        businessArea,
+        programId,
+      ],
+      queryFn: () =>
+        RestService.restBusinessAreasProgramsIndividualsList(
+          createApiParams(
+            { businessAreaSlug: businessArea, programCode: programId },
+            queryVariables,
+            { withPagination: true },
+          ),
         ),
-      ),
-    placeholderData: keepPreviousData,
-  });
+      placeholderData: keepPreviousData,
+    });
 
   const { data: countData } = useQuery<CountResponse>({
     // Count should depend only on filters (not pagination). Keep fetching only on page 0.
@@ -187,6 +188,7 @@ export function IndividualsListTable({
         data={data}
         error={error}
         isLoading={isLoading}
+        isFetching={isFetching}
         allowSort={false}
         filterOrderBy={filter.orderBy}
         itemsCount={itemsCount}

--- a/src/frontend/src/containers/tables/population/IndividualsListTable/IndividualsListTable.tsx
+++ b/src/frontend/src/containers/tables/population/IndividualsListTable/IndividualsListTable.tsx
@@ -3,6 +3,7 @@ import { UniversalRestTable } from '@components/rest/UniversalRestTable/Universa
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { IndividualList } from '@restgenerated/models/IndividualList';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { createApiParams } from '@utils/apiUtils';
 import { adjustHeadCells } from '@utils/utils';
@@ -113,64 +114,51 @@ export function IndividualsListTable({
     setQueryVariables(initialQueryVariables);
   }, [initialQueryVariables]);
 
+  const individualsListParams = createApiParams(
+    { businessAreaSlug: businessArea, programCode: programId },
+    queryVariables,
+    { withPagination: true },
+  );
   const { data, isLoading, isFetching, error } =
     useQuery<PaginatedIndividualListList>({
-      queryKey: [
-        'businessAreasProgramsIndividualsList',
-        queryVariables,
-        businessArea,
-        programId,
-      ],
+      queryKey: restQueryKey(
+        RestService.restBusinessAreasProgramsIndividualsList,
+        individualsListParams,
+      ),
       queryFn: () =>
         RestService.restBusinessAreasProgramsIndividualsList(
-          createApiParams(
-            { businessAreaSlug: businessArea, programCode: programId },
-            queryVariables,
-            { withPagination: true },
-          ),
+          individualsListParams,
         ),
       placeholderData: keepPreviousData,
     });
 
+  // Count should depend only on filters (not pagination). Keep fetching only on page 0.
+  const individualsCountParams = createApiParams(
+    { businessAreaSlug: businessArea, programCode: programId },
+    {
+      ageMax: filter.ageMax,
+      ageMin: filter.ageMin,
+      sex: [filter.sex],
+      search: filter.search?.trim(),
+      documentType: filter.documentType,
+      documentNumber: filter.documentNumber?.trim(),
+      admin2: filter.admin2,
+      flags: filter.flags,
+      status: filter.status,
+      lastRegistrationDateBefore: filter.lastRegistrationDateMin,
+      lastRegistrationDateAfter: filter.lastRegistrationDateMax,
+      rdiMergeStatus: 'MERGED',
+      orderBy: filter.orderBy,
+    },
+  );
   const { data: countData } = useQuery<CountResponse>({
-    // Count should depend only on filters (not pagination). Keep fetching only on page 0.
-    queryKey: [
-      'businessAreasProgramsIndividualsCountRetrieve',
-      businessArea,
-      programId,
-      filter.search,
-      filter.sex,
-      filter.documentType,
-      filter.documentNumber,
-      filter.admin2,
-      filter.flags,
-      filter.status,
-      filter.lastRegistrationDateMin,
-      filter.lastRegistrationDateMax,
-      filter.ageMin,
-      filter.ageMax,
-      filter.orderBy,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsIndividualsCountRetrieve,
+      individualsCountParams,
+    ),
     queryFn: () =>
       RestService.restBusinessAreasProgramsIndividualsCountRetrieve(
-        createApiParams(
-          { businessAreaSlug: businessArea, programCode: programId },
-          {
-            ageMax: filter.ageMax,
-            ageMin: filter.ageMin,
-            sex: [filter.sex],
-            search: filter.search?.trim(),
-            documentType: filter.documentType,
-            documentNumber: filter.documentNumber?.trim(),
-            admin2: filter.admin2,
-            flags: filter.flags,
-            status: filter.status,
-            lastRegistrationDateBefore: filter.lastRegistrationDateMin,
-            lastRegistrationDateAfter: filter.lastRegistrationDateMax,
-            rdiMergeStatus: 'MERGED',
-            orderBy: filter.orderBy,
-          },
-        ),
+        individualsCountParams,
       ),
     enabled: page === 0,
   });

--- a/src/frontend/src/containers/tables/population/IndividualsListTable/IndividualsListTable.tsx
+++ b/src/frontend/src/containers/tables/population/IndividualsListTable/IndividualsListTable.tsx
@@ -3,7 +3,7 @@ import { UniversalRestTable } from '@components/rest/UniversalRestTable/Universa
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { IndividualList } from '@restgenerated/models/IndividualList';
 import { RestService } from '@restgenerated/services/RestService';
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { createApiParams } from '@utils/apiUtils';
 import { adjustHeadCells } from '@utils/utils';
 import { ReactElement, useEffect, useMemo, useState } from 'react';
@@ -128,6 +128,7 @@ export function IndividualsListTable({
           { withPagination: true },
         ),
       ),
+    placeholderData: keepPreviousData,
   });
 
   const { data: countData } = useQuery<CountResponse>({

--- a/src/frontend/src/containers/tables/rdi/ImportedHouseholdsTable/ImportedHouseholdTable.tsx
+++ b/src/frontend/src/containers/tables/rdi/ImportedHouseholdsTable/ImportedHouseholdTable.tsx
@@ -1,5 +1,6 @@
 import withErrorBoundary from '@components/core/withErrorBoundary';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { adjustHeadCells } from '@utils/utils';
 import { ReactElement, useEffect, useMemo, useState } from 'react';
 import { useProgramContext } from 'src/programContext';
@@ -40,19 +41,18 @@ function ImportedHouseholdTable({ rdi, businessArea, isMerged }): ReactElement {
     setQueryVariables(initialQueryVariables);
   }, [initialQueryVariables]);
 
+  const householdsCountParams = createApiParams(
+    { businessAreaSlug: businessArea, programCode: programId },
+    queryVariables,
+  );
   const { data: countData } = useQuery<CountResponse>({
-    queryKey: [
-      'businessAreasProgramsHouseholdsCount',
-      programId,
-      businessArea,
-      queryVariables,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsHouseholdsCountRetrieve,
+      householdsCountParams,
+    ),
     queryFn: () =>
       RestService.restBusinessAreasProgramsHouseholdsCountRetrieve(
-        createApiParams(
-          { businessAreaSlug: businessArea, programCode: programId },
-          queryVariables,
-        ),
+        householdsCountParams,
       ),
     enabled: page === 0 && !notAllowedRdiShowPreviewStatuses.includes(rdi.status),
   });

--- a/src/frontend/src/containers/tables/rdi/ImportedIndividualsTable/ImportedIndividualsTable.tsx
+++ b/src/frontend/src/containers/tables/rdi/ImportedIndividualsTable/ImportedIndividualsTable.tsx
@@ -5,6 +5,7 @@ import Checkbox from '@mui/material/Checkbox';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import Grid from '@mui/material/Grid';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { adjustHeadCells } from '@utils/utils';
 import { ReactElement, useEffect, useMemo, useState } from 'react';
 import { useProgramContext } from 'src/programContext';
@@ -85,19 +86,18 @@ function ImportedIndividualsTable({
     replacements,
   );
 
+  const individualsCountParams = createApiParams(
+    { businessAreaSlug: businessArea, programCode: programId },
+    queryVariables,
+  );
   const { data: countData } = useQuery<CountResponse>({
-    queryKey: [
-      'businessAreasProgramsHouseholdsCount',
-      programId,
-      businessArea,
-      queryVariables,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsIndividualsCountRetrieve,
+      individualsCountParams,
+    ),
     queryFn: () =>
       RestService.restBusinessAreasProgramsIndividualsCountRetrieve(
-        createApiParams(
-          { businessAreaSlug: businessArea, programCode: programId },
-          queryVariables,
-        ),
+        individualsCountParams,
       ),
     enabled: page === 0 && !notAllowedRdiShowPreviewStatuses.includes(rdi.status),
   });

--- a/src/frontend/src/containers/tables/rdi/ImportedPeopleTable/ImportedPeopleTable.tsx
+++ b/src/frontend/src/containers/tables/rdi/ImportedPeopleTable/ImportedPeopleTable.tsx
@@ -60,23 +60,24 @@ export function ImportedPeopleTable({
     setQueryVariables(initialQueryVariables);
   }, [initialQueryVariables]);
 
-  const { data, isLoading, error } = useQuery<PaginatedIndividualListList>({
-    queryKey: [
-      'businessAreasProgramsIndividualsList',
-      queryVariables,
-      businessArea,
-      programId,
-    ],
-    queryFn: () =>
-      RestService.restBusinessAreasProgramsIndividualsList(
-        createApiParams(
-          { businessAreaSlug: businessArea, programCode: programId },
-          queryVariables,
-          { withPagination: true },
+  const { data, isLoading, isFetching, error } =
+    useQuery<PaginatedIndividualListList>({
+      queryKey: [
+        'businessAreasProgramsIndividualsList',
+        queryVariables,
+        businessArea,
+        programId,
+      ],
+      queryFn: () =>
+        RestService.restBusinessAreasProgramsIndividualsList(
+          createApiParams(
+            { businessAreaSlug: businessArea, programCode: programId },
+            queryVariables,
+            { withPagination: true },
+          ),
         ),
-      ),
-    placeholderData: keepPreviousData,
-  });
+      placeholderData: keepPreviousData,
+    });
 
   const { data: countData } = useQuery({
     queryKey: [
@@ -136,6 +137,7 @@ export function ImportedPeopleTable({
           data={data}
           error={error}
           isLoading={isLoading}
+          isFetching={isFetching}
           rowsPerPageOptions={rowsPerPageOptions}
           isOnPaper={isOnPaper}
           itemsCount={itemsCount}
@@ -161,6 +163,7 @@ export function ImportedPeopleTable({
           data={data}
           error={error}
           isLoading={isLoading}
+          isFetching={isFetching}
           itemsCount={itemsCount}
           page={page}
           setPage={setPage}

--- a/src/frontend/src/containers/tables/rdi/ImportedPeopleTable/ImportedPeopleTable.tsx
+++ b/src/frontend/src/containers/tables/rdi/ImportedPeopleTable/ImportedPeopleTable.tsx
@@ -4,6 +4,7 @@ import { Box, Checkbox, FormControlLabel, Grid } from '@mui/material';
 import { IndividualList } from '@restgenerated/models/IndividualList';
 import { PaginatedIndividualListList } from '@restgenerated/models/PaginatedIndividualListList';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { createApiParams } from '@utils/apiUtils';
 import { ReactElement, useEffect, useMemo, useState } from 'react';
@@ -60,38 +61,36 @@ export function ImportedPeopleTable({
     setQueryVariables(initialQueryVariables);
   }, [initialQueryVariables]);
 
+  const individualsListParams = createApiParams(
+    { businessAreaSlug: businessArea, programCode: programId },
+    queryVariables,
+    { withPagination: true },
+  );
   const { data, isLoading, isFetching, error } =
     useQuery<PaginatedIndividualListList>({
-      queryKey: [
-        'businessAreasProgramsIndividualsList',
-        queryVariables,
-        businessArea,
-        programId,
-      ],
+      queryKey: restQueryKey(
+        RestService.restBusinessAreasProgramsIndividualsList,
+        individualsListParams,
+      ),
       queryFn: () =>
         RestService.restBusinessAreasProgramsIndividualsList(
-          createApiParams(
-            { businessAreaSlug: businessArea, programCode: programId },
-            queryVariables,
-            { withPagination: true },
-          ),
+          individualsListParams,
         ),
       placeholderData: keepPreviousData,
     });
 
+  const individualsCountParams = createApiParams(
+    { businessAreaSlug: businessArea, programCode: programId },
+    queryVariables,
+  );
   const { data: countData } = useQuery({
-    queryKey: [
-      'businessAreasProgramsIndividualsCount',
-      queryVariables,
-      businessArea,
-      programId,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsIndividualsCountRetrieve,
+      individualsCountParams,
+    ),
     queryFn: () =>
       RestService.restBusinessAreasProgramsIndividualsCountRetrieve(
-        createApiParams(
-          { businessAreaSlug: businessArea, programCode: programId },
-          queryVariables,
-        ),
+        individualsCountParams,
       ),
     enabled: page === 0,
   });

--- a/src/frontend/src/containers/tables/rdi/ImportedPeopleTable/ImportedPeopleTable.tsx
+++ b/src/frontend/src/containers/tables/rdi/ImportedPeopleTable/ImportedPeopleTable.tsx
@@ -4,7 +4,7 @@ import { Box, Checkbox, FormControlLabel, Grid } from '@mui/material';
 import { IndividualList } from '@restgenerated/models/IndividualList';
 import { PaginatedIndividualListList } from '@restgenerated/models/PaginatedIndividualListList';
 import { RestService } from '@restgenerated/services/RestService';
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { createApiParams } from '@utils/apiUtils';
 import { ReactElement, useEffect, useMemo, useState } from 'react';
 import { usePersistedCount } from '@hooks/usePersistedCount';
@@ -75,6 +75,7 @@ export function ImportedPeopleTable({
           { withPagination: true },
         ),
       ),
+    placeholderData: keepPreviousData,
   });
 
   const { data: countData } = useQuery({

--- a/src/frontend/src/containers/tables/rdi/RegistrationDataImportTable/RegistrationDataImportTable.tsx
+++ b/src/frontend/src/containers/tables/rdi/RegistrationDataImportTable/RegistrationDataImportTable.tsx
@@ -136,6 +136,7 @@ function RegistrationDataImportTable({
   const {
     data: listData,
     isLoading,
+    isFetching,
     error,
   } = useQuery<PaginatedRegistrationDataImportListList>({
     queryKey: [
@@ -199,6 +200,7 @@ function RegistrationDataImportTable({
         setQueryVariables={setQueryVariables}
         data={listData}
         isLoading={isLoading}
+        isFetching={isFetching}
         error={error}
         page={page}
         setPage={setPage}

--- a/src/frontend/src/containers/tables/rdi/RegistrationDataImportTable/RegistrationDataImportTable.tsx
+++ b/src/frontend/src/containers/tables/rdi/RegistrationDataImportTable/RegistrationDataImportTable.tsx
@@ -15,6 +15,7 @@ import {
 import { RegistrationDataImportTableRow } from './RegistrationDataImportTableRow';
 import { UniversalRestTable } from '@components/rest/UniversalRestTable/UniversalRestTable';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { createApiParams } from '@utils/apiUtils';
 import { PaginatedRegistrationDataImportListList } from '@restgenerated/models/PaginatedRegistrationDataImportListList';
 import { RegistrationDataImportList } from '@restgenerated/models/RegistrationDataImportList';
@@ -52,13 +53,19 @@ function RegistrationDataImportTable({
   const { businessAreaSlug, programCode, businessArea, programId } =
     useBaseUrl();
 
+  const deduplicationFlagsParams = {
+    businessAreaSlug,
+    code: programCode,
+  };
   const { data: deduplicationFlags } = useQuery({
-    queryKey: ['deduplicationFlags', businessAreaSlug, programCode],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsDeduplicationFlagsRetrieve,
+      deduplicationFlagsParams,
+    ),
     queryFn: () =>
-      RestService.restBusinessAreasProgramsDeduplicationFlagsRetrieve({
-        businessAreaSlug,
-        code: programCode,
-      }),
+      RestService.restBusinessAreasProgramsDeduplicationFlagsRetrieve(
+        deduplicationFlagsParams,
+      ),
   });
 
   const initialVariables = useMemo(
@@ -133,44 +140,41 @@ function RegistrationDataImportTable({
 
   const [page, setPage] = useState(0);
 
+  const registrationDataImportsListParams = createApiParams(
+    { businessAreaSlug: businessArea, programCode },
+    queryVariables,
+    { withPagination: true },
+  );
   const {
     data: listData,
     isLoading,
     isFetching,
     error,
   } = useQuery<PaginatedRegistrationDataImportListList>({
-    queryKey: [
-      'businessAreasProgramsRegistrationDataImportsList',
-      businessArea,
-      programCode,
-      queryVariables,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsRegistrationDataImportsList,
+      registrationDataImportsListParams,
+    ),
     queryFn: () =>
       RestService.restBusinessAreasProgramsRegistrationDataImportsList(
-        createApiParams(
-          { businessAreaSlug: businessArea, programCode },
-          queryVariables,
-          { withPagination: true },
-        ),
+        registrationDataImportsListParams,
       ),
     placeholderData: keepPreviousData,
   });
 
+  const registrationDataImportsCountParams = createApiParams(
+    { businessAreaSlug: businessArea, programCode },
+    queryVariables,
+    { withPagination: false },
+  );
   const { data: countData } = useQuery<{ count: number }>({
-    queryKey: [
-      'businessAreasProgramsRegistrationDataImportsCount',
-      businessArea,
-      programCode,
-      queryVariables,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsRegistrationDataImportsCountRetrieve,
+      registrationDataImportsCountParams,
+    ),
     queryFn: async () => {
-      const params = createApiParams(
-        { businessAreaSlug: businessArea, programCode },
-        queryVariables,
-        { withPagination: false },
-      );
       return RestService.restBusinessAreasProgramsRegistrationDataImportsCountRetrieve(
-        params,
+        registrationDataImportsCountParams,
       );
     },
     enabled: page === 0,

--- a/src/frontend/src/containers/tables/rdi/RegistrationDataImportTable/RegistrationDataImportTable.tsx
+++ b/src/frontend/src/containers/tables/rdi/RegistrationDataImportTable/RegistrationDataImportTable.tsx
@@ -1,7 +1,7 @@
 import { TableWrapper } from '@components/core/TableWrapper';
 import withErrorBoundary from '@components/core/withErrorBoundary';
 import { useBaseUrl } from '@hooks/useBaseUrl';
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { adjustHeadCells } from '@utils/utils';
 import { ReactElement, useEffect, useState, useMemo } from 'react';
 import { usePersistedCount } from '@hooks/usePersistedCount';
@@ -152,6 +152,7 @@ function RegistrationDataImportTable({
           { withPagination: true },
         ),
       ),
+    placeholderData: keepPreviousData,
   });
 
   const { data: countData } = useQuery<{ count: number }>({

--- a/src/frontend/src/containers/tables/targeting/TargetPopulationHouseholdTable/TargetPopulationHouseholdTable.tsx
+++ b/src/frontend/src/containers/tables/targeting/TargetPopulationHouseholdTable/TargetPopulationHouseholdTable.tsx
@@ -47,6 +47,7 @@ export function TargetPopulationHouseholdTable({
   const {
     data: householdsData,
     isLoading,
+    isFetching,
     error,
   } = useQuery<PaginatedPendingPaymentList>({
     queryKey: [
@@ -119,6 +120,7 @@ export function TargetPopulationHouseholdTable({
         headCells={adjustedHeadCells}
         rowsPerPageOptions={[10, 15, 20]}
         isLoading={isLoading}
+        isFetching={isFetching}
         data={householdsData}
         error={error}
         queryVariables={queryVariables}

--- a/src/frontend/src/containers/tables/targeting/TargetPopulationHouseholdTable/TargetPopulationHouseholdTable.tsx
+++ b/src/frontend/src/containers/tables/targeting/TargetPopulationHouseholdTable/TargetPopulationHouseholdTable.tsx
@@ -2,7 +2,7 @@ import { TableWrapper } from '@components/core/TableWrapper';
 import { UniversalRestTable } from '@components/rest/UniversalRestTable/UniversalRestTable';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { RestService } from '@restgenerated/services/RestService';
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { adjustHeadCells } from '@utils/utils';
 import { usePersistedCount } from '@hooks/usePersistedCount';
 import { ReactElement, useEffect, useMemo, useState } from 'react';
@@ -69,6 +69,7 @@ export function TargetPopulationHouseholdTable({
         ),
       );
     },
+    placeholderData: keepPreviousData,
   });
 
   // Add count query for pending payments

--- a/src/frontend/src/containers/tables/targeting/TargetPopulationHouseholdTable/TargetPopulationHouseholdTable.tsx
+++ b/src/frontend/src/containers/tables/targeting/TargetPopulationHouseholdTable/TargetPopulationHouseholdTable.tsx
@@ -2,6 +2,7 @@ import { TableWrapper } from '@components/core/TableWrapper';
 import { UniversalRestTable } from '@components/rest/UniversalRestTable/UniversalRestTable';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { adjustHeadCells } from '@utils/utils';
 import { usePersistedCount } from '@hooks/usePersistedCount';
@@ -44,51 +45,47 @@ export function TargetPopulationHouseholdTable({
     setQueryVariables(initialQueryVariables);
   }, [initialQueryVariables]);
 
+  const pendingPaymentsListParams = createApiParams(
+    {
+      businessAreaSlug,
+      programCode,
+      id,
+    },
+    queryVariables,
+    { withPagination: true },
+  );
   const {
     data: householdsData,
     isLoading,
     isFetching,
     error,
   } = useQuery<PaginatedPendingPaymentList>({
-    queryKey: [
-      'businessAreasProgramsPaymentPlansPaymentsList',
-      businessAreaSlug,
-      programCode,
-      queryVariables,
-      id,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsTargetPopulationsPendingPaymentsList,
+      pendingPaymentsListParams,
+    ),
     queryFn: () => {
       return RestService.restBusinessAreasProgramsTargetPopulationsPendingPaymentsList(
-        createApiParams(
-          {
-            businessAreaSlug,
-            programCode,
-            id,
-          },
-          queryVariables,
-          { withPagination: true },
-        ),
+        pendingPaymentsListParams,
       );
     },
     placeholderData: keepPreviousData,
   });
 
   // Add count query for pending payments
+  const pendingPaymentsCountParams = {
+    businessAreaSlug,
+    programCode,
+    id,
+  };
   const { data: countData } = useQuery({
-    queryKey: [
-      'businessAreasProgramsTargetPopulationsPendingPaymentsCount',
-      businessAreaSlug,
-      programCode,
-      id,
-      queryVariables,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsTargetPopulationsPendingPaymentsCountRetrieve,
+      pendingPaymentsCountParams,
+    ),
     queryFn: () =>
       RestService.restBusinessAreasProgramsTargetPopulationsPendingPaymentsCountRetrieve(
-        {
-          businessAreaSlug,
-          programCode,
-          id,
-        },
+        pendingPaymentsCountParams,
       ),
     enabled: page === 0,
   });

--- a/src/frontend/src/containers/tables/targeting/TargetPopulationPeopleTable/TargetPopulationPeopleTable.tsx
+++ b/src/frontend/src/containers/tables/targeting/TargetPopulationPeopleTable/TargetPopulationPeopleTable.tsx
@@ -41,6 +41,7 @@ export function TargetPopulationPeopleTable({
   const {
     data: householdsData,
     isLoading,
+    isFetching,
     error,
   } = useQuery<PaginatedPendingPaymentList>({
     queryKey: [
@@ -73,6 +74,7 @@ export function TargetPopulationPeopleTable({
         headCells={headCells}
         rowsPerPageOptions={[10, 15, 20]}
         isLoading={isLoading}
+        isFetching={isFetching}
         error={error}
         queryVariables={queryVariables}
         setQueryVariables={setQueryVariables}

--- a/src/frontend/src/containers/tables/targeting/TargetPopulationPeopleTable/TargetPopulationPeopleTable.tsx
+++ b/src/frontend/src/containers/tables/targeting/TargetPopulationPeopleTable/TargetPopulationPeopleTable.tsx
@@ -2,7 +2,7 @@ import { TableWrapper } from '@components/core/TableWrapper';
 import { UniversalRestTable } from '@components/rest/UniversalRestTable/UniversalRestTable';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { RestService } from '@restgenerated/services/RestService';
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { ReactElement, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { headCells } from './TargetPopulationPeopleHeadCells';
@@ -63,6 +63,7 @@ export function TargetPopulationPeopleTable({
         ),
       );
     },
+    placeholderData: keepPreviousData,
   });
 
   return (

--- a/src/frontend/src/containers/tables/targeting/TargetPopulationPeopleTable/TargetPopulationPeopleTable.tsx
+++ b/src/frontend/src/containers/tables/targeting/TargetPopulationPeopleTable/TargetPopulationPeopleTable.tsx
@@ -2,6 +2,7 @@ import { TableWrapper } from '@components/core/TableWrapper';
 import { UniversalRestTable } from '@components/rest/UniversalRestTable/UniversalRestTable';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { ReactElement, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -38,30 +39,28 @@ export function TargetPopulationPeopleTable({
     setQueryVariables(initialQueryVariables);
   }, [initialQueryVariables]);
 
+  const pendingPaymentsListParams = createApiParams(
+    {
+      businessAreaSlug: businessArea,
+      programCode: programId,
+      id,
+    },
+    queryVariables,
+    { withPagination: true },
+  );
   const {
     data: householdsData,
     isLoading,
     isFetching,
     error,
   } = useQuery<PaginatedPendingPaymentList>({
-    queryKey: [
-      'businessAreasProgramsPaymentPlansPaymentsList',
-      businessArea,
-      programId,
-      queryVariables,
-      id,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsTargetPopulationsPendingPaymentsList,
+      pendingPaymentsListParams,
+    ),
     queryFn: () => {
       return RestService.restBusinessAreasProgramsTargetPopulationsPendingPaymentsList(
-        createApiParams(
-          {
-            businessAreaSlug: businessArea,
-            programCode: programId,
-            id,
-          },
-          queryVariables,
-          { withPagination: true },
-        ),
+        pendingPaymentsListParams,
       );
     },
     placeholderData: keepPreviousData,

--- a/src/frontend/src/containers/tables/targeting/TargetPopulationTable/TargetPopulationTable.tsx
+++ b/src/frontend/src/containers/tables/targeting/TargetPopulationTable/TargetPopulationTable.tsx
@@ -5,6 +5,7 @@ import { PaginatedTargetPopulationListList } from '@restgenerated/models/Paginat
 import { TargetPopulationList } from '@restgenerated/models/TargetPopulationList';
 import { RestService } from '@restgenerated/services/RestService';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { adjustHeadCells } from '@utils/utils';
 import { ReactElement, useEffect, useMemo, useState } from 'react';
 import { usePersistedCount } from '@hooks/usePersistedCount';
@@ -74,22 +75,21 @@ export function TargetPopulationTable({
   }, [initialQueryVariables]);
 
   // Count query (enabled only on page 0)
+  const targetPopulationsCountParams = createApiParams(
+    {
+      businessAreaSlug: businessArea,
+      programCode: programId,
+    },
+    queryVariables,
+  );
   const { data: countData } = useQuery({
-    queryKey: [
-      'businessAreasProgramsTargetPopulationsCount',
-      businessArea,
-      programId,
-      queryVariables,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsTargetPopulationsCountRetrieve,
+      targetPopulationsCountParams,
+    ),
     queryFn: () =>
       RestService.restBusinessAreasProgramsTargetPopulationsCountRetrieve(
-        createApiParams(
-          {
-            businessAreaSlug: businessArea,
-            programCode: programId,
-          },
-          queryVariables,
-        ),
+        targetPopulationsCountParams,
       ),
     enabled: page === 0,
   });
@@ -97,29 +97,27 @@ export function TargetPopulationTable({
   const persistedCount = usePersistedCount(page, countData);
 
   // Main data query
+  const targetPopulationsListParams = createApiParams(
+    {
+      businessAreaSlug: businessArea,
+      programCode: programId,
+    },
+    queryVariables,
+    { withPagination: true },
+  );
   const {
     data: targetPopulationsData,
     isLoading,
     isFetching,
     error,
   } = useQuery<PaginatedTargetPopulationListList>({
-    queryKey: [
-      'businessAreasProgramsTargetPopulationsList',
-      businessArea,
-      programId,
-      queryVariables,
-      page,
-    ],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsTargetPopulationsList,
+      targetPopulationsListParams,
+    ),
     queryFn: () => {
       return RestService.restBusinessAreasProgramsTargetPopulationsList(
-        createApiParams(
-          {
-            businessAreaSlug: businessArea,
-            programCode: programId,
-          },
-          queryVariables,
-          { withPagination: true },
-        ),
+        targetPopulationsListParams,
       );
     },
     placeholderData: keepPreviousData,

--- a/src/frontend/src/containers/tables/targeting/TargetPopulationTable/TargetPopulationTable.tsx
+++ b/src/frontend/src/containers/tables/targeting/TargetPopulationTable/TargetPopulationTable.tsx
@@ -4,7 +4,7 @@ import { useBaseUrl } from '@hooks/useBaseUrl';
 import { PaginatedTargetPopulationListList } from '@restgenerated/models/PaginatedTargetPopulationListList';
 import { TargetPopulationList } from '@restgenerated/models/TargetPopulationList';
 import { RestService } from '@restgenerated/services/RestService';
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { adjustHeadCells } from '@utils/utils';
 import { ReactElement, useEffect, useMemo, useState } from 'react';
 import { usePersistedCount } from '@hooks/usePersistedCount';
@@ -121,6 +121,7 @@ export function TargetPopulationTable({
         ),
       );
     },
+    placeholderData: keepPreviousData,
   });
 
   const handleRadioChange = (id: string): void => {

--- a/src/frontend/src/containers/tables/targeting/TargetPopulationTable/TargetPopulationTable.tsx
+++ b/src/frontend/src/containers/tables/targeting/TargetPopulationTable/TargetPopulationTable.tsx
@@ -100,6 +100,7 @@ export function TargetPopulationTable({
   const {
     data: targetPopulationsData,
     isLoading,
+    isFetching,
     error,
   } = useQuery<PaginatedTargetPopulationListList>({
     queryKey: [
@@ -155,6 +156,7 @@ export function TargetPopulationTable({
         setQueryVariables={setQueryVariables}
         data={targetPopulationsData}
         isLoading={isLoading}
+        isFetching={isFetching}
         error={error}
         renderRow={(row: TargetPopulationList) => {
           const idx = results.indexOf(row);
@@ -165,7 +167,10 @@ export function TargetPopulationTable({
           return (
             <>
               {isNewGroup && (
-                <GroupHeaderRow name={row.paymentPlanGroup?.name} id={row.paymentPlanGroup?.id} />
+                <GroupHeaderRow
+                  name={row.paymentPlanGroup?.name}
+                  id={row.paymentPlanGroup?.id}
+                />
               )}
               <TargetPopulationTableRow
                 radioChangeHandler={enableRadioButton && handleRadioChange}

--- a/src/frontend/src/hooks/useActionMutation.ts
+++ b/src/frontend/src/hooks/useActionMutation.ts
@@ -4,12 +4,13 @@ import {
   UseMutationResult,
   useQueryClient,
 } from '@tanstack/react-query';
-import type { DefaultError } from '@tanstack/query-core';
+import type { DefaultError, QueryKey } from '@tanstack/query-core';
 
 export const useActionMutation = <TData, TOptions>(
   id: string,
   mutationFn: (data: TOptions) => Promise<TData>,
-  invalidateQuery: string[],
+  // Derive via restQueryKey (utils/queryKeys.ts) so this matches the reader's key.
+  invalidateQuery: QueryKey,
   options: any = null,
 ): UseMutationResult<TData, DefaultError, void> => {
   const { businessAreaSlug, programCode } = useBaseUrl();

--- a/src/frontend/src/hooks/useHopeDetailsQuery.ts
+++ b/src/frontend/src/hooks/useHopeDetailsQuery.ts
@@ -1,5 +1,6 @@
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 
 export const useHopeDetailsQuery = <TData, TOptions = any>(
   id: string,
@@ -7,9 +8,8 @@ export const useHopeDetailsQuery = <TData, TOptions = any>(
   options: any,
 ): UseQueryResult<TData> => {
   const { businessAreaSlug, programCode } = useBaseUrl();
-  // eslint-disable-next-line @tanstack/query/exhaustive-deps
   return useQuery({
-    queryKey: [queryFn.name, { id, programCode, businessAreaSlug }],
+    queryKey: restQueryKey(queryFn, { id, programCode, businessAreaSlug }),
     queryFn: () =>
       queryFn({
         id,

--- a/src/frontend/src/hooks/usePaymentPlanTypeLabel.ts
+++ b/src/frontend/src/hooks/usePaymentPlanTypeLabel.ts
@@ -1,5 +1,6 @@
 import { RestService } from '@restgenerated/services/RestService';
 import { useQuery } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 
 /**
  * Resolves a PaymentPlan `planType` value to its human-readable label via the
@@ -10,7 +11,7 @@ export function usePaymentPlanTypeLabel(): (
   planType?: string | null,
 ) => string {
   const { data } = useQuery({
-    queryKey: ['paymentPlanTypeChoices'],
+    queryKey: restQueryKey(RestService.restChoicesPaymentPlanTypeList),
     queryFn: () => RestService.restChoicesPaymentPlanTypeList(),
   });
 

--- a/src/frontend/src/hooks/usePermissions.ts
+++ b/src/frontend/src/hooks/usePermissions.ts
@@ -2,21 +2,28 @@ import { useQuery } from '@tanstack/react-query';
 import { RestService } from '@restgenerated/services/RestService';
 import { useBaseUrl } from './useBaseUrl';
 import { Profile } from '@restgenerated/models/Profile';
+import { restQueryKey } from '@utils/queryKeys';
 import { useMemo } from 'react';
 
 export function usePermissions(): string[] {
   const { businessAreaSlug, programCode } = useBaseUrl();
+
+  const profileParams = {
+    businessAreaSlug,
+    program: programCode === 'all' ? undefined : programCode,
+  };
+
   const {
     data: meData,
     isLoading: meDataLoading,
     error,
   } = useQuery<Profile>({
-    queryKey: ['profile', businessAreaSlug, programCode],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasUsersProfileRetrieve,
+      profileParams,
+    ),
     queryFn: () => {
-      return RestService.restBusinessAreasUsersProfileRetrieve({
-        businessAreaSlug,
-        program: programCode === 'all' ? undefined : programCode,
-      });
+      return RestService.restBusinessAreasUsersProfileRetrieve(profileParams);
     },
     staleTime: 5 * 60 * 1000, // Data is considered fresh for 5 minutes
     gcTime: 30 * 60 * 1000, // Keep unused data in cache for 30 minutes

--- a/src/frontend/src/providers.tsx
+++ b/src/frontend/src/providers.tsx
@@ -20,15 +20,10 @@ interface ProvidersProps {
   children: ReactNode[];
 }
 
-// After ANY successful mutation, mark active non-static queries stale so the UI reflects the
-// write on the next mount/access (create/edit/status-change etc.). This uses
-// `refetchType: 'none'` so it does NOT actively refetch: mutations that need an immediate
-// on-screen refresh add their own targeted invalidation (default active refetch), and this net
-// only guarantees eventual freshness for the app's drifted query keys. Not refetching here also
-// avoids re-firing a query for a resource a mutation just deleted before its own onSuccess
-// navigates away. Static reference data (choices, geo areas, permissions) is exempt so it keeps
-// its long staleTime. The onSuccess closure references `queryClient` lazily — it only runs on a
-// mutation success, long after the binding is initialised — so the self-reference is safe.
+// After any successful mutation, mark active non-static queries stale (refetchType: 'none' =
+// mark without refetching). Targeted per-flow invalidations do the immediate on-screen refresh;
+// this net only guarantees eventual freshness and avoids re-firing a GET on a just-deleted
+// resource. Static reference data (see isStaticReferenceQuery) is exempt to keep its long staleTime.
 const queryClient: QueryClient = new QueryClient({
   mutationCache: new MutationCache({
     onSuccess: () => {

--- a/src/frontend/src/providers.tsx
+++ b/src/frontend/src/providers.tsx
@@ -1,5 +1,10 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import {
+  MutationCache,
+  QueryClient,
+  QueryClientProvider,
+} from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import { isStaticReferenceQuery } from '@utils/queryCacheUtils';
 import { CssBaseline } from '@mui/material';
 import { ThemeProvider as MuiThemeProvider } from '@mui/material/styles';
 import { FC, ReactNode } from 'react';
@@ -15,7 +20,20 @@ interface ProvidersProps {
   children: ReactNode[];
 }
 
-const queryClient = new QueryClient({
+// After ANY successful mutation, invalidate active queries so the UI reflects the write
+// immediately (create/edit/status-change etc.). Static reference data (choices, geo areas,
+// permissions) is exempt so it keeps its long staleTime. Individual mutations may still add
+// their own targeted invalidation; this is the safety net for the app's drifted query keys.
+// The onSuccess closure references `queryClient` lazily — it only runs on a mutation success,
+// long after the binding is initialised — so the self-reference is safe.
+const queryClient: QueryClient = new QueryClient({
+  mutationCache: new MutationCache({
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        predicate: (query) => !isStaticReferenceQuery(query.queryKey),
+      });
+    },
+  }),
   defaultOptions: {
     queries: {
       staleTime: 60 * 1000, // Data is considered fresh for 60 seconds

--- a/src/frontend/src/providers.tsx
+++ b/src/frontend/src/providers.tsx
@@ -20,17 +20,21 @@ interface ProvidersProps {
   children: ReactNode[];
 }
 
-// After ANY successful mutation, invalidate active queries so the UI reflects the write
-// immediately (create/edit/status-change etc.). Static reference data (choices, geo areas,
-// permissions) is exempt so it keeps its long staleTime. Individual mutations may still add
-// their own targeted invalidation; this is the safety net for the app's drifted query keys.
-// The onSuccess closure references `queryClient` lazily — it only runs on a mutation success,
-// long after the binding is initialised — so the self-reference is safe.
+// After ANY successful mutation, mark active non-static queries stale so the UI reflects the
+// write on the next mount/access (create/edit/status-change etc.). This uses
+// `refetchType: 'none'` so it does NOT actively refetch: mutations that need an immediate
+// on-screen refresh add their own targeted invalidation (default active refetch), and this net
+// only guarantees eventual freshness for the app's drifted query keys. Not refetching here also
+// avoids re-firing a query for a resource a mutation just deleted before its own onSuccess
+// navigates away. Static reference data (choices, geo areas, permissions) is exempt so it keeps
+// its long staleTime. The onSuccess closure references `queryClient` lazily — it only runs on a
+// mutation success, long after the binding is initialised — so the self-reference is safe.
 const queryClient: QueryClient = new QueryClient({
   mutationCache: new MutationCache({
     onSuccess: () => {
       queryClient.invalidateQueries({
         predicate: (query) => !isStaticReferenceQuery(query.queryKey),
+        refetchType: 'none',
       });
     },
   }),

--- a/src/frontend/src/providers.tsx
+++ b/src/frontend/src/providers.tsx
@@ -15,7 +15,16 @@ interface ProvidersProps {
   children: ReactNode[];
 }
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 60 * 1000, // Data is considered fresh for 60 seconds
+      gcTime: 10 * 60 * 1000, // Keep unused data in cache for 10 minutes
+      refetchOnWindowFocus: false, // Don't refetch when window regains focus
+      retry: 1, // Retry a failed query once (down from the default of 3)
+    },
+  },
+});
 
 export const Providers: FC<ProvidersProps> = ({ children }) => {
   return (

--- a/src/frontend/src/providers.tsx
+++ b/src/frontend/src/providers.tsx
@@ -20,10 +20,9 @@ interface ProvidersProps {
   children: ReactNode[];
 }
 
-// After any successful mutation, mark active non-static queries stale (refetchType: 'none' =
-// mark without refetching). Targeted per-flow invalidations do the immediate on-screen refresh;
-// this net only guarantees eventual freshness and avoids re-firing a GET on a just-deleted
-// resource. Static reference data (see isStaticReferenceQuery) is exempt to keep its long staleTime.
+// Safety net for eventual freshness only: `refetchType: 'none'` marks queries stale without
+// refetching, so it never re-fires a GET on a just-deleted resource. Targeted per-flow
+// invalidations still do the immediate on-screen refresh.
 const queryClient: QueryClient = new QueryClient({
   mutationCache: new MutationCache({
     onSuccess: () => {
@@ -35,10 +34,10 @@ const queryClient: QueryClient = new QueryClient({
   }),
   defaultOptions: {
     queries: {
-      staleTime: 60 * 1000, // Data is considered fresh for 60 seconds
-      gcTime: 10 * 60 * 1000, // Keep unused data in cache for 10 minutes
-      refetchOnWindowFocus: false, // Don't refetch when window regains focus
-      retry: 1, // Retry a failed query once (down from the default of 3)
+      staleTime: 60 * 1000,
+      gcTime: 10 * 60 * 1000,
+      refetchOnWindowFocus: false,
+      retry: 1,
     },
   },
 });

--- a/src/frontend/src/shared/Formik/FormikAsyncAutocomplete/FormikAsyncAutocomplete.tsx
+++ b/src/frontend/src/shared/Formik/FormikAsyncAutocomplete/FormikAsyncAutocomplete.tsx
@@ -2,6 +2,7 @@ import { ReactElement, useEffect, useState } from 'react';
 import { Autocomplete, TextField } from '@mui/material';
 import { useQuery } from '@tanstack/react-query';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 
 interface FormikAsyncAutocompleteProps {
   field: any;
@@ -35,7 +36,11 @@ export function FormikAsyncAutocomplete({
   };
 
   const { data, isLoading } = useQuery({
-    queryKey: ['asyncAutocomplete', restEndpoint, inputValue, variables],
+    queryKey: restQueryKey(RestService.restBusinessAreasGeoAreasList, {
+      restEndpoint,
+      inputValue,
+      variables,
+    }),
     queryFn: async () => {
       if (restEndpoint === 'adminAreas') {
         return RestService.restBusinessAreasGeoAreasList({

--- a/src/frontend/src/shared/Formik/FormikCurrencyAutocomplete/FormikCurrencyAutocomplete.tsx
+++ b/src/frontend/src/shared/Formik/FormikCurrencyAutocomplete/FormikCurrencyAutocomplete.tsx
@@ -4,6 +4,7 @@ import get from 'lodash/get';
 import { ReactElement } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { CurrencyChoice } from '@restgenerated/models/CurrencyChoice';
 
 const getCurrencyLabel = (option: CurrencyChoice): string => {
@@ -22,7 +23,7 @@ export const FormikCurrencyAutocomplete = ({
   const { t } = useTranslation();
 
   const { data } = useQuery({
-    queryKey: ['currencies'],
+    queryKey: restQueryKey(RestService.restChoicesCurrenciesList),
     queryFn: () => RestService.restChoicesCurrenciesList(),
   });
 

--- a/src/frontend/src/shared/autocompletes/AdminAreaAutocomplete.tsx
+++ b/src/frontend/src/shared/autocompletes/AdminAreaAutocomplete.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { useDebounce } from '@hooks/useDebounce';
 import {
@@ -55,18 +56,21 @@ export function AdminAreaAutocomplete({
     }));
   }, [debouncedInputText]);
 
+  const geoAreasParams = {
+    businessAreaSlug: businessArea,
+    level: level,
+    name: queryVariables.search,
+  };
   const {
     data: areasData,
     isLoading: loading,
     refetch,
   } = useQuery<AreaList[]>({
-    queryKey: ['adminAreas', queryVariables, businessArea, level],
-    queryFn: () =>
-      RestService.restBusinessAreasGeoAreasList({
-        businessAreaSlug: businessArea,
-        level: level,
-        name: queryVariables.search,
-      }),
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasGeoAreasList,
+      geoAreasParams,
+    ),
+    queryFn: () => RestService.restBusinessAreasGeoAreasList(geoAreasParams),
     enabled: open && !!businessArea,
     staleTime: 0,
     refetchOnWindowFocus: false,

--- a/src/frontend/src/shared/autocompletes/AdminAreaAutocompleteMultiple.tsx
+++ b/src/frontend/src/shared/autocompletes/AdminAreaAutocompleteMultiple.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { useDebounce } from '@hooks/useDebounce';
 import { useQuery } from '@tanstack/react-query';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import {
   StyledAutocomplete,
@@ -31,15 +32,18 @@ export function AdminAreaAutocompleteMultiple({
   const debouncedInputText = useDebounce(inputValue, 400);
   const [newValue, setNewValue] = useState([]);
   const { businessArea } = useBaseUrl();
+  const geoAreasParams = {
+    businessAreaSlug: businessArea,
+    level: level,
+    name: debouncedInputText,
+    parentId: parentId || undefined,
+  };
   const { data: areasData, isLoading } = useQuery({
-    queryKey: ['adminAreas', debouncedInputText, businessArea, level, parentId],
-    queryFn: () =>
-      RestService.restBusinessAreasGeoAreasList({
-        businessAreaSlug: businessArea,
-        level: level,
-        name: debouncedInputText,
-        parentId: parentId || undefined,
-      }),
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasGeoAreasList,
+      geoAreasParams,
+    ),
+    queryFn: () => RestService.restBusinessAreasGeoAreasList(geoAreasParams),
     enabled: !!businessArea,
   });
 

--- a/src/frontend/src/shared/autocompletes/AdminAreaFixedAutocomplete.tsx
+++ b/src/frontend/src/shared/autocompletes/AdminAreaFixedAutocomplete.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 import { useQuery } from '@tanstack/react-query';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { useDebounce } from '@hooks/useDebounce';
 
@@ -29,27 +30,23 @@ export const AdminAreaFixedAutocomplete = ({
   const debouncedInputText = useDebounce(inputValue, 800);
   const [, setNewValue] = useState(null);
   const { businessArea } = useBaseUrl();
+  const geoAreasParams = {
+    businessAreaSlug: businessArea,
+    level: level === 1 ? 1 : 2,
+    name: debouncedInputText || undefined,
+    id: value || undefined,
+    parentId: parentId || undefined,
+  };
   const {
     data: areasData,
     isLoading,
     error,
   } = useQuery({
-    queryKey: [
-      'adminAreas',
-      debouncedInputText,
-      businessArea,
-      level,
-      parentId,
-      value,
-    ],
-    queryFn: () =>
-      RestService.restBusinessAreasGeoAreasList({
-        businessAreaSlug: businessArea,
-        level: level === 1 ? 1 : 2,
-        name: debouncedInputText || undefined,
-        id: value || undefined,
-        parentId: parentId || undefined,
-      }),
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasGeoAreasList,
+      geoAreasParams,
+    ),
+    queryFn: () => RestService.restBusinessAreasGeoAreasList(geoAreasParams),
     enabled: !!businessArea,
   });
 

--- a/src/frontend/src/shared/autocompletes/AssigneeAutocompleteRestFilter.tsx
+++ b/src/frontend/src/shared/autocompletes/AssigneeAutocompleteRestFilter.tsx
@@ -9,6 +9,7 @@ import { useDebounce } from '@hooks/useDebounce';
 import { useQuery } from '@tanstack/react-query';
 import { PaginatedUserList } from '@restgenerated/models/PaginatedUserList';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { BaseAutocompleteFilterRest } from './BaseAutocompleteFilterRest';
 
 export function AssigneeAutocompleteRestFilter({
@@ -53,7 +54,7 @@ export function AssigneeAutocompleteRestFilter({
     isLoading,
     refetch,
   } = useQuery<PaginatedUserList>({
-    queryKey: ['businessAreasUsersList', queryVariables, businessArea],
+    queryKey: restQueryKey(RestService.restBusinessAreasUsersList, queryVariables),
     queryFn: () => RestService.restBusinessAreasUsersList(queryVariables),
   });
 

--- a/src/frontend/src/shared/autocompletes/CreatedByAutocompleteRestFilter.tsx
+++ b/src/frontend/src/shared/autocompletes/CreatedByAutocompleteRestFilter.tsx
@@ -6,6 +6,7 @@ import { useDebounce } from '@hooks/useDebounce';
 import { useQuery } from '@tanstack/react-query';
 import { PaginatedUserList } from '@restgenerated/models/PaginatedUserList';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import {
   createHandleApplyFilterChange,
   handleAutocompleteChange,
@@ -56,7 +57,7 @@ export const CreatedByAutocompleteRestFilter = ({
     isLoading,
     refetch,
   } = useQuery<PaginatedUserList>({
-    queryKey: ['businessAreasUsersList', queryVariables, businessArea],
+    queryKey: restQueryKey(RestService.restBusinessAreasUsersList, queryVariables),
     queryFn: () => RestService.restBusinessAreasUsersList(queryVariables),
   });
 

--- a/src/frontend/src/shared/autocompletes/LanguageAutocompleteRestFilter.tsx
+++ b/src/frontend/src/shared/autocompletes/LanguageAutocompleteRestFilter.tsx
@@ -4,6 +4,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { useDebounce } from '@hooks/useDebounce';
 import { useQuery } from '@tanstack/react-query';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import {
   createHandleApplyFilterChange,
   handleAutocompleteChange,
@@ -43,7 +44,7 @@ export function LanguageAutocompleteRestFilter({
     isLoading,
     refetch,
   } = useQuery({
-    queryKey: ['languagesList'],
+    queryKey: restQueryKey(RestService.restChoicesLanguagesList),
     queryFn: () => RestService.restChoicesLanguagesList(),
   });
 

--- a/src/frontend/src/shared/autocompletes/ProgramAutocompleteRestFilter.tsx
+++ b/src/frontend/src/shared/autocompletes/ProgramAutocompleteRestFilter.tsx
@@ -11,6 +11,7 @@ import {
 } from '@utils/utils';
 import { PaginatedProgramListList } from '@restgenerated/models/PaginatedProgramListList';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useQuery } from '@tanstack/react-query';
 import { BaseAutocompleteFilterRest } from '@shared/autocompletes/BaseAutocompleteFilterRest';
 
@@ -54,7 +55,7 @@ export function ProgramAutocompleteRestFilter({
     isLoading,
     refetch,
   } = useQuery<PaginatedProgramListList>({
-    queryKey: ['businessAreasProgramsList', queryVariables, businessArea],
+    queryKey: restQueryKey(RestService.restBusinessAreasProgramsList, queryVariables),
     queryFn: () => RestService.restBusinessAreasProgramsList(queryVariables),
   });
 

--- a/src/frontend/src/shared/autocompletes/RdiAutocompleteRestFilter.tsx
+++ b/src/frontend/src/shared/autocompletes/RdiAutocompleteRestFilter.tsx
@@ -6,6 +6,7 @@ import { useDebounce } from '@hooks/useDebounce';
 import { useQuery } from '@tanstack/react-query';
 import { PaginatedRegistrationDataImportListList } from '@restgenerated/models/PaginatedRegistrationDataImportListList';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import {
   createHandleApplyFilterChange,
   handleAutocompleteChange,
@@ -54,12 +55,10 @@ export function RdiAutocompleteRestFilter({
     isLoading,
     refetch,
   } = useQuery<PaginatedRegistrationDataImportListList>({
-    queryKey: [
-      'businessAreasProgramsRegistrationDataImportsList',
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsRegistrationDataImportsList,
       queryVariables,
-      businessArea,
-      programId,
-    ],
+    ),
     queryFn: () =>
       RestService.restBusinessAreasProgramsRegistrationDataImportsList(
         queryVariables,

--- a/src/frontend/src/shared/autocompletes/rest/AdminAreaAutocompleteMultipleRestFilter.tsx
+++ b/src/frontend/src/shared/autocompletes/rest/AdminAreaAutocompleteMultipleRestFilter.tsx
@@ -9,6 +9,7 @@ import {
 import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank';
 import CheckBoxIcon from '@mui/icons-material/CheckBox';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { useQuery } from '@tanstack/react-query';
 import { AreaList } from '@restgenerated/models/AreaList';
 
@@ -59,7 +60,11 @@ export function AdminAreaAutocompleteMultipleRestFilter({
     isLoading,
     refetch,
   } = useQuery<AreaList[]>({
-    queryKey: ['areas', businessArea, queryVariables],
+    queryKey: restQueryKey(RestService.restBusinessAreasGeoAreasList, {
+      businessAreaSlug: businessArea,
+      level: queryVariables.level,
+      name: queryVariables.search,
+    }),
     queryFn: async () => {
       try {
         return RestService.restBusinessAreasGeoAreasList({

--- a/src/frontend/src/shared/autocompletes/rest/BaseAutocompleteRest.tsx
+++ b/src/frontend/src/shared/autocompletes/rest/BaseAutocompleteRest.tsx
@@ -1,6 +1,7 @@
 import CircularProgress from '@mui/material/CircularProgress';
 import { ReactElement, ReactNode, useEffect, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import { restQueryKey } from '@utils/queryKeys';
 import { StyledAutocomplete, StyledTextField } from '../StyledAutocomplete';
 import { useDebounce } from '@hooks/useDebounce';
 import { FormHelperText } from '@mui/material';
@@ -54,9 +55,12 @@ export function BaseAutocompleteRest({
   const [inputValue, setInputValue] = useState('');
   const debouncedInputText = useDebounce(inputValue, 800);
   const [open, setOpen] = useState(false);
-  // eslint-disable-next-line @tanstack/query/exhaustive-deps
   const { data, isLoading } = useQuery({
-    queryKey: [label, businessArea, programId, queryParams],
+    queryKey: restQueryKey(fetchFunction, {
+      businessArea,
+      programId,
+      ...queryParams,
+    }),
     queryFn: () => fetchFunction(businessArea, programId, { ...queryParams }),
   });
   useEffect(

--- a/src/frontend/src/shared/autocompletes/rest/BaseAutocompleteRest.tsx
+++ b/src/frontend/src/shared/autocompletes/rest/BaseAutocompleteRest.tsx
@@ -14,6 +14,7 @@ export function BaseAutocompleteRest({
   label,
   dataCy,
   fetchFunction,
+  queryKeyMethod,
   businessArea,
   programId,
   queryParams,
@@ -37,6 +38,9 @@ export function BaseAutocompleteRest({
     programId: string,
     queryParams?: Record<string, any>,
   ) => Promise<any>;
+  // The RestService method `fetchFunction` calls, used only for its `.name`. Deriving the
+  // root from `fetchFunction` would yield 'fetchFunction' for every inline-arrow caller.
+  queryKeyMethod: (...args: any[]) => unknown;
   businessArea: string;
   programId: string;
   queryParams?: Record<string, any>;
@@ -55,8 +59,10 @@ export function BaseAutocompleteRest({
   const [inputValue, setInputValue] = useState('');
   const debouncedInputText = useDebounce(inputValue, 800);
   const [open, setOpen] = useState(false);
+  // `fetchFunction` is a fresh arrow each render; everything it reads is already in the key.
+  // eslint-disable-next-line @tanstack/query/exhaustive-deps
   const { data, isLoading } = useQuery({
-    queryKey: restQueryKey(fetchFunction, {
+    queryKey: restQueryKey(queryKeyMethod, {
       businessArea,
       programId,
       ...queryParams,

--- a/src/frontend/src/shared/autocompletes/rest/BeneficiaryGroupsAutocompleteRest.tsx
+++ b/src/frontend/src/shared/autocompletes/rest/BeneficiaryGroupsAutocompleteRest.tsx
@@ -39,6 +39,7 @@ export const BeneficiaryGroupAutocompleteRest = ({
       label={t('Beneficiary Group')}
       dataCy="filters-beneficiary-group-autocomplete"
       fetchFunction={() => RestService.restBeneficiaryGroupsList({})}
+      queryKeyMethod={RestService.restBeneficiaryGroupsList}
       businessArea={businessArea}
       handleChange={(_, selectedValue) => {
         onChange(selectedValue);

--- a/src/frontend/src/shared/autocompletes/rest/PaymentPlanGroupAutocompleteRest.tsx
+++ b/src/frontend/src/shared/autocompletes/rest/PaymentPlanGroupAutocompleteRest.tsx
@@ -53,6 +53,7 @@ export const PaymentPlanGroupAutocompleteRest = ({
           ...params,
         })
       }
+      queryKeyMethod={RestService.restBusinessAreasProgramsPaymentPlanGroupsList}
       businessArea={businessArea}
       programId={programId}
       handleChange={(_, selectedValue) => {

--- a/src/frontend/src/shared/autocompletes/rest/PaymentPlanPurposesAutocomplete.tsx
+++ b/src/frontend/src/shared/autocompletes/rest/PaymentPlanPurposesAutocomplete.tsx
@@ -3,6 +3,7 @@ import { useDebounce } from '@hooks/useDebounce';
 import { FormikChipAutocomplete } from '@shared/Formik/FormikChipAutocomplete/FormikChipAutocomplete';
 import { PaginatedPaymentPlanPurposeList } from '@restgenerated/models/PaginatedPaymentPlanPurposeList';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import { FieldInputProps, FormikProps } from 'formik';
 import { useQuery } from '@tanstack/react-query';
 import { ReactElement, useEffect, useState } from 'react';
@@ -34,13 +35,17 @@ export function PaymentPlanPurposesAutocomplete({
   const debouncedSearch = useDebounce(inputValue, 800);
   const [knownOptions, setKnownOptions] = useState<Choice[]>([]);
 
+  const purposesParams = {
+    businessAreaSlug: businessArea,
+    search: debouncedSearch || undefined,
+  };
   const { data: fetchedOptions = [], isLoading } = useQuery({
-    queryKey: ['paymentPlanPurposes', businessArea, debouncedSearch],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasPaymentPlanPurposesList,
+      purposesParams,
+    ),
     queryFn: () =>
-      RestService.restBusinessAreasPaymentPlanPurposesList({
-        businessAreaSlug: businessArea,
-        search: debouncedSearch || undefined,
-      }),
+      RestService.restBusinessAreasPaymentPlanPurposesList(purposesParams),
     select: (data: PaginatedPaymentPlanPurposeList): Choice[] =>
       (data?.results ?? []).map((p) => ({ value: p.id, name: p.name })),
   });

--- a/src/frontend/src/shared/autocompletes/rest/ProgramCycleAutocompleteRest.tsx
+++ b/src/frontend/src/shared/autocompletes/rest/ProgramCycleAutocompleteRest.tsx
@@ -44,6 +44,7 @@ export const ProgramCycleAutocompleteRest = ({
           ...params,
         })
       }
+      queryKeyMethod={RestService.restBusinessAreasProgramsCyclesList}
       businessArea={businessArea}
       programId={programId}
       handleChange={(_, selectedValue) => {

--- a/src/frontend/src/shared/autocompletes/rest/RdiAutocompleteRest.tsx
+++ b/src/frontend/src/shared/autocompletes/rest/RdiAutocompleteRest.tsx
@@ -4,6 +4,7 @@ import { handleOptionSelected } from '@utils/utils';
 import React, { ReactElement, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { BaseAutocompleteRest } from './BaseAutocompleteRest';
+import { RestService } from '@restgenerated/services/RestService';
 
 export const RdiAutocompleteRest = ({
   disabled,
@@ -30,6 +31,9 @@ export const RdiAutocompleteRest = ({
       label={t('Registration Data Import')}
       dataCy="filters-registration-data-import"
       fetchFunction={fetchRegistrationDataImports}
+      queryKeyMethod={
+        RestService.restBusinessAreasProgramsRegistrationDataImportsList
+      }
       businessArea={businessArea}
       programId={programId}
       queryParams={queryParams}

--- a/src/frontend/src/shared/autocompletes/rest/TargetPopulationAutocompleteRestFilter.tsx
+++ b/src/frontend/src/shared/autocompletes/rest/TargetPopulationAutocompleteRestFilter.tsx
@@ -2,6 +2,7 @@ import { useBaseUrl } from '@hooks/useBaseUrl';
 import { useDebounce } from '@hooks/useDebounce';
 import { PaginatedTargetPopulationListList } from '@restgenerated/models/PaginatedTargetPopulationListList';
 import { RestService } from '@restgenerated/services/RestService';
+import { restQueryKey } from '@utils/queryKeys';
 import {
   createHandleApplyFilterChange,
   handleAutocompleteChange,
@@ -58,18 +59,24 @@ export const TargetPopulationAutocompleteRestFilter = ({
   }, [debouncedInputText]);
 
   // Use the RestService function to fetch target population data
+  const targetPopulationsParams = {
+    businessAreaSlug: businessArea || '',
+    programCode: programId || '',
+    ...queryVariables,
+  };
   const {
     data: targetPopulationData,
     isLoading,
     refetch,
   } = useQuery<PaginatedTargetPopulationListList>({
-    queryKey: ['targetPopulations', businessArea, programId, queryVariables],
+    queryKey: restQueryKey(
+      RestService.restBusinessAreasProgramsTargetPopulationsList,
+      targetPopulationsParams,
+    ),
     queryFn: () =>
-      RestService.restBusinessAreasProgramsTargetPopulationsList({
-        businessAreaSlug: businessArea || '',
-        programCode: programId || '',
-        ...queryVariables,
-      }),
+      RestService.restBusinessAreasProgramsTargetPopulationsList(
+        targetPopulationsParams,
+      ),
     enabled: !!businessArea && !!programId,
   });
 

--- a/src/frontend/src/testUtils/commonMocks.ts
+++ b/src/frontend/src/testUtils/commonMocks.ts
@@ -60,30 +60,41 @@ const _utilsMock = vi.hoisted(() => ({
   individualStatusToColor: vi.fn(() => '#000000'),
 }));
 
-const _restServiceMethods = vi.hoisted(() => ({
-  restBusinessAreasProgramsHouseholdsList: vi.fn(),
-  restBusinessAreasProgramsHouseholdsCountRetrieve: vi.fn(),
-  restBusinessAreasProgramsIndividualsList: vi.fn(),
-  restBusinessAreasProgramsHouseholdsMembersList: vi.fn(),
-  restBusinessAreasProgramsList: vi.fn(),
-  restBusinessAreasProgramsCountRetrieve: vi.fn(),
-  restBusinessAreasUsersProfileRetrieve: vi.fn(() =>
-    Promise.resolve({
-      id: 'test-user',
-      username: 'mock-user',
-      permissions: ['can_view_programs'],
-    }),
-  ),
-  restBusinessAreasProgramsCyclesList: vi.fn(),
-  restBusinessAreasProgramsCyclesRetrieve: vi.fn(),
-  restBusinessAreasProgramsCyclesCreate: vi.fn(),
-  restBusinessAreasProgramsCyclesUpdate: vi.fn(),
-  restBusinessAreasProgramsCyclesPartialUpdate: vi.fn(),
-  restBusinessAreasProgramsCyclesDestroy: vi.fn(),
-  restBusinessAreasProgramsCyclesFinishCreate: vi.fn(),
-  restBusinessAreasProgramsCyclesReactivateCreate: vi.fn(),
-  restBusinessAreasProgramsCyclesCountRetrieve: vi.fn(),
-}));
+const _restServiceMethods = vi.hoisted(() => {
+  const methods = {
+    restBusinessAreasProgramsHouseholdsList: vi.fn(),
+    restBusinessAreasProgramsHouseholdsCountRetrieve: vi.fn(),
+    restBusinessAreasProgramsIndividualsList: vi.fn(),
+    restBusinessAreasProgramsIndividualsCountRetrieve: vi.fn(),
+    restBusinessAreasProgramsHouseholdsMembersList: vi.fn(),
+    restBusinessAreasProgramsList: vi.fn(),
+    restBusinessAreasProgramsCountRetrieve: vi.fn(),
+    restBusinessAreasUsersProfileRetrieve: vi.fn(() =>
+      Promise.resolve({
+        id: 'test-user',
+        username: 'mock-user',
+        permissions: ['can_view_programs'],
+      }),
+    ),
+    restBusinessAreasProgramsCyclesList: vi.fn(),
+    restBusinessAreasProgramsCyclesRetrieve: vi.fn(),
+    restBusinessAreasProgramsCyclesCreate: vi.fn(),
+    restBusinessAreasProgramsCyclesUpdate: vi.fn(),
+    restBusinessAreasProgramsCyclesPartialUpdate: vi.fn(),
+    restBusinessAreasProgramsCyclesDestroy: vi.fn(),
+    restBusinessAreasProgramsCyclesFinishCreate: vi.fn(),
+    restBusinessAreasProgramsCyclesReactivateCreate: vi.fn(),
+    restBusinessAreasProgramsCyclesCountRetrieve: vi.fn(),
+  };
+  // restQueryKey (utils/queryKeys.ts) derives the key root from `fn.name`. Bare spies are
+  // all named 'spy', so without this every mocked fetcher would share one root and two
+  // queries with equal params would collapse into a single cache entry — the second
+  // queryFn then never runs.
+  for (const [name, fn] of Object.entries(methods)) {
+    Object.defineProperty(fn, 'name', { value: name, configurable: true });
+  }
+  return methods;
+});
 
 // Top-level vi.mock() registrations — no hoisting warnings
 vi.mock('@hooks/useBaseUrl', () => ({

--- a/src/frontend/src/testUtils/commonMocks.ts
+++ b/src/frontend/src/testUtils/commonMocks.ts
@@ -86,10 +86,8 @@ const _restServiceMethods = vi.hoisted(() => {
     restBusinessAreasProgramsCyclesReactivateCreate: vi.fn(),
     restBusinessAreasProgramsCyclesCountRetrieve: vi.fn(),
   };
-  // restQueryKey (utils/queryKeys.ts) derives the key root from `fn.name`. Bare spies are
-  // all named 'spy', so without this every mocked fetcher would share one root and two
-  // queries with equal params would collapse into a single cache entry — the second
-  // queryFn then never runs.
+  // restQueryKey derives the key root from `fn.name`, and every bare spy is named 'spy'.
+  // Without this, all mocked fetchers share one root and collapse into one cache entry.
   for (const [name, fn] of Object.entries(methods)) {
     Object.defineProperty(fn, 'name', { value: name, configurable: true });
   }

--- a/src/frontend/src/utils/queryCacheUtils.test.ts
+++ b/src/frontend/src/utils/queryCacheUtils.test.ts
@@ -2,9 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { isStaticReferenceQuery } from './queryCacheUtils';
 
 describe('isStaticReferenceQuery', () => {
-  // Reference data must stay exempt so the blanket post-mutation invalidation does not
-  // needlessly refetch it and discard its long staleTime.
-  // Roots are the ones restQueryKey derives from the fetcher, not hand-written strings.
+  // Exempt so the blanket post-mutation invalidation does not discard their long staleTime.
   it('returns true for known static reference roots', () => {
     expect(
       isStaticReferenceQuery([
@@ -27,7 +25,6 @@ describe('isStaticReferenceQuery', () => {
     expect(isStaticReferenceQuery(['beneficiaryGroupsList'])).toBe(true);
   });
 
-  // The pre-migration hand-written roots are gone; nothing should still match them.
   it('returns false for the retired hand-written roots', () => {
     expect(isStaticReferenceQuery(['profile', 'afghanistan'])).toBe(false);
     expect(isStaticReferenceQuery(['businessArea', 'afghanistan'])).toBe(false);
@@ -42,9 +39,8 @@ describe('isStaticReferenceQuery', () => {
     expect(
       isStaticReferenceQuery(['businessAreasGrievanceTicketsChoices', 'afg']),
     ).toBe(true);
-    // Dropped from the STATIC_QUERY_KEY_ROOTS set but still matched by the choices heuristic.
+    // Matched by the heuristic, not the explicit set.
     expect(isStaticReferenceQuery(['restChoicesCountriesList'])).toBe(true);
-    // A derived (normalized) choices retrieve root is exempt too.
     expect(
       isStaticReferenceQuery([
         'businessAreasGrievanceTicketsChoicesRetrieve',
@@ -53,8 +49,6 @@ describe('isStaticReferenceQuery', () => {
     ).toBe(true);
   });
 
-  // Mutable data MUST NOT be exempt — these are exactly the readers that go stale after a
-  // create/edit/status-change and need to refetch.
   it('returns false for mutable data readers that must refetch after a write', () => {
     expect(isStaticReferenceQuery(['program', 'afghanistan', 'prog-1'])).toBe(false);
     expect(
@@ -66,7 +60,6 @@ describe('isStaticReferenceQuery', () => {
     expect(
       isStaticReferenceQuery(['businessAreaProgram', 'afghanistan', 'prog-1']),
     ).toBe(false);
-    // Derived (normalized) mutable-data roots must not be exempt.
     expect(
       isStaticReferenceQuery(['businessAreasProgramsList', { limit: 20 }]),
     ).toBe(false);
@@ -78,7 +71,6 @@ describe('isStaticReferenceQuery', () => {
     ).toBe(false);
   });
 
-  // The exact-match guard must not treat `businessArea`-prefixed data keys as static.
   it('does not treat businessArea-prefixed data keys as static via prefix', () => {
     expect(
       isStaticReferenceQuery(['businessAreasProgramsTargetPopulationsList', {}]),

--- a/src/frontend/src/utils/queryCacheUtils.test.ts
+++ b/src/frontend/src/utils/queryCacheUtils.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { isStaticReferenceQuery } from './queryCacheUtils';
+
+describe('isStaticReferenceQuery', () => {
+  // Reference data must stay exempt so the blanket post-mutation invalidation does not
+  // needlessly refetch it and discard its long staleTime.
+  it('returns true for known static reference roots', () => {
+    expect(isStaticReferenceQuery(['profile', 'afghanistan', 'prog'])).toBe(true);
+    expect(isStaticReferenceQuery(['businessArea', 'afghanistan'])).toBe(true);
+    expect(isStaticReferenceQuery(['allAreasTree', 'afghanistan'])).toBe(true);
+    expect(isStaticReferenceQuery(['beneficiaryGroups'])).toBe(true);
+    expect(isStaticReferenceQuery(['restChoicesCountriesList'])).toBe(true);
+  });
+
+  it('returns true for any choices endpoint key', () => {
+    expect(isStaticReferenceQuery(['programChoices', 'afghanistan'])).toBe(true);
+    expect(isStaticReferenceQuery(['householdChoices', 'afghanistan'])).toBe(true);
+    expect(isStaticReferenceQuery(['choicesPaymentPlanStatusList'])).toBe(true);
+    expect(
+      isStaticReferenceQuery(['businessAreasGrievanceTicketsChoices', 'afg']),
+    ).toBe(true);
+  });
+
+  // Mutable data MUST NOT be exempt — these are exactly the readers that go stale after a
+  // create/edit/status-change and need to refetch.
+  it('returns false for mutable data readers that must refetch after a write', () => {
+    expect(isStaticReferenceQuery(['program', 'afghanistan', 'prog-1'])).toBe(false);
+    expect(
+      isStaticReferenceQuery(['businessAreasProgramsList', {}, 'afghanistan']),
+    ).toBe(false);
+    expect(
+      isStaticReferenceQuery(['paymentPlan', 'afghanistan', 'pp-1', 'prog-1']),
+    ).toBe(false);
+    expect(
+      isStaticReferenceQuery(['businessAreaProgram', 'afghanistan', 'prog-1']),
+    ).toBe(false);
+  });
+
+  // The exact-match guard must not treat `businessArea`-prefixed data keys as static.
+  it('does not treat businessArea-prefixed data keys as static via prefix', () => {
+    expect(
+      isStaticReferenceQuery(['businessAreasProgramsTargetPopulationsList', {}]),
+    ).toBe(false);
+  });
+
+  it('returns false when the first key element is not a string', () => {
+    expect(isStaticReferenceQuery([{ limit: 100 }, 'afghanistan'])).toBe(false);
+    expect(isStaticReferenceQuery([])).toBe(false);
+  });
+});

--- a/src/frontend/src/utils/queryCacheUtils.test.ts
+++ b/src/frontend/src/utils/queryCacheUtils.test.ts
@@ -9,7 +9,6 @@ describe('isStaticReferenceQuery', () => {
     expect(isStaticReferenceQuery(['businessArea', 'afghanistan'])).toBe(true);
     expect(isStaticReferenceQuery(['allAreasTree', 'afghanistan'])).toBe(true);
     expect(isStaticReferenceQuery(['beneficiaryGroups'])).toBe(true);
-    expect(isStaticReferenceQuery(['restChoicesCountriesList'])).toBe(true);
   });
 
   it('returns true for any choices endpoint key', () => {
@@ -18,6 +17,15 @@ describe('isStaticReferenceQuery', () => {
     expect(isStaticReferenceQuery(['choicesPaymentPlanStatusList'])).toBe(true);
     expect(
       isStaticReferenceQuery(['businessAreasGrievanceTicketsChoices', 'afg']),
+    ).toBe(true);
+    // Dropped from the STATIC_QUERY_KEY_ROOTS set but still matched by the choices heuristic.
+    expect(isStaticReferenceQuery(['restChoicesCountriesList'])).toBe(true);
+    // A derived (normalized) choices retrieve root is exempt too.
+    expect(
+      isStaticReferenceQuery([
+        'businessAreasGrievanceTicketsChoicesRetrieve',
+        { businessAreaSlug: 'afg' },
+      ]),
     ).toBe(true);
   });
 
@@ -33,6 +41,16 @@ describe('isStaticReferenceQuery', () => {
     ).toBe(false);
     expect(
       isStaticReferenceQuery(['businessAreaProgram', 'afghanistan', 'prog-1']),
+    ).toBe(false);
+    // Derived (normalized) mutable-data roots must not be exempt.
+    expect(
+      isStaticReferenceQuery(['businessAreasProgramsList', { limit: 20 }]),
+    ).toBe(false);
+    expect(
+      isStaticReferenceQuery([
+        'businessAreasProgramsRetrieve',
+        { businessAreaSlug: 'afg', code: 'p1' },
+      ]),
     ).toBe(false);
   });
 

--- a/src/frontend/src/utils/queryCacheUtils.test.ts
+++ b/src/frontend/src/utils/queryCacheUtils.test.ts
@@ -4,11 +4,35 @@ import { isStaticReferenceQuery } from './queryCacheUtils';
 describe('isStaticReferenceQuery', () => {
   // Reference data must stay exempt so the blanket post-mutation invalidation does not
   // needlessly refetch it and discard its long staleTime.
+  // Roots are the ones restQueryKey derives from the fetcher, not hand-written strings.
   it('returns true for known static reference roots', () => {
-    expect(isStaticReferenceQuery(['profile', 'afghanistan', 'prog'])).toBe(true);
-    expect(isStaticReferenceQuery(['businessArea', 'afghanistan'])).toBe(true);
-    expect(isStaticReferenceQuery(['allAreasTree', 'afghanistan'])).toBe(true);
-    expect(isStaticReferenceQuery(['beneficiaryGroups'])).toBe(true);
+    expect(
+      isStaticReferenceQuery([
+        'businessAreasUsersProfileRetrieve',
+        { businessAreaSlug: 'afghanistan', programCode: 'prog' },
+      ]),
+    ).toBe(true);
+    expect(
+      isStaticReferenceQuery([
+        'businessAreasRetrieve',
+        { businessAreaSlug: 'afghanistan' },
+      ]),
+    ).toBe(true);
+    expect(
+      isStaticReferenceQuery([
+        'businessAreasGeoAreasList',
+        { businessAreaSlug: 'afghanistan', level: 2 },
+      ]),
+    ).toBe(true);
+    expect(isStaticReferenceQuery(['beneficiaryGroupsList'])).toBe(true);
+  });
+
+  // The pre-migration hand-written roots are gone; nothing should still match them.
+  it('returns false for the retired hand-written roots', () => {
+    expect(isStaticReferenceQuery(['profile', 'afghanistan'])).toBe(false);
+    expect(isStaticReferenceQuery(['businessArea', 'afghanistan'])).toBe(false);
+    expect(isStaticReferenceQuery(['allAreasTree', 'afghanistan'])).toBe(false);
+    expect(isStaticReferenceQuery(['beneficiaryGroups'])).toBe(false);
   });
 
   it('returns true for any choices endpoint key', () => {

--- a/src/frontend/src/utils/queryCacheUtils.ts
+++ b/src/frontend/src/utils/queryCacheUtils.ts
@@ -1,15 +1,12 @@
-// Query keys in this app are hand-written string-array literals (not derived from
-// restgenerated), so they drift. The global MutationCache.onSuccess in providers.tsx
-// invalidates every query after any successful mutation to keep the UI fresh, but static
-// reference data (choices, geo areas, permissions) is never changed by those mutations and
-// carries a deliberately long staleTime. This predicate exempts that data from the blanket
-// invalidation so it is not needlessly refetched after every write.
+// Exempts static reference data (choices, geo areas, permissions) from the blanket
+// post-mutation invalidation in providers.tsx, so it keeps its long staleTime. Query
+// keys are derived from the fetcher via restQueryKey (see utils/queryKeys.ts).
 const STATIC_QUERY_KEY_ROOTS = new Set<string>([
   'profile', // permissions / current-user profile (usePermissions, AppBar)
   'businessArea', // business-area details
   'allAreasTree', // geo areas
   'beneficiaryGroups',
-  'restChoicesCountriesList',
+  // restChoicesCountriesList / any *choices* root is covered by the heuristic below.
 ]);
 
 /** True when a query holds static reference data that user mutations never change. */

--- a/src/frontend/src/utils/queryCacheUtils.ts
+++ b/src/frontend/src/utils/queryCacheUtils.ts
@@ -1,11 +1,17 @@
 // Exempts static reference data (choices, geo areas, permissions) from the blanket
 // post-mutation invalidation in providers.tsx, so it keeps its long staleTime. Query
 // keys are derived from the fetcher via restQueryKey (see utils/queryKeys.ts).
+// Roots are what restQueryKey derives from the fetcher name, so they must be updated
+// alongside the readers — a hand-written root here silently stops matching.
 const STATIC_QUERY_KEY_ROOTS = new Set<string>([
-  'profile', // permissions / current-user profile (usePermissions, AppBar)
-  'businessArea', // business-area details
-  'allAreasTree', // geo areas
-  'beneficiaryGroups',
+  // restBusinessAreasUsersProfileRetrieve — permissions / current-user profile
+  'businessAreasUsersProfileRetrieve',
+  // restBusinessAreasRetrieve — business-area details
+  'businessAreasRetrieve',
+  // restBusinessAreasGeoAreasList — geo areas
+  'businessAreasGeoAreasList',
+  // restBeneficiaryGroupsList
+  'beneficiaryGroupsList',
   // restChoicesCountriesList / any *choices* root is covered by the heuristic below.
 ]);
 

--- a/src/frontend/src/utils/queryCacheUtils.ts
+++ b/src/frontend/src/utils/queryCacheUtils.ts
@@ -1,0 +1,24 @@
+// Query keys in this app are hand-written string-array literals (not derived from
+// restgenerated), so they drift. The global MutationCache.onSuccess in providers.tsx
+// invalidates every query after any successful mutation to keep the UI fresh, but static
+// reference data (choices, geo areas, permissions) is never changed by those mutations and
+// carries a deliberately long staleTime. This predicate exempts that data from the blanket
+// invalidation so it is not needlessly refetched after every write.
+const STATIC_QUERY_KEY_ROOTS = new Set<string>([
+  'profile', // permissions / current-user profile (usePermissions, AppBar)
+  'businessArea', // business-area details
+  'allAreasTree', // geo areas
+  'beneficiaryGroups',
+  'restChoicesCountriesList',
+]);
+
+/** True when a query holds static reference data that user mutations never change. */
+export function isStaticReferenceQuery(queryKey: readonly unknown[]): boolean {
+  const root = queryKey[0];
+  // Only string roots can be static; list keys with an object first element are data.
+  if (typeof root !== 'string') return false;
+  // Exact match only — never a prefix, since many data keys start with `businessArea…`.
+  if (STATIC_QUERY_KEY_ROOTS.has(root)) return true;
+  // Every choices endpoint is reference data (e.g. programChoices, choicesPaymentPlanStatusList).
+  return root.toLowerCase().includes('choices');
+}

--- a/src/frontend/src/utils/queryCacheUtils.ts
+++ b/src/frontend/src/utils/queryCacheUtils.ts
@@ -1,27 +1,19 @@
-// Exempts static reference data (choices, geo areas, permissions) from the blanket
-// post-mutation invalidation in providers.tsx, so it keeps its long staleTime. Query
-// keys are derived from the fetcher via restQueryKey (see utils/queryKeys.ts).
-// Roots are what restQueryKey derives from the fetcher name, so they must be updated
-// alongside the readers — a hand-written root here silently stops matching.
+// Roots exempt from the blanket post-mutation invalidation in providers.tsx, so reference
+// data keeps its long staleTime. These are restQueryKey roots (see utils/queryKeys.ts) and
+// must be updated alongside their readers — a stale root here silently stops matching.
+// Any *choices* root is covered by the heuristic below.
 const STATIC_QUERY_KEY_ROOTS = new Set<string>([
-  // restBusinessAreasUsersProfileRetrieve — permissions / current-user profile
   'businessAreasUsersProfileRetrieve',
-  // restBusinessAreasRetrieve — business-area details
   'businessAreasRetrieve',
-  // restBusinessAreasGeoAreasList — geo areas
   'businessAreasGeoAreasList',
-  // restBeneficiaryGroupsList
   'beneficiaryGroupsList',
-  // restChoicesCountriesList / any *choices* root is covered by the heuristic below.
 ]);
 
 /** True when a query holds static reference data that user mutations never change. */
 export function isStaticReferenceQuery(queryKey: readonly unknown[]): boolean {
   const root = queryKey[0];
-  // Only string roots can be static; list keys with an object first element are data.
   if (typeof root !== 'string') return false;
   // Exact match only — never a prefix, since many data keys start with `businessArea…`.
   if (STATIC_QUERY_KEY_ROOTS.has(root)) return true;
-  // Every choices endpoint is reference data (e.g. programChoices, choicesPaymentPlanStatusList).
   return root.toLowerCase().includes('choices');
 }

--- a/src/frontend/src/utils/queryKeys.test.ts
+++ b/src/frontend/src/utils/queryKeys.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { restQueryKey } from './queryKeys';
 
-// Stand-ins for RestService static methods — only their `.name` matters to the factory.
+// Stand-ins for RestService methods — only `.name` matters.
 function restBusinessAreasProgramsList(): void {}
 function restBusinessAreasProgramsRetrieve(): void {}
 function hhStatusRetrieve(): void {}
@@ -27,7 +27,7 @@ describe('restQueryKey', () => {
     const params = { businessAreaSlug: 'afghanistan', limit: 20 };
     const key = restQueryKey(restBusinessAreasProgramsRetrieve, params);
     expect(key).toEqual(['businessAreasProgramsRetrieve', params]);
-    // The params object is embedded as-is, not cloned — cache identity relies on this.
+    // Embedded by identity, not cloned — cache identity relies on this.
     expect(key[1]).toBe(params);
   });
 

--- a/src/frontend/src/utils/queryKeys.test.ts
+++ b/src/frontend/src/utils/queryKeys.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { restQueryKey } from './queryKeys';
+
+// Stand-ins for RestService static methods — only their `.name` matters to the factory.
+function restBusinessAreasProgramsList(): void {}
+function restBusinessAreasProgramsRetrieve(): void {}
+function hhStatusRetrieve(): void {}
+
+describe('restQueryKey', () => {
+  it('normalizes the method name (drops `rest`, lower-cases first char)', () => {
+    expect(restQueryKey(restBusinessAreasProgramsList)).toEqual([
+      'businessAreasProgramsList',
+    ]);
+  });
+
+  it('leaves a non-`rest`-prefixed method name untouched', () => {
+    expect(restQueryKey(hhStatusRetrieve)).toEqual(['hhStatusRetrieve']);
+  });
+
+  it('returns [root] when no params are given (list prefix / invalidation)', () => {
+    expect(restQueryKey(restBusinessAreasProgramsRetrieve)).toEqual([
+      'businessAreasProgramsRetrieve',
+    ]);
+  });
+
+  it('returns [root, params] and passes params through by identity', () => {
+    const params = { businessAreaSlug: 'afghanistan', limit: 20 };
+    const key = restQueryKey(restBusinessAreasProgramsRetrieve, params);
+    expect(key).toEqual(['businessAreasProgramsRetrieve', params]);
+    // The params object is embedded as-is, not cloned — cache identity relies on this.
+    expect(key[1]).toBe(params);
+  });
+
+  it('derives distinct roots from distinct methods', () => {
+    expect(restQueryKey(restBusinessAreasProgramsList)[0]).not.toBe(
+      restQueryKey(restBusinessAreasProgramsRetrieve)[0],
+    );
+  });
+});

--- a/src/frontend/src/utils/queryKeys.ts
+++ b/src/frontend/src/utils/queryKeys.ts
@@ -1,0 +1,28 @@
+import type { QueryKey } from '@tanstack/react-query';
+
+// A RestService fetcher: a named static method taking one object arg (or none).
+// We rely only on its `.name`.
+type RestMethod = (...args: any[]) => unknown;
+
+// Normalizes a RestService method name to the app's query-key root convention:
+// drop the generated `rest` prefix and lower-case the first char. This reproduces the
+// existing hand-written list prefixes exactly (restBusinessAreasProgramsList ->
+// 'businessAreasProgramsList'), so derived keys match existing readers.
+function normalizeRoot(name: string): string {
+  const stripped = name.startsWith('rest') ? name.slice('rest'.length) : name;
+  return stripped.charAt(0).toLowerCase() + stripped.slice(1);
+}
+
+// Derives a stable query key from a RestService method's identity, so keys are never
+// hand-written and cannot drift from their reader/invalidator counterpart.
+//   restQueryKey(method)         -> [root]          // list prefix / invalidation
+//   restQueryKey(method, params) -> [root, params]  // detail / scoped reader
+// List readers pass their pagination/filter object as `params`; their invalidators pass
+// none, so the bare prefix matches every cached variant (default non-exact match).
+export function restQueryKey(
+  method: RestMethod,
+  params?: Record<string, unknown>,
+): QueryKey {
+  const root = normalizeRoot(method.name);
+  return params === undefined ? [root] : [root, params];
+}

--- a/src/frontend/src/utils/queryKeys.ts
+++ b/src/frontend/src/utils/queryKeys.ts
@@ -1,24 +1,17 @@
 import type { QueryKey } from '@tanstack/react-query';
 
-// A RestService fetcher: a named static method taking one object arg (or none).
-// We rely only on its `.name`.
+// A RestService fetcher. Only its `.name` is used.
 type RestMethod = (...args: any[]) => unknown;
 
-// Normalizes a RestService method name to the app's query-key root convention:
-// drop the generated `rest` prefix and lower-case the first char. This reproduces the
-// existing hand-written list prefixes exactly (restBusinessAreasProgramsList ->
-// 'businessAreasProgramsList'), so derived keys match existing readers.
+// restBusinessAreasProgramsList -> 'businessAreasProgramsList'
 function normalizeRoot(name: string): string {
   const stripped = name.startsWith('rest') ? name.slice('rest'.length) : name;
   return stripped.charAt(0).toLowerCase() + stripped.slice(1);
 }
 
-// Derives a stable query key from a RestService method's identity, so keys are never
-// hand-written and cannot drift from their reader/invalidator counterpart.
-//   restQueryKey(method)         -> [root]          // list prefix / invalidation
-//   restQueryKey(method, params) -> [root, params]  // detail / scoped reader
-// List readers pass their pagination/filter object as `params`; their invalidators pass
-// none, so the bare prefix matches every cached variant (default non-exact match).
+// Derives the key from the fetcher's identity so readers and invalidators cannot drift.
+//   restQueryKey(method)         -> [root]          // invalidators: matches every variant
+//   restQueryKey(method, params) -> [root, params]  // readers
 export function restQueryKey(
   method: RestMethod,
   params?: Record<string, unknown>,

--- a/src/hope/apps/core/api/views.py
+++ b/src/hope/apps/core/api/views.py
@@ -108,7 +108,7 @@ class BusinessAreaViewSet(
             200: FieldAttributeSerializer(many=True),
         },
     )
-    @action(detail=True, methods=["get"], url_path="all-fields-attributes")
+    @action(detail=True, methods=["get"], url_path="all-fields-attributes", pagination_class=None)
     def all_fields_attributes(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         program_id = request.query_params.get("program_id", None)
         business_area_slug = self.kwargs["slug"]


### PR DESCRIPTION
## Summary

Adds caching defaults to TanStack Query and fixes the stale-data bug that surfaced once caching was enabled.

Previously the `QueryClient` had no `defaultOptions`, so almost every query ran with `staleTime: 0` and `refetchOnWindowFocus: true`, refetching on every remount and window focus. Adding caching defaults fixed that, but exposed a pre-existing problem: query keys in this app are hand-written string arrays, not generated, and many had drifted out of sync with the keys queries actually read. Several mutations invalidated keys nothing reads, or invalidated nothing at all. This never mattered at `staleTime: 0` because everything refetched on remount. With caching on, those no-op invalidations left stale data on screen until the cache expired (e.g. edit a Programme name, save, and the details page still shows the old name).

This PR includes both the caching change and the invalidation fixes needed to make it safe.

## Part 1 — Caching and refetch changes

- `providers.tsx`: global `QueryClient` defaults — `staleTime` 60s, `gcTime` 10min, `refetchOnWindowFocus: false`, `retry: 1`. Hooks that need always-fresh data still set their own `staleTime: 0`.
- `PaymentPlanDetailsPage.tsx`, `TargetPopulationDetailsPage.tsx`: removed `refetchIntervalInBackground: true`, so the 3s status polls pause when the tab is hidden.
- Added `placeholderData: keepPreviousData` to 34 paginated tables so rows stay visible while the next page/filter loads.
- `VerifyManual.tsx`: removed a `setQueryData` that was immediately overwritten by `invalidateQueries` on the same key — dead code, no behavior change.

## Part 2 — Fix stale data after mutations

**2a. Global safety net.** Added a `MutationCache.onSuccess` handler in `providers.tsx` that invalidates active queries after any successful mutation, regardless of whether that mutation defines its own `onSuccess`. A new `isStaticReferenceQuery` predicate (`utils/queryCacheUtils.ts`, unit-tested) exempts static reference data — choices, geo areas, permissions/profile, business-area metadata — so those keep their long cache time. This is the fix for the reported bug: it only refetches mounted, non-static queries, and only after a mutation, so it's strictly less traffic than the old `staleTime: 0` behavior.

**2b. Query-key corrections.** Fixed the drifted keys so each flow is also correct without relying on the safety net:

- **Programme** — Create/Duplicate/Delete invalidated wrong keys; Edit never invalidated the details page.
- **Grievance** — ticket edit had no invalidation; payment-grievance verification used a wrong key; bulk assign/priority/urgency/note modals passed a key that never matched when a specific programme was selected.
- **Target Population** — Create only refreshed the autocomplete; Delete and Duplicate had no invalidation.
- **Payment Plan** — two invalidations had elements in the wrong order (no-op); status changes and Create/Edit/Delete never refreshed the list.
- **Feedback / Surveys / Communication** — adding a feedback message used a key matching no reader; create/edit didn't refresh lists.
- **Periodic Data Updates** — a malformed key matched nothing on detail pages; new online edits didn't appear in the list; some cross-list invalidations relied on sort order instead of the correct key.

## Out of scope

Per-endpoint volatility tiers, `select` adoption, a centralized query-key factory, removing redundant per-hook cache config, optimistic updates.

## Verification

- `bun run lint` — clean
- `tsc --noEmit` — no new errors (5 pre-existing errors on unrelated files also exist on `develop`)
- `bun run test` — new `queryCacheUtils` unit tests pass
