### PR TITLE
feat: add view-on-site button to admin change forms

### DIFF
--- a/src/hope/admin/grievance.py
+++ b/src/hope/admin/grievance.py
@@ -8,7 +8,7 @@ from django.db.models import QuerySet
 from django.http import HttpRequest
 from smart_admin.mixins import LinkedObjectsMixin
 
-from hope.admin.utils import HOPEModelAdminBase
+from hope.admin.utils import HOPEModelAdminBase, ViewOnSiteMixin
 from hope.apps.grievance.models import (
     GrievanceDocument,
     GrievanceTicket,
@@ -29,7 +29,7 @@ from hope.apps.grievance.models import (
 
 
 @admin.register(GrievanceTicket)
-class GrievanceTicketAdmin(CursorPaginatorAdmin, LinkedObjectsMixin, HOPEModelAdminBase):
+class GrievanceTicketAdmin(CursorPaginatorAdmin, LinkedObjectsMixin, HOPEModelAdminBase, ViewOnSiteMixin):
     list_display = (
         "unicef_id",
         "created_at",
@@ -92,6 +92,12 @@ class GrievanceTicketAdmin(CursorPaginatorAdmin, LinkedObjectsMixin, HOPEModelAd
         if ordering:
             qs = qs.order_by(*ordering)
         return qs
+
+    def frontend_url(self, obj: GrievanceTicket) -> str | None:
+        return (
+            f"/{obj.business_area.slug}/programs/all/grievance/tickets/"
+            f"{obj.grievance_type_to_string()}-generated/{obj.id}"
+        )
 
 
 @admin.register(TicketNote)

--- a/src/hope/admin/household.py
+++ b/src/hope/admin/household.py
@@ -33,6 +33,7 @@ from hope.admin.utils import (
     LinkedObjectsManagerMixin,
     RdiMergeStatusAdminMixin,
     SoftDeletableAdminMixin,
+    ViewOnSiteMixin,
 )
 from hope.apps.household.celery_tasks import (
     enroll_households_to_program_async_task,
@@ -317,6 +318,7 @@ class HouseholdAdmin(
     HouseholdWithdrawnMixin,
     HOPEModelAdminBase,
     RdiMergeStatusAdminMixin,
+    ViewOnSiteMixin,
 ):
     list_display = (
         "unicef_id",
@@ -487,6 +489,9 @@ class HouseholdAdmin(
         if ordering:
             qs = qs.order_by(*ordering)
         return qs
+
+    def frontend_url(self, obj: Household) -> str | None:
+        return f"/{obj.business_area.slug}/programs/{obj.program.code}/population/household/{obj.id}"
 
     def formfield_for_foreignkey(self, db_field: Any, request: HttpRequest, **kwargs: Any) -> Any:
         if db_field.name == "head_of_household":

--- a/src/hope/admin/individual.py
+++ b/src/hope/admin/individual.py
@@ -27,6 +27,7 @@ from hope.admin.utils import (
     LinkedObjectsManagerMixin,
     RdiMergeStatusAdminMixin,
     SoftDeletableAdminMixin,
+    ViewOnSiteMixin,
 )
 from hope.apps.household.celery_tasks import revalidate_phone_number_async_task
 from hope.apps.utils.security import is_root
@@ -71,6 +72,7 @@ class IndividualAdmin(
     CursorPaginatorAdmin,
     HOPEModelAdminBase,
     RdiMergeStatusAdminMixin,
+    ViewOnSiteMixin,
 ):
     # Custom template to merge AdminAdvancedFiltersMixin and ExtraButtonsMixin
     advanced_change_list_template = "admin/household/advanced_filters_extra_buttons_change_list.html"
@@ -196,6 +198,9 @@ class IndividualAdmin(
                 "business_area",
             )
         )
+
+    def frontend_url(self, obj: Individual) -> str | None:
+        return f"/{obj.business_area.slug}/programs/{obj.program.code}/population/individuals/{obj.id}"
 
     def formfield_for_foreignkey(self, db_field: Any, request: HttpRequest, **kwargs: Any) -> Any:
         if db_field.name == "household":

--- a/src/hope/admin/payment_plan.py
+++ b/src/hope/admin/payment_plan.py
@@ -15,7 +15,7 @@ from django.shortcuts import redirect, render
 from django.urls import reverse
 from django.utils.html import format_html
 
-from hope.admin.utils import HOPEModelAdminBase, PaymentPlanCeleryTasksMixin
+from hope.admin.utils import HOPEModelAdminBase, PaymentPlanCeleryTasksMixin, ViewOnSiteMixin
 from hope.apps.account.permissions import Permissions
 from hope.apps.activity_log.utils import copy_model_object, create_diff
 from hope.apps.payment.forms import BatchReexportForm
@@ -140,7 +140,7 @@ def has_payment_instruction_download_permission(request: Any) -> bool:
 
 
 @admin.register(PaymentPlan)
-class PaymentPlanAdmin(HOPEModelAdminBase, PaymentPlanCeleryTasksMixin):
+class PaymentPlanAdmin(HOPEModelAdminBase, PaymentPlanCeleryTasksMixin, ViewOnSiteMixin):
     list_display = (
         "unicef_id",
         "name",
@@ -234,6 +234,9 @@ class PaymentPlanAdmin(HOPEModelAdminBase, PaymentPlanCeleryTasksMixin):
     def wu_reports(self, request: HttpRequest, pk: "UUID") -> HttpResponseRedirect:
         url = reverse("admin:payment_westernunionpaymentplanreport_changelist")
         return HttpResponseRedirect(f"{url}?payment_plan__id__exact={pk}")
+
+    def frontend_url(self, obj: PaymentPlan) -> str | None:
+        return f"/{obj.business_area.slug}/programs/{obj.program.code}/payment-module/payment-plans/{obj.id}"
 
     def get_form(self, request: HttpRequest, obj: Any = None, change: bool = False, **kwargs: Any) -> Any:
         request._payment_plan_obj = obj
@@ -552,7 +555,7 @@ class PaymentHouseholdSnapshotInline(admin.StackedInline):
 
 
 @admin.register(Payment)
-class PaymentAdmin(CursorPaginatorAdmin, AdminAdvancedFiltersMixin, HOPEModelAdminBase):
+class PaymentAdmin(CursorPaginatorAdmin, AdminAdvancedFiltersMixin, HOPEModelAdminBase, ViewOnSiteMixin):
     search_fields = ("unicef_id",)
     list_display = (
         "unicef_id",
@@ -668,6 +671,12 @@ class PaymentAdmin(CursorPaginatorAdmin, AdminAdvancedFiltersMixin, HOPEModelAdm
 
     def has_delete_permission(self, request: HttpRequest, obj: Any | None = None) -> bool:
         return False
+
+    def frontend_url(self, obj: Payment) -> str | None:
+        program = obj.program
+        if program is None:
+            return None
+        return f"/{obj.business_area.slug}/programs/{program.code}/payment-module/payments/{obj.id}"
 
     @button(
         visible=lambda btn: can_sync_with_payment_gateway(btn.original.parent),

--- a/src/hope/admin/program.py
+++ b/src/hope/admin/program.py
@@ -29,6 +29,7 @@ from hope.admin.utils import (
     HOPEModelAdminBase,
     LastSyncDateResetMixin,
     SoftDeletableAdminMixin,
+    ViewOnSiteMixin,
 )
 from hope.apps.household.forms import CreateTargetPopulationTextForm
 from hope.apps.household.services.index_management import check_program_indexes, rebuild_program_indexes
@@ -211,6 +212,7 @@ class ProgramAdmin(
     LastSyncDateResetMixin,
     AdminAutoCompleteSearchMixin,
     HOPEModelAdminBase,
+    ViewOnSiteMixin,
 ):
     form = ProgramAdminForm
     list_display = (
@@ -255,6 +257,9 @@ class ProgramAdmin(
             "QuerySet[Program]",
             super().get_queryset(request).select_related("data_collecting_type", "business_area", "beneficiary_group"),
         )
+
+    def frontend_url(self, obj: Program) -> str | None:
+        return f"/{obj.business_area.slug}/programs/{obj.code}/details/{obj.code}"
 
     @button(
         permission="payment.add_paymentplan",

--- a/src/hope/admin/utils.py
+++ b/src/hope/admin/utils.py
@@ -2,7 +2,7 @@ from typing import Any, TypeVar
 from uuid import UUID
 
 from admin_extra_buttons.buttons import StandardButton
-from admin_extra_buttons.decorators import button
+from admin_extra_buttons.decorators import button, link
 from admin_extra_buttons.mixins import ExtraButtonsMixin, confirm_action
 from adminactions.helpers import AdminActionPermMixin
 from adminfilters.mixin import AdminFiltersMixin
@@ -165,6 +165,33 @@ class HOPEModelAdminBase(AutocompleteForeignKeyMixin, HopeModelAdminMixin, JSONW
     def count_queryset(self, request: HttpRequest, queryset: QuerySet) -> None:
         count = queryset.count()
         self.message_user(request, f"Selection contains {count} records")
+
+
+class ViewOnSiteMixin:
+    """Add a "View on site" button that links to the object page on the frontend.
+
+    Subclasses must implement :meth:`frontend_url` returning the frontend path
+    (without protocol/host) for the given object, or ``None`` when not available.
+    """
+
+    @link(
+        label="View on site",
+        html_attrs={"target": "_blank", "class": "aeb-green"},
+        change_list=False,
+    )
+    def view_on_site(self, button: Any) -> None:
+        button.href = None
+        obj = button.original
+        if self is None or obj is None:
+            return
+        path = self.frontend_url(obj)  # type: ignore[attr-defined]
+        if not path:
+            return
+        protocol = "https" if settings.SOCIAL_AUTH_REDIRECT_IS_HTTPS else "http"
+        button.href = f"{protocol}://{settings.FRONTEND_HOST}{path}"
+
+    def frontend_url(self, obj: Any) -> str | None:
+        raise NotImplementedError
 
 
 class HUBBusinessAreaFilter(SimpleListFilter):


### PR DESCRIPTION
Add a **View on site** button to the Django admin change forms for:

- `Program`
- `Household`
- `Individual`
- `PaymentPlan`
- `Payment`
- `GrievanceTicket`

The button opens the corresponding frontend page in a new tab, built from `settings.FRONTEND_HOST` and each model's `frontend_url`.

Implementation:
- New `ViewOnSiteMixin` in `src/hope/admin/utils.py` using `admin_extra_buttons` `@link` decorator.
- Each admin implements `frontend_url` returning the frontend path (or `None` when not available).

Verified: `pre-commit run --all-files` passes; `tests/unit/admin/test_admin_smoke.py` (512 passed).