### PR TITLE
BaseAPI passing creds in constructor

### DIFF
--- a/src/hope/apps/core/api/mixins.py
+++ b/src/hope/apps/core/api/mixins.py
@@ -76,7 +76,7 @@ class BaseAPI:
             self._client.headers.update({"Authorization": f"Token {self.api_key}"})
 
     def get_url(self, endpoint: str) -> str:
-        return f"{self.api_url}{endpoint}"
+        return f"{self.api_url.rstrip('/')}/{endpoint.lstrip('/')}"
 
     def validate_response(self, response: Response) -> Response:
         if not response.ok:

--- a/src/hope/apps/core/api/mixins.py
+++ b/src/hope/apps/core/api/mixins.py
@@ -56,9 +56,9 @@ class BaseAPI:
                 f"Missing {self.__class__.__name__} settings: {', '.join(missing_setting_names)}"
             )
 
-    def __init__(self) -> None:
-        self.api_url = self.get_api_url()
-        self.api_key = self.get_api_key()
+    def __init__(self, api_url: str | None = None, api_key: str | None = None) -> None:
+        self.api_url = api_url if api_url is not None else self.get_api_url()
+        self.api_key = api_key if api_key is not None else self.get_api_key()
 
         if not self.api_url or (self.API_KEY_SETTING_NAME and not self.api_key):
             raise self.API_MISSING_CREDENTIALS_EXCEPTION_CLASS(f"Missing {self.__class__.__name__} Key/URL")

--- a/tests/unit/apps/core/test_mixins.py
+++ b/tests/unit/apps/core/test_mixins.py
@@ -221,3 +221,18 @@ def test_get_url_uses_constructor_api_url(settings):
     api = ConstructorOverrideAPI(api_url="https://cw.example.com")
 
     assert api.get_url("/api/rest/rdi/delete-callback/") == ("https://cw.example.com/api/rest/rdi/delete-callback/")
+
+
+@pytest.mark.parametrize(
+    ("api_url", "endpoint"),
+    [
+        ("https://cw.example.com/api/", "/rest/rdi/delete-callback/"),
+        ("https://cw.example.com/api", "/rest/rdi/delete-callback/"),
+        ("https://cw.example.com/api/", "rest/rdi/delete-callback/"),
+    ],
+)
+def test_get_url_normalizes_slashes(settings, api_url, endpoint):
+    settings.TEST_API_KEY = "settings_key"
+    api = ConstructorOverrideAPI(api_url=api_url)
+
+    assert api.get_url(endpoint) == "https://cw.example.com/api/rest/rdi/delete-callback/"

--- a/tests/unit/apps/core/test_mixins.py
+++ b/tests/unit/apps/core/test_mixins.py
@@ -177,3 +177,47 @@ def test_get_api_key_returns_none_when_env_name_not_set():
     api = BaseAPI.__new__(BaseAPI)
     assert api.API_KEY_SETTING_NAME == ""
     assert api.get_api_key() is None
+
+
+class ConstructorOverrideAPI(BaseAPI):
+    API_URL_SETTING_NAME = ""
+    API_KEY_SETTING_NAME = "TEST_API_KEY"
+
+
+def test_init_prefers_constructor_api_url(settings):
+    settings.TEST_API_KEY = "settings_key"
+    api = ConstructorOverrideAPI(api_url="https://cw.example.com/api/cb/")
+
+    assert api.api_url == "https://cw.example.com/api/cb/"
+    assert api.api_key == "settings_key"
+
+
+def test_init_prefers_constructor_api_key(settings):
+    api = ConstructorOverrideAPI(api_url="https://cw.example.com/", api_key="arg_key")
+
+    assert api.api_key == "arg_key"
+    assert api._client.headers["Authorization"] == "Token arg_key"
+
+
+def test_init_falls_back_to_settings_without_args(settings):
+    # backward-compat: no-arg construction is unchanged
+    settings.TEST_API_URL = "http://test-hope.com"
+    api = TestAPI()
+
+    assert api.api_url == "http://test-hope.com"
+    assert api.api_key == "test_fake_key"
+
+
+def test_init_raises_when_url_absent_from_args_and_settings(settings):
+    settings.TEST_API_KEY = "settings_key"
+    with pytest.raises(BaseAPI.APIMissingCredentialsError) as exc:
+        ConstructorOverrideAPI()
+
+    assert "Missing ConstructorOverrideAPI Key/URL" in str(exc.value)
+
+
+def test_get_url_uses_constructor_api_url(settings):
+    settings.TEST_API_KEY = "settings_key"
+    api = ConstructorOverrideAPI(api_url="https://cw.example.com")
+
+    assert api.get_url("/api/rest/rdi/delete-callback/") == ("https://cw.example.com/api/rest/rdi/delete-callback/")


### PR DESCRIPTION
## Problem

BaseAPI requires API URL and API Token to be set in settings. If we get callback URL as a full URL we don't need to / we can't set it in settings, but BaseAPI children requires them to have it defined. This PR implements a workaround that enables API creds to be passed in a constructor and use settings values as a fallback.

## Context

This PR is required for adjusting to new deduplication flow. CW will be able to DELETE RDI using HOPE endpoint and HOPE needs to tell CW: "We finished deleting a RDI" using callback provided by CW.