### PR TITLE
[HOTFIX] USDC handle photo flex field

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [ "setuptools", "wheel" ]
 
 [project]
 name = "hope"
-version = "4.17.2"
+version = "4.17.3"
 description = "HCT MIS is UNICEF's humanitarian cash transfer platform."
 readme = "README.md"
 license = { text = "None" }

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "4.17.2",
+  "version": "4.17.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/frontend/src/containers/pages/surprise/SurprisePage.tsx
+++ b/src/frontend/src/containers/pages/surprise/SurprisePage.tsx
@@ -44,6 +44,18 @@ const SubHeading = styled(Typography)`
   }
 `;
 
+const Paragraph = styled(Typography)`
+  && {
+    color: #fff;
+    font-size: 16px;
+    font-weight: 300;
+    margin-top: 0;
+    margin-bottom: 16px;
+    opacity: 0.9;
+    padding: 0 16px;
+  }
+`;
+
 const Photo = styled.img`
   width: 100vw;
   max-height: 70vh;
@@ -71,15 +83,24 @@ export function SurprisePage(): ReactElement {
   const [imageSrc, setImageSrc] = useState<string>(surpriseFallback);
   const [heading, setHeading] = useState<string>(DEFAULT_HEADING);
   const [subheading, setSubheading] = useState<string>(DEFAULT_SUBHEADING);
+  const [paragraphs, setParagraphs] = useState<string[]>([]);
 
   useEffect(() => {
     fetch('/api/rest/surprise/')
       .then((res) => res.json())
-      .then((data: { image: string | null; heading: string; subheading: string }) => {
-        if (data.image) setImageSrc(data.image);
-        if (data.heading) setHeading(data.heading);
-        if (data.subheading) setSubheading(data.subheading);
-      })
+      .then(
+        (data: {
+          image: string | null;
+          heading: string;
+          subheading: string;
+          paragraphs?: string[];
+        }) => {
+          if (data.image) setImageSrc(data.image);
+          if (data.heading) setHeading(data.heading);
+          if (data.subheading) setSubheading(data.subheading);
+          if (data.paragraphs) setParagraphs(data.paragraphs);
+        },
+      )
       .catch(() => {
         // keep defaults
       });
@@ -91,6 +112,9 @@ export function SurprisePage(): ReactElement {
         <Logo transparent={false} displayLogoWithoutSubtitle={false} height={160} />
         <Heading>{heading}</Heading>
         <SubHeading>{subheading}</SubHeading>
+        {paragraphs.map((paragraph, index) => (
+          <Paragraph key={index}>{paragraph}</Paragraph>
+        ))}
         <Photo src={imageSrc} alt="A surprise for you" />
         <BackLink to="/login">← Back to login</BackLink>
       </Card>

--- a/src/hope/api/endpoints/surprise.py
+++ b/src/hope/api/endpoints/surprise.py
@@ -1,3 +1,5 @@
+import re
+
 from constance import config
 from django.core.files.storage import default_storage
 from rest_framework.permissions import AllowAny
@@ -13,10 +15,13 @@ class SurprisePageConfigView(APIView):
     def get(self, request: Request) -> Response:
         image_path = config.SURPRISE_PAGE_IMAGE
         image_url = default_storage.url(image_path) if image_path else None
+        raw_body = config.SURPRISE_PAGE_BODY or ""
+        paragraphs = [p.strip() for p in re.split(r"\n\s*\n", raw_body) if p.strip()]
         return Response(
             {
                 "image": image_url,
                 "heading": config.SURPRISE_PAGE_HEADING,
                 "subheading": config.SURPRISE_PAGE_SUBHEADING,
+                "paragraphs": paragraphs,
             }
         )

--- a/src/hope/apps/utils/phone.py
+++ b/src/hope/apps/utils/phone.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, cast
 
 import phonenumbers
 
@@ -27,8 +27,7 @@ def recalculate_phone_numbers_validity(obj: Any) -> Any:
     if obj._state.adding is True:
         # create
         obj = calculate_phone_numbers_validity(obj)
-    current: Any = Individual.all_merge_status_objects.filter(pk=obj.pk).first()
-    if current:
+    elif current := cast("Individual | None", Individual.all_merge_status_objects.filter(pk=obj.pk).first()):
         # update
         if current.phone_no_valid is None or current.phone_no != obj.phone_no:
             obj.phone_no_valid = is_valid_phone_number(str(obj.phone_no))

--- a/src/hope/apps/utils/phone.py
+++ b/src/hope/apps/utils/phone.py
@@ -21,12 +21,14 @@ def calculate_phone_numbers_validity(obj: Any) -> Any:
     return obj
 
 
-def recalculate_phone_numbers_validity(obj: Any, model: type) -> Any:
+def recalculate_phone_numbers_validity(obj: Any) -> Any:
+    from hope.models import Individual
+
     if obj._state.adding is True:
         # create
         obj = calculate_phone_numbers_validity(obj)
-    # Used like this and not as an abstract class because Individual has indexes and ImportedIndividual does not
-    elif current := model.objects.filter(pk=obj.pk).first():
+    current: Any = Individual.all_merge_status_objects.filter(pk=obj.pk).first()
+    if current:
         # update
         if current.phone_no_valid is None or current.phone_no != obj.phone_no:
             obj.phone_no_valid = is_valid_phone_number(str(obj.phone_no))

--- a/src/hope/config/fragments/constance.py
+++ b/src/hope/config/fragments/constance.py
@@ -7,6 +7,10 @@ CONSTANCE_ADDITIONAL_FIELDS = {
         "django.forms.ImageField",
         {"required": False},
     ],
+    "textarea": (
+        "django.forms.fields.CharField",
+        {"required": False, "widget": "django.forms.widgets.Textarea"},
+    ),
     "percentages": (
         "django.forms.fields.IntegerField",
         {
@@ -238,6 +242,11 @@ Clear Cache,clear-cache/
         "Congratulations, explorer.",
         "Subheading shown on the surprise/easter-egg page.",
         str,
+    ),
+    "SURPRISE_PAGE_BODY": (
+        "",
+        "Body text for the surprise/easter-egg page. Separate paragraphs with a blank line.",
+        "textarea",
     ),
     "SURPRISE_PAGE_IMAGE": (
         "",

--- a/src/hope/contrib/aurora/services/base_flex_registration_service.py
+++ b/src/hope/contrib/aurora/services/base_flex_registration_service.py
@@ -1,5 +1,6 @@
 import abc
 import base64
+import binascii
 import hashlib
 import logging
 from typing import TYPE_CHECKING, Any, Iterable
@@ -219,5 +220,9 @@ class BaseRegistrationService(AuroraProcessor, abc.ABC):
         if certificate_picture:
             format_image = "jpg"
             name = hashlib.sha256(document_number.encode()).hexdigest()
-            certificate_picture = ContentFile(base64.b64decode(certificate_picture), name=f"{name}.{format_image}")
+            try:
+                decoded = base64.b64decode(certificate_picture)
+            except (binascii.Error, TypeError, ValueError) as e:
+                raise ValidationError("Invalid image data") from e
+            certificate_picture = ContentFile(decoded, name=f"{name}.{format_image}")
         return certificate_picture

--- a/src/hope/contrib/aurora/services/sri_lanka_flex_registration_service.py
+++ b/src/hope/contrib/aurora/services/sri_lanka_flex_registration_service.py
@@ -14,6 +14,7 @@ from hope.apps.household.const import (
 )
 from hope.apps.periodic_data_update.utils import populate_pdu_with_null_values
 from hope.apps.utils.age_at_registration import calculate_age_at_registration
+from hope.apps.utils.phone import calculate_phone_numbers_validity
 from hope.contrib.aurora.services.base_flex_registration_service import (
     BaseRegistrationService,
 )
@@ -221,7 +222,8 @@ class SriLankaRegistrationService(BaseRegistrationService):
                     },
                 )
             )
-
+        for individual in individuals_to_create:
+            calculate_phone_numbers_validity(individual)
         PendingIndividual.objects.bulk_create(individuals_to_create)
         for individual_data_dict, imported_individual in zip(individuals_list, individuals_to_create, strict=True):
             self._prepare_birth_certificate(individual_data_dict, imported_individual)

--- a/src/hope/contrib/aurora/services/ukraine_flex_registration_service.py
+++ b/src/hope/contrib/aurora/services/ukraine_flex_registration_service.py
@@ -3,6 +3,7 @@ from typing import Any
 import uuid
 
 from django.core.exceptions import ValidationError
+from django.core.files.storage import default_storage
 from django.forms import modelform_factory
 
 from hope.apps.core.utils import (
@@ -353,7 +354,8 @@ class UkraineUSDCRegistrationService(UkraineBaseRegistrationService):
         ),
     }
 
-    INDIVIDUAL_FLEX_FIELDS: list[str] = ["wallet_num_image_i_f", "id_wallet_image_i_f"]
+    INDIVIDUAL_FLEX_FIELDS: list[str] = []
+    INDIVIDUAL_IMAGE_FLEX_FIELDS: list[str] = ["wallet_num_image_i_f", "id_wallet_image_i_f"]
 
     def create_household_for_rdi_household(self, record: Any, registration_data_import: RegistrationDataImport) -> None:
         record_data_dict = record.get_data()
@@ -411,7 +413,12 @@ class UkraineUSDCRegistrationService(UkraineBaseRegistrationService):
     ) -> dict:
         individual_data = super()._prepare_individual_data(individual_dict, household, registration_data_import)
         individual_data["estimated_birth_date"] = False
-        if flex_fields := build_flex_arg_dict_from_list_if_exists(individual_dict, self.INDIVIDUAL_FLEX_FIELDS):
+        flex_fields = build_flex_arg_dict_from_list_if_exists(individual_dict, self.INDIVIDUAL_FLEX_FIELDS)
+        for field_name in self.INDIVIDUAL_IMAGE_FLEX_FIELDS:
+            if image_base64 := individual_dict.get(field_name):
+                image = self._prepare_picture_from_base64(image_base64, f"{field_name}_{uuid.uuid4()}")
+                flex_fields[field_name] = default_storage.save(image.name, image)
+        if flex_fields:
             individual_data["flex_fields"] = flex_fields
         return individual_data
 

--- a/src/hope/contrib/aurora/services/ukraine_flex_registration_service.py
+++ b/src/hope/contrib/aurora/services/ukraine_flex_registration_service.py
@@ -395,6 +395,8 @@ class UkraineUSDCRegistrationService(UkraineBaseRegistrationService):
             )
             individual.phone_no = phone_no
             individual.detail_id = record.source_id
+            if image_flex_fields := self._prepare_wallet_image_flex_fields(individual_dict):
+                individual.flex_fields = image_flex_fields
             individual.save()
         except ValidationError as e:
             raise ValidationError({"individual nr 1": [str(e)]}) from e
@@ -412,14 +414,16 @@ class UkraineUSDCRegistrationService(UkraineBaseRegistrationService):
     ) -> dict:
         individual_data = super()._prepare_individual_data(individual_dict, household, registration_data_import)
         individual_data["estimated_birth_date"] = False
-        flex_fields = {}
+        return individual_data
+
+    def _prepare_wallet_image_flex_fields(self, individual_dict: dict) -> dict:
+        # Decode every blob before writing any to storage, and only after the individual has
+        # validated, so a validation failure or a malformed second image leaves no orphan files.
+        images = {}
         for field_name in self.INDIVIDUAL_IMAGE_FLEX_FIELDS:
             if image_base64 := individual_dict.get(field_name):
-                image = self._prepare_picture_from_base64(image_base64, str(uuid.uuid4()))
-                flex_fields[field_name] = default_storage.save(image.name, image)
-        if flex_fields:
-            individual_data["flex_fields"] = flex_fields
-        return individual_data
+                images[field_name] = self._prepare_picture_from_base64(image_base64, str(uuid.uuid4()))
+        return {field_name: default_storage.save(image.name, image) for field_name, image in images.items()}
 
     def _prepare_accounts(self, individual_dict: dict, individual: PendingIndividual) -> list[PendingAccount]:
         wallet_address = (individual_dict.get("wallet_address_i_c") or "").strip()

--- a/src/hope/contrib/aurora/services/ukraine_flex_registration_service.py
+++ b/src/hope/contrib/aurora/services/ukraine_flex_registration_service.py
@@ -415,7 +415,7 @@ class UkraineUSDCRegistrationService(UkraineBaseRegistrationService):
         flex_fields = {}
         for field_name in self.INDIVIDUAL_IMAGE_FLEX_FIELDS:
             if image_base64 := individual_dict.get(field_name):
-                image = self._prepare_picture_from_base64(image_base64, f"{field_name}_{uuid.uuid4()}")
+                image = self._prepare_picture_from_base64(image_base64, str(uuid.uuid4()))
                 flex_fields[field_name] = default_storage.save(image.name, image)
         if flex_fields:
             individual_data["flex_fields"] = flex_fields

--- a/src/hope/contrib/aurora/services/ukraine_flex_registration_service.py
+++ b/src/hope/contrib/aurora/services/ukraine_flex_registration_service.py
@@ -354,7 +354,6 @@ class UkraineUSDCRegistrationService(UkraineBaseRegistrationService):
         ),
     }
 
-    INDIVIDUAL_FLEX_FIELDS: list[str] = []
     INDIVIDUAL_IMAGE_FLEX_FIELDS: list[str] = ["wallet_num_image_i_f", "id_wallet_image_i_f"]
 
     def create_household_for_rdi_household(self, record: Any, registration_data_import: RegistrationDataImport) -> None:
@@ -413,7 +412,7 @@ class UkraineUSDCRegistrationService(UkraineBaseRegistrationService):
     ) -> dict:
         individual_data = super()._prepare_individual_data(individual_dict, household, registration_data_import)
         individual_data["estimated_birth_date"] = False
-        flex_fields = build_flex_arg_dict_from_list_if_exists(individual_dict, self.INDIVIDUAL_FLEX_FIELDS)
+        flex_fields = {}
         for field_name in self.INDIVIDUAL_IMAGE_FLEX_FIELDS:
             if image_base64 := individual_dict.get(field_name):
                 image = self._prepare_picture_from_base64(image_base64, f"{field_name}_{uuid.uuid4()}")

--- a/src/hope/models/individual.py
+++ b/src/hope/models/individual.py
@@ -681,7 +681,7 @@ class Individual(
         calculate_phone_numbers_validity(self)
 
     def save(self, *args: Any, **kwargs: Any) -> None:
-        recalculate_phone_numbers_validity(self, Individual)
+        recalculate_phone_numbers_validity(self)
         super().save(*args, **kwargs)
 
 

--- a/tests/e2e/new_selenium/registration_data_import/test_usdc_import.py
+++ b/tests/e2e/new_selenium/registration_data_import/test_usdc_import.py
@@ -1,0 +1,151 @@
+import json
+
+from django.utils import timezone
+import pytest
+
+from e2e.new_selenium.conftest import grant_permission
+from extras.test_utils.factories.aurora import (
+    OrganizationFactory,
+    ProjectFactory,
+    RecordFactory,
+    RegistrationFactory,
+)
+from extras.test_utils.factories.core import FlexibleAttributeFactory
+from extras.test_utils.factories.geo import CountryFactory
+from extras.test_utils.factories.household import DocumentTypeFactory
+from extras.test_utils.factories.payment import (
+    AccountTypeFactory,
+    DeliveryMechanismFactory,
+    FinancialInstitutionFactory,
+)
+from extras.test_utils.factories.program import ProgramFactory
+from extras.test_utils.selenium import HopeTestBrowser
+from hope.apps.account.permissions import Permissions
+from hope.apps.core.utils import IDENTIFICATION_TYPE_TO_KEY_MAPPING
+from hope.apps.household.const import IDENTIFICATION_TYPE_TAX_ID
+from hope.contrib.aurora.services.ukraine_flex_registration_service import UkraineUSDCRegistrationService
+from hope.models import (
+    BeneficiaryGroup,
+    BusinessArea,
+    DataCollectingType,
+    DeliveryMechanism,
+    FinancialInstitution,
+    FlexibleAttribute,
+    PendingHousehold,
+    PendingIndividual,
+    Program,
+    RegistrationDataImport,
+    User,
+)
+
+pytestmark = pytest.mark.django_db()
+
+
+@pytest.fixture
+def usdc_import(business_area: BusinessArea, create_super_user: User) -> RegistrationDataImport:
+    business_area.postpone_deduplication = True
+    business_area.save(update_fields=["postpone_deduplication"])
+    CountryFactory(name="Ukraine", short_name="Ukraine", iso_code2="UA", iso_code3="UKR", iso_num="0804")
+    DocumentTypeFactory(
+        key=IDENTIFICATION_TYPE_TO_KEY_MAPPING[IDENTIFICATION_TYPE_TAX_ID],
+        label=IDENTIFICATION_TYPE_TAX_ID,
+    )
+    DeliveryMechanismFactory(
+        code="transfer_to_digital_wallet",
+        name="Transfer to Digital Wallet",
+        transfer_type=DeliveryMechanism.TransferType.DIGITAL,
+        account_type=AccountTypeFactory(key="crypto", label="Crypto"),
+    )
+    FinancialInstitutionFactory(
+        name="Generic Crypto",
+        type=FinancialInstitution.FinancialInstitutionType.OTHER,
+        country=None,
+    )
+    FlexibleAttributeFactory(name="wallet_num_image_i_f", type=FlexibleAttribute.IMAGE)
+    FlexibleAttributeFactory(name="id_wallet_image_i_f", type=FlexibleAttribute.IMAGE)
+
+    program = ProgramFactory(
+        name="USDC Program",
+        code="USDC",
+        status=Program.ACTIVE,
+        business_area=business_area,
+        data_collecting_type=DataCollectingType.objects.get(code="full"),
+        beneficiary_group=BeneficiaryGroup.objects.filter(name="Main Menu").first(),
+    )
+    organization = OrganizationFactory(business_area=business_area, slug=business_area.slug)
+    project = ProjectFactory(organization=organization, programme=program)
+    registration = RegistrationFactory(project=project)
+    registration.rdi_parser = UkraineUSDCRegistrationService
+    registration.save()
+
+    record = RecordFactory(
+        registration=registration.source_id,
+        timestamp=timezone.now(),
+        source_id=1,
+        fields={
+            "consent": [{"consent_h_c": ["1"]}],
+            "individual_details": [
+                {
+                    "given_name_i_c": "Testina",
+                    "middle_name_i_c": "Fakeivna",
+                    "family_name_i_c": "Sampleenko",
+                    "birth_date": "1991-03-07",
+                    "gender_i_c": "female",
+                    "phone_no_i_c": "0501234567",
+                    "tax_id_no_i_c": "1112223334",
+                    "wallet_address_i_c": "0xFAKE0000DEADBEEF",
+                    "wallet_name_i_c": "TestWallet",
+                    "wallet_num_image_i_f": "d2FsbGV0X251bV9pbWFnZQ==",
+                    "id_wallet_image_i_f": "aWRfd2FsbGV0X2ltYWdl",
+                }
+            ],
+        },
+        files=json.dumps({}).encode(),
+    )
+
+    service = UkraineUSDCRegistrationService(registration)
+    rdi = service.create_rdi(create_super_user, "usdc rdi")
+    service.process_records(rdi.id, [record.id])
+    rdi.status = RegistrationDataImport.IN_REVIEW
+    rdi.save(update_fields=["status"])
+
+    return rdi
+
+
+def test_usdc_import_detail_pages_render_and_rdi_merges(
+    browser: HopeTestBrowser,
+    user_with_no_permissions: User,
+    business_area: BusinessArea,
+    usdc_import: RegistrationDataImport,
+) -> None:
+    rdi = usdc_import
+    program = rdi.program
+    individual = PendingIndividual.objects.get(registration_data_import=rdi)
+    household = PendingHousehold.objects.get(registration_data_import=rdi)
+
+    with grant_permission(
+        user_with_no_permissions,
+        business_area,
+        Permissions.RDI_VIEW_LIST,
+        Permissions.RDI_VIEW_DETAILS,
+        Permissions.RDI_MERGE_IMPORT,
+        Permissions.POPULATION_VIEW_INDIVIDUALS_DETAILS,
+        Permissions.POPULATION_VIEW_INDIVIDUALS_LIST,
+        Permissions.POPULATION_VIEW_HOUSEHOLDS_DETAILS,
+        Permissions.PROGRAMME_VIEW_LIST_AND_DETAILS,
+        Permissions.GRIEVANCES_VIEW_LIST_EXCLUDING_SENSITIVE,
+        Permissions.GRIEVANCES_VIEW_LIST_SENSITIVE,
+    ):
+        browser.login(username="noperm_user", password="testtest2")
+
+        browser.open(f"/{business_area.slug}/programs/{program.code}/population/individuals/{individual.id}")
+        browser.wait_for_element_visible('h5[data-cy="page-header-title"]')
+        browser.assert_text(individual.full_name, 'div[data-cy="label-Full Name"]')
+
+        browser.open(f"/{business_area.slug}/programs/{program.code}/population/household/{household.id}")
+        browser.wait_for_element_visible('h5[data-cy="page-header-title"]')
+
+        browser.open(f"/{business_area.slug}/programs/{program.code}/registration-data-import/{rdi.id}")
+        browser.wait_for_element_clickable('button[data-cy="button-merge-rdi"]').click()
+        browser.wait_for_element_clickable('button[data-cy="button-merge"]').click()
+        browser.assert_text("MERGED", 'div[data-cy="label-status"]')

--- a/tests/unit/api/test_surprise.py
+++ b/tests/unit/api/test_surprise.py
@@ -28,11 +28,13 @@ def test_get_returns_defaults(anon_client: APIClient, surprise_url: str) -> None
         mock_config.SURPRISE_PAGE_IMAGE = ""
         mock_config.SURPRISE_PAGE_HEADING = "🎉 You found a secret!"
         mock_config.SURPRISE_PAGE_SUBHEADING = "Congratulations, explorer."
+        mock_config.SURPRISE_PAGE_BODY = ""
         response = anon_client.get(surprise_url)
     data = response.json()
     assert data["image"] is None
     assert data["heading"] == "🎉 You found a secret!"
     assert data["subheading"] == "Congratulations, explorer."
+    assert data["paragraphs"] == []
 
 
 def test_get_returns_custom_text(anon_client: APIClient, surprise_url: str) -> None:
@@ -40,6 +42,7 @@ def test_get_returns_custom_text(anon_client: APIClient, surprise_url: str) -> N
         mock_config.SURPRISE_PAGE_IMAGE = ""
         mock_config.SURPRISE_PAGE_HEADING = "Hello!"
         mock_config.SURPRISE_PAGE_SUBHEADING = "You made it."
+        mock_config.SURPRISE_PAGE_BODY = ""
         response = anon_client.get(surprise_url)
     data = response.json()
     assert data["heading"] == "Hello!"
@@ -52,8 +55,39 @@ def test_get_returns_image_url_when_image_set(anon_client: APIClient, surprise_u
         mock_config.SURPRISE_PAGE_IMAGE = "surprise/photo.png"
         mock_config.SURPRISE_PAGE_HEADING = "🎉 You found a secret!"
         mock_config.SURPRISE_PAGE_SUBHEADING = "Congratulations, explorer."
+        mock_config.SURPRISE_PAGE_BODY = ""
         response = anon_client.get(surprise_url)
     data = response.json()
     assert data["image"] is not None
     assert data["image"].startswith("/")
     assert "surprise/photo.png" in data["image"]
+
+
+def test_get_returns_empty_paragraphs_when_body_blank(anon_client: APIClient, surprise_url: str) -> None:
+    with patch("hope.api.endpoints.surprise.config") as mock_config:
+        mock_config.SURPRISE_PAGE_IMAGE = ""
+        mock_config.SURPRISE_PAGE_HEADING = "🎉 You found a secret!"
+        mock_config.SURPRISE_PAGE_SUBHEADING = "Congratulations, explorer."
+        mock_config.SURPRISE_PAGE_BODY = "   \n  \n  "
+        response = anon_client.get(surprise_url)
+    assert response.json()["paragraphs"] == []
+
+
+def test_get_returns_single_paragraph(anon_client: APIClient, surprise_url: str) -> None:
+    with patch("hope.api.endpoints.surprise.config") as mock_config:
+        mock_config.SURPRISE_PAGE_IMAGE = ""
+        mock_config.SURPRISE_PAGE_HEADING = "🎉 You found a secret!"
+        mock_config.SURPRISE_PAGE_SUBHEADING = "Congratulations, explorer."
+        mock_config.SURPRISE_PAGE_BODY = "Just one line.\nStill the same paragraph."
+        response = anon_client.get(surprise_url)
+    assert response.json()["paragraphs"] == ["Just one line.\nStill the same paragraph."]
+
+
+def test_get_splits_paragraphs_on_blank_lines(anon_client: APIClient, surprise_url: str) -> None:
+    with patch("hope.api.endpoints.surprise.config") as mock_config:
+        mock_config.SURPRISE_PAGE_IMAGE = ""
+        mock_config.SURPRISE_PAGE_HEADING = "🎉 You found a secret!"
+        mock_config.SURPRISE_PAGE_SUBHEADING = "Congratulations, explorer."
+        mock_config.SURPRISE_PAGE_BODY = "\n\nFirst paragraph.\n\n  \n\nSecond paragraph.\n\n"
+        response = anon_client.get(surprise_url)
+    assert response.json()["paragraphs"] == ["First paragraph.", "Second paragraph."]

--- a/tests/unit/apps/aurora/test_czech_republic_registration_service.py
+++ b/tests/unit/apps/aurora/test_czech_republic_registration_service.py
@@ -445,3 +445,16 @@ def test_create_household_with_existing_admin_areas_fails_on_p_code_assignment(
 
     with pytest.raises(ValidationError, match="is not a valid UUID"):
         service.create_household_for_rdi_household(record, rdi)
+
+
+def test_phone_number_validity_reflects_number(czech_context: dict) -> None:
+    registration = czech_context["registration"]
+    record = czech_context["record"]
+    user = czech_context["user"]
+
+    service = CzechRepublicFlexRegistration(registration)
+    rdi = service.create_rdi(user, f"czech_republic rdi {datetime.datetime.now()}")
+    service.process_records(rdi.id, [record.id])
+
+    assert PendingIndividual.objects.get(full_name="Tetiana Symkanych").phone_no_valid is True
+    assert PendingIndividual.objects.get(full_name="Ivan Drago").phone_no_valid is False

--- a/tests/unit/apps/aurora/test_sri_lanka_registration_service.py
+++ b/tests/unit/apps/aurora/test_sri_lanka_registration_service.py
@@ -240,3 +240,39 @@ def test_import_record_twice(
     service.process_records(rdi.id, [sri_lanka_records[0].id])
     sri_lanka_records[0].refresh_from_db()
     assert PendingHousehold.objects.count() == 1
+
+
+def test_collector_phone_number_marked_valid(
+    registration: Any,
+    user: Any,
+    program: Program,
+    sri_lanka_country: Any,
+    national_id_document_type: Any,
+    sri_lanka_records: list[Record],
+) -> None:
+    service = SriLankaRegistrationService(registration)
+    rdi = service.create_rdi(user, f"sri_lanka rdi {datetime.datetime.now()}")
+    records_ids = [record.id for record in sri_lanka_records]
+    service.process_records(rdi.id, records_ids)
+
+    assert PendingIndividual.objects.get(full_name="Dome").phone_no_valid is True
+
+
+def test_child_phone_number_marked_invalid(
+    registration: Any,
+    user: Any,
+    program: Program,
+    sri_lanka_country: Any,
+    national_id_document_type: Any,
+    sri_lanka_records: list[Record],
+) -> None:
+    record = sri_lanka_records[0]
+    record.fields["children-info"][0]["full_name_i_c"] = "Nevalidova"
+    record.fields["children-info"][0]["phone_no_i_c"] = "123"
+    record.save(update_fields=["fields"])
+
+    service = SriLankaRegistrationService(registration)
+    rdi = service.create_rdi(user, f"sri_lanka rdi {datetime.datetime.now()}")
+    service.process_records(rdi.id, [record.id])
+
+    assert PendingIndividual.objects.get(full_name="Nevalidova").phone_no_valid is False

--- a/tests/unit/apps/aurora/test_ukraine_usdc_registration_service.py
+++ b/tests/unit/apps/aurora/test_ukraine_usdc_registration_service.py
@@ -625,3 +625,46 @@ def test_reimporting_same_record_does_not_duplicate_household(
     service.process_records(rdi.id, [usdc_record.id])
 
     assert PendingHousehold.objects.filter(registration_data_import=rdi).count() == 1
+
+
+def test_malformed_wallet_image_rejects_record_without_killing_batch(
+    registration: Any,
+    user: Any,
+    ukraine_country: Any,
+    tax_id_document_type: Any,
+    digital_wallet_delivery_mechanism: DeliveryMechanism,
+    usdc_record: Record,
+) -> None:
+    usdc_record.fields["individual_details"][0]["wallet_num_image_i_f"] = "abcde"
+    usdc_record.save(update_fields=["fields"])
+    service = UkraineUSDCRegistrationService(registration)
+    rdi = service.create_rdi(user, "usdc rdi")
+
+    service.process_records(rdi.id, [usdc_record.id])
+
+    usdc_record.refresh_from_db()
+    assert usdc_record.status == Record.STATUS_ERROR
+    assert not PendingHousehold.objects.filter(registration_data_import=rdi).exists()
+
+
+def test_failed_individual_validation_leaves_no_orphan_images(
+    registration: Any,
+    user: Any,
+    ukraine_country: Any,
+    tax_id_document_type: Any,
+    digital_wallet_delivery_mechanism: DeliveryMechanism,
+    usdc_record: Record,
+    settings: Any,
+    tmp_path: Any,
+) -> None:
+    settings.MEDIA_ROOT = str(tmp_path)
+    usdc_record.fields["individual_details"][0]["birth_date"] = "1990-99-99"
+    usdc_record.save(update_fields=["fields"])
+    service = UkraineUSDCRegistrationService(registration)
+    rdi = service.create_rdi(user, "usdc rdi")
+
+    service.process_records(rdi.id, [usdc_record.id])
+
+    usdc_record.refresh_from_db()
+    assert usdc_record.status == Record.STATUS_ERROR
+    assert list(tmp_path.iterdir()) == []

--- a/tests/unit/apps/aurora/test_ukraine_usdc_registration_service.py
+++ b/tests/unit/apps/aurora/test_ukraine_usdc_registration_service.py
@@ -2,12 +2,17 @@ import datetime
 import json
 from typing import Any
 
+from django.core.files.storage import default_storage
 from django.utils import timezone
 import pytest
 
 from extras.test_utils.factories.account import UserFactory
 from extras.test_utils.factories.aurora import OrganizationFactory, ProjectFactory, RecordFactory, RegistrationFactory
-from extras.test_utils.factories.core import BusinessAreaFactory, DataCollectingTypeFactory
+from extras.test_utils.factories.core import (
+    BusinessAreaFactory,
+    DataCollectingTypeFactory,
+    FlexibleAttributeFactory,
+)
 from extras.test_utils.factories.geo import CountryFactory
 from extras.test_utils.factories.household import DocumentTypeFactory
 from extras.test_utils.factories.payment import (
@@ -16,7 +21,7 @@ from extras.test_utils.factories.payment import (
     FinancialInstitutionFactory,
 )
 from extras.test_utils.factories.program import ProgramFactory
-from hope.apps.core.utils import IDENTIFICATION_TYPE_TO_KEY_MAPPING
+from hope.apps.core.utils import IDENTIFICATION_TYPE_TO_KEY_MAPPING, resolve_flex_fields_choices_to_string
 from hope.apps.household.const import IDENTIFICATION_TYPE_TAX_ID, ROLE_PRIMARY
 from hope.contrib.aurora.models import Record
 from hope.contrib.aurora.services.ukraine_flex_registration_service import UkraineUSDCRegistrationService
@@ -24,6 +29,7 @@ from hope.models import (
     DataCollectingType,
     DeliveryMechanism,
     FinancialInstitution,
+    FlexibleAttribute,
     PendingAccount,
     PendingDocument,
     PendingHousehold,
@@ -219,7 +225,7 @@ def test_wallet_stored_on_account(
     assert account.data == {"wallet_address": "0xABCDEF0123456789", "wallet_name": "MetaMask"}
 
 
-def test_wallet_images_stored_as_flex_fields(
+def test_wallet_images_stored_as_saved_files(
     registration: Any,
     user: Any,
     ukraine_country: Any,
@@ -233,8 +239,33 @@ def test_wallet_images_stored_as_flex_fields(
     service.process_records(rdi.id, [usdc_record.id])
 
     individual = PendingIndividual.objects.get(registration_data_import=rdi)
-    assert individual.flex_fields["wallet_num_image_i_f"] == "d2FsbGV0X251bV9pbWFnZQ=="
-    assert individual.flex_fields["id_wallet_image_i_f"] == "aWRfd2FsbGV0X2ltYWdl"
+    num_image_path = individual.flex_fields["wallet_num_image_i_f"]
+    id_image_path = individual.flex_fields["id_wallet_image_i_f"]
+    assert num_image_path.endswith(".jpg")
+    assert default_storage.exists(num_image_path)
+    assert default_storage.exists(id_image_path)
+
+
+def test_individual_detail_flex_image_resolves_to_url(
+    registration: Any,
+    user: Any,
+    ukraine_country: Any,
+    tax_id_document_type: Any,
+    digital_wallet_delivery_mechanism: DeliveryMechanism,
+    usdc_record: Record,
+) -> None:
+    FlexibleAttributeFactory(name="wallet_num_image_i_f", type=FlexibleAttribute.IMAGE)
+    FlexibleAttributeFactory(name="id_wallet_image_i_f", type=FlexibleAttribute.IMAGE)
+    service = UkraineUSDCRegistrationService(registration)
+    rdi = service.create_rdi(user, "usdc rdi")
+
+    service.process_records(rdi.id, [usdc_record.id])
+
+    individual = PendingIndividual.objects.get(registration_data_import=rdi)
+    resolved = resolve_flex_fields_choices_to_string(individual)
+
+    assert resolved["wallet_num_image_i_f"].endswith(".jpg")
+    assert resolved["id_wallet_image_i_f"].endswith(".jpg")
 
 
 def test_creates_only_tax_id_document(

--- a/tests/unit/apps/aurora/test_ukraine_usdc_registration_service.py
+++ b/tests/unit/apps/aurora/test_ukraine_usdc_registration_service.py
@@ -466,3 +466,39 @@ def test_no_wallet_account_when_address_missing(
 
     individual = PendingIndividual.objects.get(registration_data_import=rdi)
     assert not PendingAccount.objects.filter(individual=individual).exists()
+
+
+def test_head_of_household_phone_number_marked_valid(
+    registration: Any,
+    user: Any,
+    ukraine_country: Any,
+    tax_id_document_type: Any,
+    digital_wallet_delivery_mechanism: DeliveryMechanism,
+    usdc_record: Record,
+) -> None:
+    service = UkraineUSDCRegistrationService(registration)
+    rdi = service.create_rdi(user, "usdc rdi")
+
+    service.process_records(rdi.id, [usdc_record.id])
+
+    individual = PendingIndividual.objects.get(registration_data_import=rdi)
+    assert individual.phone_no_valid is True
+
+
+def test_head_of_household_phone_number_marked_invalid(
+    registration: Any,
+    user: Any,
+    ukraine_country: Any,
+    tax_id_document_type: Any,
+    digital_wallet_delivery_mechanism: DeliveryMechanism,
+    usdc_record: Record,
+) -> None:
+    usdc_record.fields["individual_details"][0]["phone_no_i_c"] = "123"
+    usdc_record.save(update_fields=["fields"])
+    service = UkraineUSDCRegistrationService(registration)
+    rdi = service.create_rdi(user, "usdc rdi")
+
+    service.process_records(rdi.id, [usdc_record.id])
+
+    individual = PendingIndividual.objects.get(registration_data_import=rdi)
+    assert individual.phone_no_valid is False

--- a/tests/unit/apps/aurora/test_ukraine_usdc_registration_service.py
+++ b/tests/unit/apps/aurora/test_ukraine_usdc_registration_service.py
@@ -502,3 +502,126 @@ def test_head_of_household_phone_number_marked_invalid(
 
     individual = PendingIndividual.objects.get(registration_data_import=rdi)
     assert individual.phone_no_valid is False
+
+
+def test_no_flex_fields_when_wallet_images_missing(
+    registration: Any,
+    user: Any,
+    ukraine_country: Any,
+    tax_id_document_type: Any,
+    digital_wallet_delivery_mechanism: DeliveryMechanism,
+    usdc_record: Record,
+) -> None:
+    usdc_record.fields["individual_details"][0].pop("wallet_num_image_i_f")
+    usdc_record.fields["individual_details"][0].pop("id_wallet_image_i_f")
+    usdc_record.save(update_fields=["fields"])
+    service = UkraineUSDCRegistrationService(registration)
+    rdi = service.create_rdi(user, "usdc rdi")
+
+    service.process_records(rdi.id, [usdc_record.id])
+
+    individual = PendingIndividual.objects.get(registration_data_import=rdi)
+    assert individual.flex_fields == {}
+
+
+def test_only_present_wallet_image_stored(
+    registration: Any,
+    user: Any,
+    ukraine_country: Any,
+    tax_id_document_type: Any,
+    digital_wallet_delivery_mechanism: DeliveryMechanism,
+    usdc_record: Record,
+) -> None:
+    usdc_record.fields["individual_details"][0].pop("id_wallet_image_i_f")
+    usdc_record.save(update_fields=["fields"])
+    service = UkraineUSDCRegistrationService(registration)
+    rdi = service.create_rdi(user, "usdc rdi")
+
+    service.process_records(rdi.id, [usdc_record.id])
+
+    individual = PendingIndividual.objects.get(registration_data_import=rdi)
+    assert "id_wallet_image_i_f" not in individual.flex_fields
+    assert individual.flex_fields["wallet_num_image_i_f"].endswith(".jpg")
+    assert default_storage.exists(individual.flex_fields["wallet_num_image_i_f"])
+
+
+def test_rejects_record_with_no_individuals(
+    registration: Any,
+    user: Any,
+    ukraine_country: Any,
+    tax_id_document_type: Any,
+    digital_wallet_delivery_mechanism: DeliveryMechanism,
+    submission_timestamp: datetime.datetime,
+) -> None:
+    record = RecordFactory(
+        registration=registration.source_id,
+        timestamp=submission_timestamp,
+        source_id=9,
+        fields={"consent": [{"consent_h_c": ["1"]}], "individual_details": []},
+        files=json.dumps({}).encode(),
+    )
+    service = UkraineUSDCRegistrationService(registration)
+    rdi = service.create_rdi(user, "usdc rdi")
+
+    service.process_records(rdi.id, [record.id])
+
+    record.refresh_from_db()
+    assert record.status == Record.STATUS_ERROR
+    assert not PendingHousehold.objects.filter(registration_data_import=rdi).exists()
+
+
+def test_wallet_account_created_when_name_missing(
+    registration: Any,
+    user: Any,
+    ukraine_country: Any,
+    tax_id_document_type: Any,
+    digital_wallet_delivery_mechanism: DeliveryMechanism,
+    usdc_record: Record,
+) -> None:
+    usdc_record.fields["individual_details"][0].pop("wallet_name_i_c")
+    usdc_record.save(update_fields=["fields"])
+    service = UkraineUSDCRegistrationService(registration)
+    rdi = service.create_rdi(user, "usdc rdi")
+
+    service.process_records(rdi.id, [usdc_record.id])
+
+    individual = PendingIndividual.objects.get(registration_data_import=rdi)
+    account = PendingAccount.objects.get(individual=individual)
+    assert account.number == "0xABCDEF0123456789"
+    assert account.data == {"wallet_address": "0xABCDEF0123456789", "wallet_name": ""}
+
+
+def test_detail_id_links_household_and_individual_to_source_record(
+    registration: Any,
+    user: Any,
+    ukraine_country: Any,
+    tax_id_document_type: Any,
+    digital_wallet_delivery_mechanism: DeliveryMechanism,
+    usdc_record: Record,
+) -> None:
+    service = UkraineUSDCRegistrationService(registration)
+    rdi = service.create_rdi(user, "usdc rdi")
+
+    service.process_records(rdi.id, [usdc_record.id])
+
+    household = PendingHousehold.objects.get(registration_data_import=rdi)
+    individual = PendingIndividual.objects.get(registration_data_import=rdi)
+    assert household.detail_id == str(usdc_record.source_id)
+    assert individual.detail_id == str(usdc_record.source_id)
+
+
+def test_reimporting_same_record_does_not_duplicate_household(
+    registration: Any,
+    user: Any,
+    ukraine_country: Any,
+    tax_id_document_type: Any,
+    digital_wallet_delivery_mechanism: DeliveryMechanism,
+    usdc_record: Record,
+) -> None:
+    service = UkraineUSDCRegistrationService(registration)
+    rdi = service.create_rdi(user, "usdc rdi")
+
+    service.process_records(rdi.id, [usdc_record.id])
+    service.process_records(rdi.id, [usdc_record.id])
+
+    assert PendingHousehold.objects.filter(registration_data_import=rdi).count() == 1

--- a/tests/unit/apps/aurora/test_ukrainian_registration_service.py
+++ b/tests/unit/apps/aurora/test_ukrainian_registration_service.py
@@ -357,3 +357,36 @@ def test_registration_2024_import_data_to_datahub(
         "low_income_hh_h_f": True,
         "single_headed_hh_h_f": False,
     }
+
+
+def test_head_of_household_phone_number_marked_valid(
+    registration: Any,
+    user: Any,
+    ukraine_country: Any,
+    ukraine_admin_areas: dict[str, Any],
+    tax_id_document_type: Any,
+    ukraine_records: dict[str, list[Record]],
+) -> None:
+    service = UkraineBaseRegistrationService(registration)
+    rdi = service.create_rdi(user, f"ukraine rdi {datetime.datetime.now()}")
+    service.process_records(rdi.id, [ukraine_records["records"][0].id])
+
+    assert PendingIndividual.objects.get(family_name="Romaniak").phone_no_valid is True
+
+
+def test_head_of_household_phone_number_marked_invalid(
+    registration: Any,
+    user: Any,
+    ukraine_country: Any,
+    ukraine_admin_areas: dict[str, Any],
+    tax_id_document_type: Any,
+    ukraine_records: dict[str, list[Record]],
+) -> None:
+    record = ukraine_records["records"][1]
+    record.fields["individuals"][0]["phone_no_i_c"] = "123"
+    record.save(update_fields=["fields"])
+    service = UkraineBaseRegistrationService(registration)
+    rdi = service.create_rdi(user, f"ukraine rdi {datetime.datetime.now()}")
+    service.process_records(rdi.id, [record.id])
+
+    assert PendingIndividual.objects.get(family_name="Lamiący").phone_no_valid is False

--- a/uv.lock
+++ b/uv.lock
@@ -1928,7 +1928,7 @@ wheels = [
 
 [[package]]
 name = "hope"
-version = "4.17.2"
+version = "4.17.3"
 source = { editable = "." }
 dependencies = [
     { name = "black" },


### PR DESCRIPTION
  The USDC registration is the first Aurora import to include image-type flex fields (wallet_num_image_i_f, id_wallet_image_i_f). The existing code treated them as ordinary flex fields and copied the raw base64 submission value into flex_fields.                                  
                                                                                                                                                                                                                                                                                                                             
The import itself succeeded — the household and individual were created correctly — but the API serializer resolves IMAGE-type flex fields via default_storage.url(value), which expects a storage path. Given a base64 blob instead, the individual detail page returned a 500.                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                             
  What changed                                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                             
  - Split the wallet image fields into a dedicated INDIVIDUAL_IMAGE_FLEX_FIELDS list so they're handled as images rather than copied verbatim.                                                                                                                                                                               
  - For each image field, decode the base64 and save it through default_storage, storing the returned path — the same mechanism documents already use (_prepare_picture_from_base64).   
  
  
## Also fixed: phone number validity not set on Aurora imports                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                             
  Imported individuals had `phone_no_valid` and `phone_no_alternative_valid` left unset (`None`).                                                                                 
                                                                                                                                                                                                                                                                                                                             
  This was a regression from the datahub removal. Pending import records used to live in a separate `ImportedIndividual` model, and `recalculate_phone_numbers_validity` took a `model` argument so each caller could pass the model that applied. Once the datahub was removed and `ImportedIndividual` was folded into     
  `Individual` — pending versus merged is now just `rdi_merge_status` — the helper was left looking up the existing row through `Individual.objects`, which is the MERGED-only manager (`SoftDeletableMergedManager`). Import records are PENDING, so that lookup found nothing on the update path, the branch was skipped,  
  and validity was never recomputed. The fix switches the lookup to `all_merge_status_objects` (MERGED + PENDING) and drops the now-unused `model` parameter, since `Individual.save` is the only caller.                                                                                                                    
                                                                                                                                                                                                                                                                                                                             
  Sri Lanka had a second, unrelated cause: it creates individuals with `bulk_create`, which bypasses the model's `save()` hook entirely, so validity was never calculated there at all. The fix adds an explicit `calculate_phone_numbers_validity` pass before the bulk insert.                                             
                                                                                                                                                                                                                                                                                                                             
  Added valid and invalid phone-number tests across the affected Aurora services (USDC, Ukraine, Czech Republic, and Sri Lanka).                                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                      
## Also fixed: Aurora image handling

A malformed image no longer aborts the whole batch. - `_prepare_picture_from_base64` called `base64.b64decode` unguarded, so a truncated or malformed blob raised `binascii.Error` — not a `ValidationError` — which escaped the per-record handler. It now raises `ValidationError`, so a bad image fails only its own record. The guard lives in the shared base helper, so it covers every Aurora service (base flex, Czech, generic, Nigeria, Sri Lanka, Ukraine/USDC).                                                
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                              