### PR TITLE
[333832] remove environment based setting logic

### DIFF
--- a/src/hope/apps/payment/notifications.py
+++ b/src/hope/apps/payment/notifications.py
@@ -97,17 +97,14 @@ class PaymentNotification:
             .exclude(expiry_date__lt=timezone.now())
             .distinct()
         )
-        users = (
+        return (
             User.objects.filter(
                 Q(role_assignments__in=role_assignments) | Q(partner__role_assignments__in=role_assignments)
             )
             .exclude(id=self.action_user.id)
+            .exclude(Q(is_superuser=True) | Q(is_staff=True))
             .distinct()
         )
-
-        if settings.ENV == "prod":
-            users = users.exclude(Q(is_superuser=True) | Q(is_staff=True))
-        return users
 
     def _prepare_email(self) -> MailjetClient:
         body_variables = self._prepare_body_variables()

--- a/src/hope/apps/payment/notifications.py
+++ b/src/hope/apps/payment/notifications.py
@@ -97,14 +97,16 @@ class PaymentNotification:
             .exclude(expiry_date__lt=timezone.now())
             .distinct()
         )
-        return (
+        users = (
             User.objects.filter(
                 Q(role_assignments__in=role_assignments) | Q(partner__role_assignments__in=role_assignments)
             )
             .exclude(id=self.action_user.id)
-            .exclude(Q(is_superuser=True) | Q(is_staff=True))
             .distinct()
         )
+        if not config.NOTIFY_INTERNAL_USERS:
+            users = users.exclude(Q(is_superuser=True) | Q(is_staff=True))
+        return users
 
     def _prepare_email(self) -> MailjetClient:
         body_variables = self._prepare_body_variables()

--- a/src/hope/apps/payment/services/payment_plan_services.py
+++ b/src/hope/apps/payment/services/payment_plan_services.py
@@ -5,7 +5,6 @@ import logging
 from typing import TYPE_CHECKING, Any, Callable, Union, cast
 
 from constance import config
-from django.conf import settings
 from django.contrib.postgres.aggregates import ArrayAgg
 from django.core.paginator import Paginator
 from django.db import transaction
@@ -1549,12 +1548,13 @@ class PaymentPlanService:
             .exclude(expiry_date__lt=timezone.now())
             .distinct()
         )
-        users = User.objects.filter(
-            Q(role_assignments__in=role_assignments) | Q(partner__role_assignments__in=role_assignments)
-        ).distinct()
-
-        if settings.ENV == "prod":
-            users = users.exclude(is_superuser=True)
+        users = (
+            User.objects.filter(
+                Q(role_assignments__in=role_assignments) | Q(partner__role_assignments__in=role_assignments)
+            )
+            .exclude(is_superuser=True)
+            .distinct()
+        )
 
         if users:
             text_template = "payment/pp_reconciliation_overdue_email.txt"

--- a/src/hope/apps/payment/services/payment_plan_services.py
+++ b/src/hope/apps/payment/services/payment_plan_services.py
@@ -1548,13 +1548,12 @@ class PaymentPlanService:
             .exclude(expiry_date__lt=timezone.now())
             .distinct()
         )
-        users = (
-            User.objects.filter(
-                Q(role_assignments__in=role_assignments) | Q(partner__role_assignments__in=role_assignments)
-            )
-            .exclude(is_superuser=True)
-            .distinct()
-        )
+        users = User.objects.filter(
+            Q(role_assignments__in=role_assignments) | Q(partner__role_assignments__in=role_assignments)
+        ).distinct()
+
+        if not config.NOTIFY_INTERNAL_USERS:
+            users = users.exclude(is_superuser=True)
 
         if users:
             text_template = "payment/pp_reconciliation_overdue_email.txt"

--- a/src/hope/apps/periodic_data_update/notifications.py
+++ b/src/hope/apps/periodic_data_update/notifications.py
@@ -83,15 +83,17 @@ class PDUOnlineEditNotification:
             .distinct()
         )
 
-        return (
+        users = (
             User.objects.filter(
                 Q(role_assignments__in=role_assignments) | Q(partner__role_assignments__in=role_assignments)
             )
             .filter(id__in=authorized_user_ids)  # Only authorized users
             .exclude(id=self.action_user.id)
-            .exclude(is_superuser=True)
             .distinct()
         )
+        if not config.NOTIFY_INTERNAL_USERS:
+            users = users.exclude(is_superuser=True)
+        return users
 
     def _prepare_email(self) -> MailjetClient:
         body_variables = self._prepare_body_variables()

--- a/src/hope/apps/periodic_data_update/notifications.py
+++ b/src/hope/apps/periodic_data_update/notifications.py
@@ -83,18 +83,15 @@ class PDUOnlineEditNotification:
             .distinct()
         )
 
-        users = (
+        return (
             User.objects.filter(
                 Q(role_assignments__in=role_assignments) | Q(partner__role_assignments__in=role_assignments)
             )
             .filter(id__in=authorized_user_ids)  # Only authorized users
             .exclude(id=self.action_user.id)
+            .exclude(is_superuser=True)
             .distinct()
         )
-
-        if settings.ENV == "prod":
-            users = users.exclude(is_superuser=True)
-        return users
 
     def _prepare_email(self) -> MailjetClient:
         body_variables = self._prepare_body_variables()

--- a/src/hope/apps/utils/mailjet.py
+++ b/src/hope/apps/utils/mailjet.py
@@ -23,8 +23,7 @@ class MailjetClient:
         self.mailjet_template_id = mailjet_template_id
         self.html_body = html_body
         self.text_body = text_body
-        subject_prefix = settings.EMAIL_SUBJECT_PREFIX
-        self.subject = f"[{subject_prefix}] {subject}" if subject_prefix else subject
+        self.subject = subject
         self.recipients = settings.CATCH_ALL_EMAIL or recipients
         self.ccs = kwargs.get("ccs") or []
         self.variables = kwargs.get("variables")

--- a/src/hope/config/fragments/constance.py
+++ b/src/hope/config/fragments/constance.py
@@ -146,6 +146,11 @@ CONSTANCE_CONFIG = {
         "Should send PDU Online Edit notification",
         bool,
     ),
+    "NOTIFY_INTERNAL_USERS": (
+        False,
+        "Should send notifications to internal users (superusers and staff)",
+        bool,
+    ),
     "ENABLE_MAILJET": (
         False,
         "Enable sending emails via Mailjet",

--- a/src/hope/config/settings.py
+++ b/src/hope/config/settings.py
@@ -85,18 +85,12 @@ EMAIL_PORT = env("EMAIL_PORT")
 EMAIL_HOST_USER = env("EMAIL_HOST_USER")
 EMAIL_HOST_PASSWORD = env("EMAIL_HOST_PASSWORD")
 EMAIL_USE_TLS = env.bool("EMAIL_USE_TLS")
+EMAIL_SUBJECT_PREFIX = ""
 
 # Get the ENV setting. Needs to be set in .bashrc or similar.
 ENV = env("ENV")
 
 DB_ZOMBIE_TIMEOUT_MS = 4 * 60 * 60 * 1000
-
-# prefix all non-production emails
-if ENV != "prod":
-    EMAIL_SUBJECT_PREFIX = f"{ENV}"
-else:
-    EMAIL_SUBJECT_PREFIX = ""
-
 
 RO_CONN = env.db("REP_DATABASE_URL")
 RO_CONN.update(

--- a/tests/unit/api/test_api_token.py
+++ b/tests/unit/api/test_api_token.py
@@ -43,7 +43,7 @@ def token(user, afghanistan) -> APIToken:
 @patch("hope.apps.utils.celery_tasks.requests.post")
 @patch.object(APITokenAdmin, "message_user", return_value=None)
 @patch.object(APITokenAdmin, "__init__", return_value=None)
-@override_settings(EMAIL_SUBJECT_PREFIX="test")
+@override_settings(DEFAULT_EMAIL_DISPLAY="test")
 @override_config(ENABLE_MAILJET=True)
 def test_send_api_token(
     mocked_admin_init: MagicMock,
@@ -64,9 +64,9 @@ def test_send_api_token(
                 {
                     "From": {
                         "Email": settings.DEFAULT_EMAIL,
-                        "Name": settings.DEFAULT_EMAIL_DISPLAY,
+                        "Name": "test",
                     },
-                    "Subject": f"[test] HOPE API Token {token} infos",
+                    "Subject": f"HOPE API Token {token} infos",
                     "To": [
                         {
                             "Email": "testapitoken@email.com",

--- a/tests/unit/apps/payment/test_finish_verification_plan.py
+++ b/tests/unit/apps/payment/test_finish_verification_plan.py
@@ -1,7 +1,6 @@
 from unittest import mock
 
 from constance.test import override_config
-from django.test import override_settings
 import pytest
 from rest_framework.exceptions import ValidationError
 
@@ -127,7 +126,6 @@ def payment_verification_records(payment_verification_plan, household):
 
 
 @mock.patch("hope.apps.utils.celery_tasks.requests.post")
-@override_settings(EMAIL_SUBJECT_PREFIX="test")
 @override_config(SEND_GRIEVANCES_NOTIFICATION=True, ENABLE_MAILJET=True)
 def test_create_tickets_with_admin2_same_as_in_household(
     mocked_requests_post,

--- a/tests/unit/apps/payment/test_payment_notification.py
+++ b/tests/unit/apps/payment/test_payment_notification.py
@@ -962,3 +962,27 @@ def test_send_email_notification_exclude_staff_user(notification_setup: dict, mo
         assert users[key].email in payment_notification.email.recipients
 
     assert mock_post.call_count == 1
+
+
+@override_config(
+    SEND_PAYMENT_PLANS_NOTIFICATION=True,
+    ENABLE_MAILJET=True,
+    MAILJET_TEMPLATE_PAYMENT_PLAN_NOTIFICATION=1,
+    NOTIFY_INTERNAL_USERS=True,
+)
+def test_send_email_notification_include_internal_users(notification_setup: dict, mocker: Any) -> None:
+    mocker.patch("hope.apps.utils.celery_tasks.requests.post")
+    users = notification_setup["users"]
+    users["user_with_partner_unicef_hq"].is_superuser = True
+    users["user_with_partner_unicef_hq"].is_staff = True
+    users["user_with_partner_unicef_hq"].save()
+
+    payment_notification = PaymentNotification(
+        notification_setup["payment_plan"],
+        PaymentPlan.Action.SEND_FOR_APPROVAL.name,
+        notification_setup["user_action_user"],
+        f"{timezone.now():%-d %B %Y}",
+    )
+    payment_notification.send_email_notification()
+
+    assert users["user_with_partner_unicef_hq"].email in payment_notification.email.recipients

--- a/tests/unit/apps/payment/test_payment_notification.py
+++ b/tests/unit/apps/payment/test_payment_notification.py
@@ -875,7 +875,6 @@ def test_send_email_notification_without_catch_all_email(notification_setup: dic
     ENABLE_MAILJET=True,
     MAILJET_TEMPLATE_PAYMENT_PLAN_NOTIFICATION=1,
 )
-@override_settings(ENV="prod")
 def test_send_email_notification_exclude_superuser(notification_setup: dict, mocker: Any) -> None:
     mock_post = mocker.patch("hope.apps.utils.celery_tasks.requests.post")
     users = notification_setup["users"]
@@ -923,7 +922,6 @@ def test_send_email_notification_exclude_superuser(notification_setup: dict, moc
     ENABLE_MAILJET=True,
     MAILJET_TEMPLATE_PAYMENT_PLAN_NOTIFICATION=1,
 )
-@override_settings(ENV="prod")
 def test_send_email_notification_exclude_staff_user(notification_setup: dict, mocker: Any) -> None:
     mock_post = mocker.patch("hope.apps.utils.celery_tasks.requests.post")
     users = notification_setup["users"]

--- a/tests/unit/apps/payment/test_payment_notification.py
+++ b/tests/unit/apps/payment/test_payment_notification.py
@@ -732,7 +732,6 @@ def test_action_user_is_ccd_and_excluded_from_recipients_for_mark_ready_for_clos
 
 
 @override_config(SEND_PAYMENT_PLANS_NOTIFICATION=True)
-@override_settings(EMAIL_SUBJECT_PREFIX="")
 def test_send_email_notification_subject_mark_ready_for_closure(notification_setup: dict, mocker: Any) -> None:
     mocker.patch("hope.apps.payment.notifications.MailjetClient.send_email")
     payment_notification = PaymentNotification(
@@ -758,7 +757,6 @@ def test_send_email_notification_mark_ready_for_closure(notification_setup: dict
 
 
 @override_config(SEND_PAYMENT_PLANS_NOTIFICATION=True)
-@override_settings(EMAIL_SUBJECT_PREFIX="")
 def test_send_email_notification_subject_send_back_to_finished(notification_setup: dict, mocker: Any) -> None:
     mocker.patch("hope.apps.payment.notifications.MailjetClient.send_email")
     payment_notification = PaymentNotification(
@@ -797,21 +795,7 @@ def test_send_email_notification(notification_setup: dict, mocker: Any) -> None:
 
 
 @override_config(SEND_PAYMENT_PLANS_NOTIFICATION=True)
-@override_settings(EMAIL_SUBJECT_PREFIX="test")
-def test_send_email_notification_subject_test_env(notification_setup: dict, mocker: Any) -> None:
-    mocker.patch("hope.apps.payment.notifications.MailjetClient.send_email")
-    payment_notification = PaymentNotification(
-        notification_setup["payment_plan"],
-        PaymentPlan.Action.SEND_FOR_APPROVAL.name,
-        notification_setup["user_action_user"],
-        f"{timezone.now():%-d %B %Y}",
-    )
-    assert payment_notification.email.subject == "[test] Payment pending for Approval"
-
-
-@override_config(SEND_PAYMENT_PLANS_NOTIFICATION=True)
-@override_settings(EMAIL_SUBJECT_PREFIX="")
-def test_send_email_notification_subject_prod_env(notification_setup: dict, mocker: Any) -> None:
+def test_send_email_notification_subject_send_for_approval(notification_setup: dict, mocker: Any) -> None:
     mocker.patch("hope.apps.payment.notifications.MailjetClient.send_email")
     payment_notification = PaymentNotification(
         notification_setup["payment_plan"],

--- a/tests/unit/apps/payment/test_payment_plan_services.py
+++ b/tests/unit/apps/payment/test_payment_plan_services.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 import uuid
 
 from aniso8601 import parse_date
+from constance.test import override_config
 from django.contrib.contenttypes.models import ContentType
 from django.core.files.base import ContentFile
 from django.db import IntegrityError, transaction
@@ -1874,6 +1875,38 @@ def test_send_reconciliation_overdue_email_recipients(business_area: Any) -> Non
         assert user_with_perm_ba_wide in emailed_users
         assert superuser_with_perm not in emailed_users
         assert user_with_perm_in_different_program not in emailed_users
+
+
+@override_config(NOTIFY_INTERNAL_USERS=True)
+def test_send_reconciliation_overdue_email_recipients_include_internal_users(business_area: Any) -> None:
+    partner_unicef = PartnerFactory(name="UNICEF")
+    partner_unicef_hq = PartnerFactory(name="UNICEF HQ", parent=partner_unicef)
+    role, _ = Role.objects.update_or_create(
+        name="RECEIVE_PP_OVERDUE_EMAIL", defaults={"permissions": [Permissions.RECEIVE_PP_OVERDUE_EMAIL.value]}
+    )
+
+    program = ProgramFactory(business_area=business_area, status=Program.ACTIVE)
+    cycle = ProgramCycleFactory(program=program)
+    pp = PaymentPlanFactory(
+        dispersion_start_date=now() - timedelta(days=10),
+        dispersion_end_date=now(),
+        status=PaymentPlan.Status.ACCEPTED,
+        program_cycle=cycle,
+    )
+    pp.refresh_from_db()
+    program = pp.program
+    program.reconciliation_window_in_days = 10
+    program.send_reconciliation_window_expiry_notifications = True
+    program.save()
+
+    superuser_with_perm = UserFactory(partner=partner_unicef_hq, is_superuser=True)
+    RoleAssignment.objects.create(user=superuser_with_perm, role=role, business_area=business_area, program=program)
+
+    with mock.patch.object(User, "email_user", autospec=True) as mock_email_user:
+        PaymentPlanService(pp).send_reconciliation_overdue_email_for_pp()
+
+        assert mock_email_user.call_count == 1
+        assert mock_email_user.call_args_list[0].args[0] == superuser_with_perm
 
 
 @pytest.fixture

--- a/tests/unit/apps/payment/test_payment_plan_services.py
+++ b/tests/unit/apps/payment/test_payment_plan_services.py
@@ -9,7 +9,6 @@ from aniso8601 import parse_date
 from django.contrib.contenttypes.models import ContentType
 from django.core.files.base import ContentFile
 from django.db import IntegrityError, transaction
-from django.test import override_settings
 from django.utils import timezone
 from django.utils.timezone import now
 from freezegun import freeze_time
@@ -1827,7 +1826,6 @@ def test_get_collector() -> None:
     assert collcector_type == "PRIMARY"
 
 
-@override_settings(ENV="prod")
 def test_send_reconciliation_overdue_email_recipients(business_area: Any) -> None:
     partner_unicef = PartnerFactory(name="UNICEF")
     partner_unicef_hq = PartnerFactory(name="UNICEF HQ", parent=partner_unicef)

--- a/tests/unit/apps/periodic_data_update/test_periodic_data_update_online_edit_notification.py
+++ b/tests/unit/apps/periodic_data_update/test_periodic_data_update_online_edit_notification.py
@@ -406,23 +406,7 @@ def test_send_email_notification_disabled_by_business_area(
 
 @mock.patch("hope.apps.utils.mailjet.send_email_async_task.delay")
 @override_config(SEND_PDU_ONLINE_EDIT_NOTIFICATION=True)
-@override_settings(EMAIL_SUBJECT_PREFIX="test")
-def test_send_email_notification_subject_test_env(
-    mock_send: Any, pdu_with_authorized_users: PDUOnlineEdit, user_action_user: User
-) -> None:
-    pdu_notification = PDUOnlineEditNotification(
-        pdu_with_authorized_users,
-        PDUOnlineEditNotification.ACTION_SEND_FOR_APPROVAL,
-        user_action_user,
-        "1 January 2025",
-    )
-    assert pdu_notification.email.subject == "[test] PDU Online Edit pending for Approval"
-
-
-@mock.patch("hope.apps.utils.mailjet.send_email_async_task.delay")
-@override_config(SEND_PDU_ONLINE_EDIT_NOTIFICATION=True)
-@override_settings(EMAIL_SUBJECT_PREFIX="")
-def test_send_email_notification_subject_prod_env(
+def test_send_email_notification_subject_send_for_approval(
     mock_send: Any, pdu_with_authorized_users: PDUOnlineEdit, user_action_user: User
 ) -> None:
     pdu_notification = PDUOnlineEditNotification(

--- a/tests/unit/apps/periodic_data_update/test_periodic_data_update_online_edit_notification.py
+++ b/tests/unit/apps/periodic_data_update/test_periodic_data_update_online_edit_notification.py
@@ -473,7 +473,6 @@ def test_send_email_notification_without_catch_all_email(
     assert mock_post.call_count == 1
 
 
-@override_settings(ENV="prod")
 def send_email_notification_exclude_superuser(
     pdu_with_authorized_users: PDUOnlineEdit, user_action_user: User, authorized_users: dict
 ) -> None:

--- a/tests/unit/apps/periodic_data_update/test_periodic_data_update_online_edit_notification.py
+++ b/tests/unit/apps/periodic_data_update/test_periodic_data_update_online_edit_notification.py
@@ -492,6 +492,23 @@ def send_email_notification_exclude_superuser(
     assert authorized_users["unicef_hq_authorized"] not in actual_recipients
 
 
+@override_config(SEND_PDU_ONLINE_EDIT_NOTIFICATION=True, NOTIFY_INTERNAL_USERS=True)
+def test_send_email_notification_include_internal_users(
+    pdu_with_authorized_users: PDUOnlineEdit, user_action_user: User, authorized_users: dict
+) -> None:
+    authorized_users["unicef_hq_authorized"].is_superuser = True
+    authorized_users["unicef_hq_authorized"].save()
+
+    pdu_notification = PDUOnlineEditNotification(
+        pdu_with_authorized_users,
+        PDUOnlineEditNotification.ACTION_SEND_FOR_APPROVAL,
+        user_action_user,
+        "1 January 2025",
+    )
+
+    assert authorized_users["unicef_hq_authorized"] in pdu_notification.user_recipients
+
+
 @override_config(
     SEND_PDU_ONLINE_EDIT_NOTIFICATION=True,
     ENABLE_MAILJET=True,

--- a/tests/unit/apps/sanction_list/test_check_against_sanction_list_task.py
+++ b/tests/unit/apps/sanction_list/test_check_against_sanction_list_task.py
@@ -86,7 +86,7 @@ def make_uploaded_file(sanction_list: SanctionList) -> Any:
 
 @patch("hope.apps.utils.celery_tasks.requests.post")
 @patch("hope.apps.sanction_list.tasks.check_against_sanction_list.load_workbook")
-@override_settings(EMAIL_SUBJECT_PREFIX="test")
+@override_settings(DEFAULT_EMAIL_DISPLAY="test")
 @override_config(ENABLE_MAILJET=True)
 @freeze_time("2024-01-10 01:01:01")
 def test_sanction_list_email(
@@ -149,9 +149,9 @@ def test_sanction_list_email(
                 {
                     "From": {
                         "Email": settings.DEFAULT_EMAIL,
-                        "Name": settings.DEFAULT_EMAIL_DISPLAY,
+                        "Name": "test",
                     },
-                    "Subject": f"[test] {subject}",
+                    "Subject": subject,
                     "To": [{"Email": "test_email@email.com"}],
                     "Cc": [{"Email": settings.SANCTION_LIST_CC_MAIL}],
                     "HTMLPart": render_to_string(

--- a/tests/unit/apps/utils/test_mailjet.py
+++ b/tests/unit/apps/utils/test_mailjet.py
@@ -17,7 +17,7 @@ pytestmark = pytest.mark.django_db
 
 
 @patch("hope.apps.utils.celery_tasks.requests.post")
-@override_settings(EMAIL_SUBJECT_PREFIX="test")
+@override_settings(DEFAULT_EMAIL_DISPLAY="test")
 @override_config(ENABLE_MAILJET=True)
 def test_mailjet_body_with_template(mocked_requests_post: Any) -> None:
     mocked_requests_post.return_value.status_code = 200
@@ -36,9 +36,9 @@ def test_mailjet_body_with_template(mocked_requests_post: Any) -> None:
                 {
                     "From": {
                         "Email": settings.DEFAULT_EMAIL,
-                        "Name": settings.DEFAULT_EMAIL_DISPLAY,
+                        "Name": "test",
                     },
-                    "Subject": "[test] Subject for email with Template",
+                    "Subject": "Subject for email with Template",
                     "To": [
                         {
                             "Email": "test@email.com",
@@ -70,7 +70,7 @@ def test_mailjet_body_with_template(mocked_requests_post: Any) -> None:
 
 @patch("hope.apps.utils.celery_tasks.requests.post")
 @override_settings(
-    EMAIL_SUBJECT_PREFIX="test",
+    DEFAULT_EMAIL_DISPLAY="test",
     CATCH_ALL_EMAIL=["catchallemail@email.com", "catchallemail2@email.com"],
 )
 @override_config(ENABLE_MAILJET=True)
@@ -91,9 +91,9 @@ def test_mailjet_body_with_template_with_catch_all(mocked_requests_post: Any) ->
                 {
                     "From": {
                         "Email": settings.DEFAULT_EMAIL,
-                        "Name": settings.DEFAULT_EMAIL_DISPLAY,
+                        "Name": "test",
                     },
-                    "Subject": "[test] Subject for email with Template for Catch All",
+                    "Subject": "Subject for email with Template for Catch All",
                     "To": [
                         {
                             "Email": "catchallemail@email.com",
@@ -124,7 +124,7 @@ def test_mailjet_body_with_template_with_catch_all(mocked_requests_post: Any) ->
 
 
 @patch("hope.apps.utils.celery_tasks.requests.post")
-@override_settings(EMAIL_SUBJECT_PREFIX="test")
+@override_settings(DEFAULT_EMAIL_DISPLAY="test")
 @override_config(ENABLE_MAILJET=True)
 def test_mailjet_body_with_html_and_text_body(mocked_requests_post: Any) -> None:
     mocked_requests_post.return_value.status_code = 200
@@ -143,9 +143,9 @@ def test_mailjet_body_with_html_and_text_body(mocked_requests_post: Any) -> None
                 {
                     "From": {
                         "Email": settings.DEFAULT_EMAIL,
-                        "Name": settings.DEFAULT_EMAIL_DISPLAY,
+                        "Name": "test",
                     },
-                    "Subject": "[test] Subject for email with HTML and Text body",
+                    "Subject": "Subject for email with HTML and Text body",
                     "To": [
                         {
                             "Email": "test@email.com",
@@ -175,7 +175,7 @@ def test_mailjet_body_with_html_and_text_body(mocked_requests_post: Any) -> None
 
 
 @patch("hope.apps.utils.celery_tasks.requests.post")
-@override_settings(EMAIL_SUBJECT_PREFIX="test")
+@override_settings(DEFAULT_EMAIL_DISPLAY="test")
 @override_config(ENABLE_MAILJET=True)
 def test_mailjet_body_with_text_body(mocked_requests_post: Any) -> None:
     mocked_requests_post.return_value.status_code = 200
@@ -193,9 +193,9 @@ def test_mailjet_body_with_text_body(mocked_requests_post: Any) -> None:
                 {
                     "From": {
                         "Email": settings.DEFAULT_EMAIL,
-                        "Name": settings.DEFAULT_EMAIL_DISPLAY,
+                        "Name": "test",
                     },
-                    "Subject": "[test] Subject for email with Text body",
+                    "Subject": "Subject for email with Text body",
                     "To": [
                         {
                             "Email": "test@email.com",
@@ -224,7 +224,7 @@ def test_mailjet_body_with_text_body(mocked_requests_post: Any) -> None:
 
 
 @patch("hope.apps.utils.celery_tasks.requests.post")
-@override_settings(EMAIL_SUBJECT_PREFIX="test")
+@override_settings(DEFAULT_EMAIL_DISPLAY="test")
 @override_config(ENABLE_MAILJET=True)
 def test_mailjet_body_with_template_and_attachment(mocked_requests_post: Any) -> None:
     mocked_requests_post.return_value.status_code = 200
@@ -266,9 +266,9 @@ def test_mailjet_body_with_template_and_attachment(mocked_requests_post: Any) ->
                 {
                     "From": {
                         "Email": settings.DEFAULT_EMAIL,
-                        "Name": settings.DEFAULT_EMAIL_DISPLAY,
+                        "Name": "test",
                     },
-                    "Subject": "[test] Subject for email with Template and Attachments",
+                    "Subject": "Subject for email with Template and Attachments",
                     "To": [
                         {
                             "Email": "test@email.com",
@@ -372,7 +372,6 @@ def test_mailjet_incorrect_body_without_template_and_without_html_and_text_body(
 
 
 @patch("hope.apps.utils.celery_tasks.requests.post")
-@override_settings(EMAIL_SUBJECT_PREFIX="test")
 @override_config(ENABLE_MAILJET=True)
 def test_email_user_via_mailjet(mocked_requests_post: Any) -> None:
     mocked_requests_post.return_value.status_code = 200
@@ -390,7 +389,7 @@ def test_email_user_via_mailjet(mocked_requests_post: Any) -> None:
             "Messages": [
                 {
                     "From": {"Email": "sender@email.com", "Name": "Sender"},
-                    "Subject": "[test] Test subject",
+                    "Subject": "Test subject",
                     "To": [
                         {
                             "Email": "testuser@email.com",


### PR DESCRIPTION
Closes: [AB#333832](https://unicef.visualstudio.com/4e044e8d-bc28-4768-8074-f80ff6e4a0e5/_workitems/edit/333832)

---
**Breaking**: non-production emails no longer carry an [env] prefix in the subject. The environment marker moves to the sender display name - set per deployment via DEFAULT_EMAIL_DISPLAY (hope-deployment 0173ddc, e.g. [DEV] HOPE), so subjects are now identical across all environments. Any mail-client rule or filter matching on a subject prefix must be re-pointed at the sender name instead.

**Breaking**: the ENV == "prod" guard is gone, so superusers (and, for payment plan actions, staff users) are now excluded from notification recipients in every environment, not just prod. Testing notifications on dev/stg/trn therefore needs a non-superuser, non-staff account with the relevant role - or enable the new NOTIFY_INTERNAL_USERS Constance flag (default off) on that environment to have internal accounts included again.