### PR TITLE
Action on retry task terminal failure

### DIFF
--- a/src/hope/apps/core/celery_tasks.py
+++ b/src/hope/apps/core/celery_tasks.py
@@ -2,7 +2,6 @@ from datetime import timedelta
 import logging
 from typing import Any
 
-from celery.exceptions import Retry
 from django.apps import apps
 from django.conf import settings
 from django.utils import timezone
@@ -189,19 +188,15 @@ def async_retry_job_task(
         }
         job.save(update_fields=["errors"])
         logger.exception(f"Async retry job action failed for job {job.pk} ({job.action})")
-        try:
-            raise self.retry(exc=exc)
-        except Retry:
+        if self.request.retries >= self.max_retries:  # retries exhausted — give up
+            action = job.config.get("on_failure_action")
+            if action:
+                try:
+                    import_string(action)(job, exc)
+                except Exception:
+                    logger.exception("on_failure_action %s failed (job %s)", action, job.pk)
             raise
-        except Exception as raised:
-            if raised is exc:  # retries exhausted — Celery re-raised the original exc
-                action = job.config.get("on_failure_action")
-                if action:
-                    try:
-                        import_string(action)(job, exc)
-                    except Exception:
-                        logger.exception("on_failure_action %s failed (job %s)", action, job.pk)
-            raise
+        raise self.retry(exc=exc)
 
 
 def recover_missing_async_jobs_async_task_action(

--- a/src/hope/apps/core/celery_tasks.py
+++ b/src/hope/apps/core/celery_tasks.py
@@ -2,9 +2,11 @@ from datetime import timedelta
 import logging
 from typing import Any
 
+from celery.exceptions import Retry
 from django.apps import apps
 from django.conf import settings
 from django.utils import timezone
+from django.utils.module_loading import import_string
 from sentry_sdk import set_tag
 
 from hope.apps.core.celery import app
@@ -187,7 +189,19 @@ def async_retry_job_task(
         }
         job.save(update_fields=["errors"])
         logger.exception(f"Async retry job action failed for job {job.pk} ({job.action})")
-        raise self.retry(exc=exc)
+        try:
+            raise self.retry(exc=exc)
+        except Retry:
+            raise
+        except Exception as raised:
+            if raised is exc:  # retries exhausted — Celery re-raised the original exc
+                action = job.config.get("on_failure_action")
+                if action:
+                    try:
+                        import_string(action)(job, exc)
+                    except Exception:
+                        logger.exception("on_failure_action %s failed (job %s)", action, job.pk)
+            raise
 
 
 def recover_missing_async_jobs_async_task_action(

--- a/tests/unit/apps/core/test_celery_tasks.py
+++ b/tests/unit/apps/core/test_celery_tasks.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 from unittest.mock import MagicMock, PropertyMock, patch
 
-from celery.exceptions import MaxRetriesExceededError, Retry
+from celery.exceptions import Retry
 from django.utils import timezone
 import pytest
 
@@ -38,11 +38,6 @@ def fake_async_retry_job_failure_action(job: AsyncRetryJob) -> None:
 
 def fake_async_retry_job_non_retriable_action(job: AsyncRetryJob) -> None:
     raise NonRetriableTaskError("permanent failure")
-
-
-def reraise_retry_exc(*args: object, exc: Exception, **kwargs: object) -> None:
-    # Simulates Celery re-raising the original exc on retry exhaustion (self.retry(exc=exc)).
-    raise exc
 
 
 ON_FAILURE_ACTION = "unit.apps.core.on_failure_handlers.record_failure"
@@ -707,11 +702,9 @@ def test_async_retry_job_task_preserves_partial_errors_on_failure(mock_retry) ->
 
 @pytest.mark.django_db
 @patch("hope.apps.core.celery_tasks.import_string", create=True)
-@patch("hope.apps.core.celery_tasks.async_retry_job_task.retry")
-def test_async_retry_job_task_fires_on_failure_action_when_retries_exhausted(mock_retry, mock_import_string) -> None:
+def test_async_retry_job_task_fires_on_failure_action_when_retries_exhausted(mock_import_string) -> None:
     handler = MagicMock()
     mock_import_string.return_value = handler
-    mock_retry.side_effect = reraise_retry_exc
 
     job = AsyncRetryJob.queue_task(
         action="unit.apps.core.test_celery_tasks.fake_async_retry_job_failure_action",
@@ -719,48 +712,40 @@ def test_async_retry_job_task_fires_on_failure_action_when_retries_exhausted(moc
     )
 
     with pytest.raises(Exception, match="sync failed") as exc_info:
-        async_retry_job_task.run(job._meta.label_lower, job.pk, job.version)
+        async_retry_job_task.apply((job._meta.label_lower, job.pk, job.version)).get()
 
     mock_import_string.assert_called_once_with(ON_FAILURE_ACTION)
     handler.assert_called_once_with(job, exc_info.value)
     job.refresh_from_db()
     assert job.errors == {"exception": "sync failed"}
-    mock_retry.assert_called_once()
 
 
 @pytest.mark.django_db
 @patch("hope.apps.core.celery_tasks.import_string", create=True)
-@patch("hope.apps.core.celery_tasks.async_retry_job_task.retry")
-def test_async_retry_job_task_does_not_fire_on_failure_action_while_retries_remain(
-    mock_retry, mock_import_string
-) -> None:
-    mock_retry.side_effect = Retry("retry")
-
+def test_async_retry_job_task_does_not_fire_on_failure_action_while_retries_remain(mock_import_string) -> None:
     job = AsyncRetryJob.queue_task(
         action="unit.apps.core.test_celery_tasks.fake_async_retry_job_failure_action",
         config={"on_failure_action": ON_FAILURE_ACTION},
     )
 
-    with pytest.raises(Retry):
-        async_retry_job_task.run(job._meta.label_lower, job.pk, job.version)
+    # Fail once then succeed: the task retries but never exhausts, so the hook must stay quiet.
+    with patch.object(AsyncRetryJob, "execute", side_effect=[Exception("sync failed"), None]):
+        result = async_retry_job_task.apply((job._meta.label_lower, job.pk, job.version))
 
+    assert result.successful()
     mock_import_string.assert_not_called()
-    mock_retry.assert_called_once()
 
 
 @pytest.mark.django_db
 @patch("hope.apps.core.celery_tasks.import_string", create=True)
-@patch("hope.apps.core.celery_tasks.async_retry_job_task.retry")
-def test_async_retry_job_task_no_on_failure_action_configured_is_noop(mock_retry, mock_import_string) -> None:
-    mock_retry.side_effect = reraise_retry_exc
-
+def test_async_retry_job_task_no_on_failure_action_configured_is_noop(mock_import_string) -> None:
     job = AsyncRetryJob.queue_task(
         action="unit.apps.core.test_celery_tasks.fake_async_retry_job_failure_action",
         config={},
     )
 
     with pytest.raises(Exception, match="sync failed"):
-        async_retry_job_task.run(job._meta.label_lower, job.pk, job.version)
+        async_retry_job_task.apply((job._meta.label_lower, job.pk, job.version)).get()
 
     mock_import_string.assert_not_called()
     job.refresh_from_db()
@@ -770,13 +755,11 @@ def test_async_retry_job_task_no_on_failure_action_configured_is_noop(mock_retry
 @pytest.mark.django_db
 @patch("hope.apps.core.celery_tasks.logger")
 @patch("hope.apps.core.celery_tasks.import_string", create=True)
-@patch("hope.apps.core.celery_tasks.async_retry_job_task.retry")
 def test_async_retry_job_task_failing_on_failure_action_is_logged_and_original_exc_reraised(
-    mock_retry, mock_import_string, mock_logger
+    mock_import_string, mock_logger
 ) -> None:
     failing_handler = MagicMock(side_effect=Exception("handler boom"))
     mock_import_string.return_value = failing_handler
-    mock_retry.side_effect = reraise_retry_exc
 
     job = AsyncRetryJob.queue_task(
         action="unit.apps.core.test_celery_tasks.fake_async_retry_job_failure_action",
@@ -784,7 +767,7 @@ def test_async_retry_job_task_failing_on_failure_action_is_logged_and_original_e
     )
 
     with pytest.raises(Exception, match="sync failed") as exc_info:
-        async_retry_job_task.run(job._meta.label_lower, job.pk, job.version)
+        async_retry_job_task.apply((job._meta.label_lower, job.pk, job.version)).get()
 
     failing_handler.assert_called_once_with(job, exc_info.value)
     mock_logger.exception.assert_any_call(
@@ -808,23 +791,3 @@ def test_async_retry_job_task_non_retriable_error_skips_on_failure_action(mock_r
 
     mock_import_string.assert_not_called()
     mock_retry.assert_not_called()
-
-
-@pytest.mark.django_db
-@patch("hope.apps.core.celery_tasks.import_string", create=True)
-@patch("hope.apps.core.celery_tasks.async_retry_job_task.retry")
-def test_async_retry_job_task_does_not_fire_on_failure_action_when_retry_raises_other_error(
-    mock_retry, mock_import_string
-) -> None:
-    mock_retry.side_effect = MaxRetriesExceededError("max retries")
-
-    job = AsyncRetryJob.queue_task(
-        action="unit.apps.core.test_celery_tasks.fake_async_retry_job_failure_action",
-        config={"on_failure_action": ON_FAILURE_ACTION},
-    )
-
-    with pytest.raises(MaxRetriesExceededError):
-        async_retry_job_task.run(job._meta.label_lower, job.pk, job.version)
-
-    mock_import_string.assert_not_called()
-    mock_retry.assert_called_once()

--- a/tests/unit/apps/core/test_celery_tasks.py
+++ b/tests/unit/apps/core/test_celery_tasks.py
@@ -10,6 +10,7 @@ from hope.apps.core.celery import app
 from hope.apps.core.celery_queues import CELERY_QUEUE_DEFAULT, CELERY_QUEUE_PERIODIC
 from hope.apps.core.celery_tasks import (
     DEFAULT_RECOVER_MISSING_ASYNC_JOBS_MIN_AGE_SECONDS,
+    NonRetriableTaskError,
     async_job_task,
     async_retry_job_task,
     cleanup_old_periodic_async_jobs_async_task,
@@ -33,6 +34,18 @@ def fake_async_retry_job_success_action(job: AsyncRetryJob) -> None:
 
 def fake_async_retry_job_failure_action(job: AsyncRetryJob) -> None:
     raise Exception("sync failed")
+
+
+def fake_async_retry_job_non_retriable_action(job: AsyncRetryJob) -> None:
+    raise NonRetriableTaskError("permanent failure")
+
+
+def reraise_retry_exc(*args: object, exc: Exception, **kwargs: object) -> None:
+    # Simulates Celery re-raising the original exc on retry exhaustion (self.retry(exc=exc)).
+    raise exc
+
+
+ON_FAILURE_ACTION = "unit.apps.core.on_failure_handlers.record_failure"
 
 
 def test_async_job_task_skips_execution_when_version_mismatch():
@@ -690,3 +703,108 @@ def test_async_retry_job_task_preserves_partial_errors_on_failure(mock_retry) ->
     job.refresh_from_db()
     assert job.errors == {"start_flow_error": "keep me", "exception": "sync failed"}
     mock_retry.assert_called_once()
+
+
+@pytest.mark.django_db
+@patch("hope.apps.core.celery_tasks.import_string", create=True)
+@patch("hope.apps.core.celery_tasks.async_retry_job_task.retry")
+def test_async_retry_job_task_fires_on_failure_action_when_retries_exhausted(mock_retry, mock_import_string) -> None:
+    handler = MagicMock()
+    mock_import_string.return_value = handler
+    mock_retry.side_effect = reraise_retry_exc
+
+    job = AsyncRetryJob.queue_task(
+        action="unit.apps.core.test_celery_tasks.fake_async_retry_job_failure_action",
+        config={"on_failure_action": ON_FAILURE_ACTION},
+    )
+
+    with pytest.raises(Exception, match="sync failed") as exc_info:
+        async_retry_job_task.run(job._meta.label_lower, job.pk, job.version)
+
+    mock_import_string.assert_called_once_with(ON_FAILURE_ACTION)
+    handler.assert_called_once_with(job, exc_info.value)
+    job.refresh_from_db()
+    assert job.errors == {"exception": "sync failed"}
+    mock_retry.assert_called_once()
+
+
+@pytest.mark.django_db
+@patch("hope.apps.core.celery_tasks.import_string", create=True)
+@patch("hope.apps.core.celery_tasks.async_retry_job_task.retry")
+def test_async_retry_job_task_does_not_fire_on_failure_action_while_retries_remain(
+    mock_retry, mock_import_string
+) -> None:
+    mock_retry.side_effect = Retry("retry")
+
+    job = AsyncRetryJob.queue_task(
+        action="unit.apps.core.test_celery_tasks.fake_async_retry_job_failure_action",
+        config={"on_failure_action": ON_FAILURE_ACTION},
+    )
+
+    with pytest.raises(Retry):
+        async_retry_job_task.run(job._meta.label_lower, job.pk, job.version)
+
+    mock_import_string.assert_not_called()
+    mock_retry.assert_called_once()
+
+
+@pytest.mark.django_db
+@patch("hope.apps.core.celery_tasks.import_string", create=True)
+@patch("hope.apps.core.celery_tasks.async_retry_job_task.retry")
+def test_async_retry_job_task_no_on_failure_action_configured_is_noop(mock_retry, mock_import_string) -> None:
+    mock_retry.side_effect = reraise_retry_exc
+
+    job = AsyncRetryJob.queue_task(
+        action="unit.apps.core.test_celery_tasks.fake_async_retry_job_failure_action",
+        config={},
+    )
+
+    with pytest.raises(Exception, match="sync failed"):
+        async_retry_job_task.run(job._meta.label_lower, job.pk, job.version)
+
+    mock_import_string.assert_not_called()
+    job.refresh_from_db()
+    assert job.errors == {"exception": "sync failed"}
+
+
+@pytest.mark.django_db
+@patch("hope.apps.core.celery_tasks.logger")
+@patch("hope.apps.core.celery_tasks.import_string", create=True)
+@patch("hope.apps.core.celery_tasks.async_retry_job_task.retry")
+def test_async_retry_job_task_failing_on_failure_action_is_logged_and_original_exc_reraised(
+    mock_retry, mock_import_string, mock_logger
+) -> None:
+    failing_handler = MagicMock(side_effect=Exception("handler boom"))
+    mock_import_string.return_value = failing_handler
+    mock_retry.side_effect = reraise_retry_exc
+
+    job = AsyncRetryJob.queue_task(
+        action="unit.apps.core.test_celery_tasks.fake_async_retry_job_failure_action",
+        config={"on_failure_action": ON_FAILURE_ACTION},
+    )
+
+    with pytest.raises(Exception, match="sync failed") as exc_info:
+        async_retry_job_task.run(job._meta.label_lower, job.pk, job.version)
+
+    failing_handler.assert_called_once_with(job, exc_info.value)
+    mock_logger.exception.assert_any_call(
+        "on_failure_action %s failed (job %s)",
+        ON_FAILURE_ACTION,
+        job.pk,
+    )
+
+
+@pytest.mark.django_db
+@patch("hope.apps.core.celery_tasks.import_string", create=True)
+@patch("hope.apps.core.celery_tasks.async_retry_job_task.retry")
+def test_async_retry_job_task_non_retriable_error_skips_on_failure_action(mock_retry, mock_import_string) -> None:
+    job = AsyncRetryJob.queue_task(
+        action="unit.apps.core.test_celery_tasks.fake_async_retry_job_non_retriable_action",
+        config={"on_failure_action": ON_FAILURE_ACTION},
+    )
+
+    with pytest.raises(NonRetriableTaskError, match="permanent failure"):
+        async_retry_job_task.run(job._meta.label_lower, job.pk, job.version)
+
+    mock_import_string.assert_not_called()
+    mock_retry.assert_not_called()

--- a/tests/unit/apps/core/test_celery_tasks.py
+++ b/tests/unit/apps/core/test_celery_tasks.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 from unittest.mock import MagicMock, PropertyMock, patch
 
-from celery.exceptions import Retry
+from celery.exceptions import MaxRetriesExceededError, Retry
 from django.utils import timezone
 import pytest
 
@@ -808,3 +808,23 @@ def test_async_retry_job_task_non_retriable_error_skips_on_failure_action(mock_r
 
     mock_import_string.assert_not_called()
     mock_retry.assert_not_called()
+
+
+@pytest.mark.django_db
+@patch("hope.apps.core.celery_tasks.import_string", create=True)
+@patch("hope.apps.core.celery_tasks.async_retry_job_task.retry")
+def test_async_retry_job_task_does_not_fire_on_failure_action_when_retry_raises_other_error(
+    mock_retry, mock_import_string
+) -> None:
+    mock_retry.side_effect = MaxRetriesExceededError("max retries")
+
+    job = AsyncRetryJob.queue_task(
+        action="unit.apps.core.test_celery_tasks.fake_async_retry_job_failure_action",
+        config={"on_failure_action": ON_FAILURE_ACTION},
+    )
+
+    with pytest.raises(MaxRetriesExceededError):
+        async_retry_job_task.run(job._meta.label_lower, job.pk, job.version)
+
+    mock_import_string.assert_not_called()
+    mock_retry.assert_called_once()


### PR DESCRIPTION
## Problem

I'm working on adjusting to new deduplication flow https://github.com/unicef/hope/pull/6256 and I need to be able to send email to HOPE admins when deleting RDI did not succeed after three retries. I decided to add the action-on-terminal-failure logic as separate PR and this is that PR.

## Testing
```python
# Demo command for the async_retry_job_task on_failure_action hook.
from argparse import ArgumentParser
from typing import Any

from django.core.management import BaseCommand
from django_celery_boost.models import AsyncJobModel

from hope.apps.core.celery_tasks import async_retry_job_task
from hope.models import AsyncRetryJob


def demo_task_action(job: AsyncRetryJob) -> None:
    """Demo AsyncRetryJob JOB_TASK action — receives the job instance as its sole arg."""
    if job.config.get("should_fail"):
        raise RuntimeError("demo task deliberate failure")


def demo_on_failure_handler(job: AsyncRetryJob, exc: Exception) -> None:
    """on_failure_action hook — fires once after retries are exhausted. Prints to stdout."""
    print("=" * 64)
    print(f"🔥 ON_FAILURE HOOK FIRED — AsyncRetryJob {job.pk} gave up after all retries")
    print(f"   final exception: {exc!r}")
    print("=" * 64)


class Command(BaseCommand):
    help = "Demonstrate the async_retry_job_task on_failure_action hook by driving a job eagerly in-process."

    def add_arguments(self, parser: ArgumentParser) -> None:
        group = parser.add_mutually_exclusive_group(required=True)
        group.add_argument("--fail", action="store_true", help="Force the task to fail and fire the on_failure hook.")
        group.add_argument("--succeed", action="store_true", help="Let the task succeed (no on_failure hook).")

    def handle(self, *args: Any, **options: Any) -> None:
        should_fail = bool(options["fail"])
        self.stdout.write(f"Running demo in {'FAIL' if should_fail else 'SUCCEED'} mode...")

        job = AsyncRetryJob.objects.create(
            job_name="demo_on_failure_hook",
            type=AsyncJobModel.JobType.JOB_TASK,
            action="hope.apps.core.management.commands.demo_on_failure_hook.demo_task_action",
            config={
                "should_fail": should_fail,
                "on_failure_action": "hope.apps.core.management.commands.demo_on_failure_hook.demo_on_failure_handler",
            },
        )

        result = async_retry_job_task.apply((job._meta.label_lower, job.pk, job.version))

        if result.successful():
            self.stdout.write(self.style.SUCCESS(f"Task SUCCEEDED (job {job.pk}) — no on_failure hook fired."))
        else:
            self.stdout.write(
                self.style.WARNING(
                    f"Task FAILED after retries (job {job.pk}) — on_failure hook fired above. "
                    f"Final error: {result.result!r}"
                )
            )

```

## More testing
1. Added following tasks:
```python
# --- DEMO: exercise the async_retry_job_task on_failure_action hook (throwaway) ---
def demo_always_fail_async_task_action(job: AsyncRetryJob) -> None:
    """Demo action that always raises so retries exhaust and the on_failure hook fires."""
    raise RuntimeError("demo always-fail task: deliberate failure")


def demo_always_fail_on_failure(job: AsyncRetryJob, exc: Exception) -> None:
    """on_failure_action hook — fires once in the worker after all retries are spent."""
    logger.error(
        "🔥 ON_FAILURE HOOK FIRED — AsyncRetryJob %s (%s) gave up after all retries: %r",
        job.pk,
        job.job_name,
        exc,
    )


def demo_always_fail_async_task() -> AsyncRetryJob:
    """Enqueue the always-fail demo job through the real broker (needs a running worker)."""
    return AsyncRetryJob.queue_task(
        job_name=demo_always_fail_async_task.__name__,
        action="hope.apps.registration_data.celery_tasks.demo_always_fail_async_task_action",
        config={
            "on_failure_action": "hope.apps.registration_data.celery_tasks.demo_always_fail_on_failure",
        },
        group_key="registration_data",
        description="Demo always-fail task exercising the on_failure hook",
    )
```
2. Ran in shell:
```bash
job = demo_always_fail_async_task()
```
3. In logs:
```bash
[...]
🔥 ON_FAILURE HOOK FIRED — AsyncRetryJob 9
```