### PR TITLE
es_reindex: stream populate reads (avoid WITH HOLD cursor materialization)

### DIFF
--- a/src/hope/apps/household/documents.py
+++ b/src/hope/apps/household/documents.py
@@ -1,11 +1,11 @@
 from django.conf import settings
-from django.db.models import QuerySet
+from django.db.models import Prefetch, QuerySet
 from django_elasticsearch_dsl import Document, fields
 from elasticsearch.dsl import AttrDict
 
 from hope.apps.core.es_analyzers import name_synonym_analyzer, phonetic_analyzer
 from hope.apps.utils.elasticsearch_utils import DEFAULT_SCRIPT
-from hope.models import Household, Individual, IndividualIdentity, IndividualRoleInHousehold
+from hope.models import Document as DocumentModel, Household, Individual, IndividualIdentity, IndividualRoleInHousehold
 
 type RelatedInstanceType = Document | Household | IndividualIdentity | IndividualRoleInHousehold
 
@@ -226,7 +226,18 @@ def get_individual_doc(program_id: str) -> type[IndividualDocument]:
             pass
 
         def get_queryset(self) -> QuerySet[Individual]:
-            return Individual.all_merge_status_objects.filter(program_id=program_id)
+            # select/prefetch mirror exactly what prepare() touches - without them every row
+            # costs ~6 extra queries, which dominates populate time on a remote database.
+            # Prefetch querysets MUST filter like the related managers (MERGED, not removed)
+            # or the prefetch cache would change which documents/identities get indexed.
+            return (
+                Individual.all_merge_status_objects.filter(program_id=program_id)
+                .select_related("household__admin1", "household__admin2", "business_area")
+                .prefetch_related(
+                    Prefetch("documents", queryset=DocumentModel.objects.select_related("type", "country")),
+                    Prefetch("identities", queryset=IndividualIdentity.objects.select_related("partner")),
+                )
+            )
 
     ProgramIndividualDocument.__name__ = f"IndividualDocument_{program.business_area.slug}_{program.code}"
     _set_django_attr(ProgramIndividualDocument, ProgramIndividualDocument.Django)
@@ -256,7 +267,17 @@ def get_household_doc(program_id: str) -> type[HouseholdDocument]:
             pass
 
         def get_queryset(self) -> QuerySet[Household]:
-            return Household.objects.filter(program_id=program_id)
+            # same rationale as the individual queryset above
+            return (
+                Household.objects.filter(program_id=program_id)
+                .select_related("head_of_household", "admin1", "admin2", "business_area")
+                .prefetch_related(
+                    Prefetch(
+                        "head_of_household__documents",
+                        queryset=DocumentModel.objects.select_related("type", "country"),
+                    )
+                )
+            )
 
     ProgramHouseholdDocument.__name__ = f"HouseholdDocument_{program.business_area.slug}_{program.code}"
     _set_django_attr(ProgramHouseholdDocument, ProgramHouseholdDocument.Django)

--- a/src/hope/apps/household/management/commands/es_populate_delta.py
+++ b/src/hope/apps/household/management/commands/es_populate_delta.py
@@ -265,15 +265,16 @@ class Command(BaseCommand):
     @staticmethod
     def _apply_delta(delta: dict, ind_doc: type, hh_doc: type, using: str, opts: dict) -> None:
         from hope.apps.utils.elasticsearch_utils import remove_elasticsearch_documents_by_matching_ids
-        from hope.models import Household, Individual
 
         chunk = opts["chunk_size"]
         parallel = opts["parallel"]
+        # get_queryset() rather than raw model managers: same scope (program + merge status)
+        # plus the select/prefetch that keeps prepare() from doing per-row queries
         if delta["ind_present"]:
-            qs = Individual.all_merge_status_objects.filter(id__in=delta["ind_present"]).iterator(chunk_size=chunk)
+            qs = ind_doc().get_queryset().filter(id__in=delta["ind_present"]).iterator(chunk_size=chunk)
             ind_doc().update(qs, action="index", parallel=parallel, using=using)
         if delta["hh_present"]:
-            qs = Household.objects.filter(id__in=delta["hh_present"]).iterator(chunk_size=chunk)
+            qs = hh_doc().get_queryset().filter(id__in=delta["hh_present"]).iterator(chunk_size=chunk)
             hh_doc().update(qs, action="index", parallel=parallel, using=using)
         if delta["ind_removed"]:
             remove_elasticsearch_documents_by_matching_ids([str(i) for i in delta["ind_removed"]], ind_doc, using=using)

--- a/src/hope/apps/household/management/commands/es_reindex.py
+++ b/src/hope/apps/household/management/commands/es_reindex.py
@@ -36,9 +36,13 @@ instead of rebuilding:
   which deletes dark versions newer than the alias target first for a clean rebuild.
 
 Versions BELOW the alias target (the rollback safety net during a sanity window) are never
-touched; those are ``es_drop_old_index_versions``' job, days later. Re-running the command is
-always safe; a fully-reindexed program just gets its next version (there is deliberately no
-"mapping unchanged, skip" detection - the operator decides when a reindex is due).
+touched; those are ``es_drop_old_index_versions``' job, days later.
+
+Fleet-level resume: a program whose ALIAS TARGETS already carry the current code mapping stamp
+was completed by this very code, so it is skipped - re-running ``--all`` after a mid-fleet
+crash finishes only the remaining programs. ``--force`` rebuilds such programs anyway (next
+version as usual); ``--sweep-wrecks`` also bypasses the skip, because analyzer-only changes
+are invisible to the stamp and a sweep must never be suppressed by it.
 
 Examples
 --------
@@ -118,6 +122,15 @@ class Command(BaseCommand):
             ),
         )
         parser.add_argument(
+            "--force",
+            action="store_true",
+            help=(
+                "Reindex even programs whose alias target already carries the current code "
+                "mapping stamp. Without it such programs are skipped, so a re-run after a "
+                "mid-fleet crash finishes only the remaining programs."
+            ),
+        )
+        parser.add_argument(
             "--force-unlock",
             action="store_true",
             help="Remove a stale lock left by a crashed run, then continue.",
@@ -145,7 +158,7 @@ class Command(BaseCommand):
             self._report_status(es, code_by_id)
             return
         if opts["dry_run"]:
-            self._report_plan(es, code_by_id)
+            self._report_plan(es, code_by_id, opts)
             return
 
         self._acquire_lock(es, force=opts["force_unlock"])
@@ -196,7 +209,7 @@ class Command(BaseCommand):
                 db_count = doc_class().get_queryset().count()
                 self.stdout.write(f"{code}  {name}: {detail}  versions={versions}  es={es_count} db={db_count}")
 
-    def _report_plan(self, es: Elasticsearch, code_by_id: dict) -> None:
+    def _report_plan(self, es: Elasticsearch, code_by_id: dict, opts: dict) -> None:
         for pid, code in sorted(code_by_id.items(), key=lambda kv: kv[1] or ""):
             docs = self._doc_classes(str(pid))
             names = [d._index._name for d in docs]
@@ -204,7 +217,14 @@ class Command(BaseCommand):
             if not_aliased:
                 self.stdout.write(f"{code}: SKIP - not an alias yet: {not_aliased} (run es_bootstrap_aliases)")
                 continue
-            current = {n: self._alias_target(es, n) for n in names}
+            current = {n: t for n in names if (t := self._alias_target(es, n)) is not None}
+            if (
+                not opts["force"]
+                and not opts["sweep_wrecks"]
+                and all(self._resumable(es, doc, current[doc._index._name]) for doc in docs)
+            ):
+                self.stdout.write(f"{code}: up-to-date {list(current.values())} - would skip (--force to rebuild)")
+                continue
             try:
                 suffix = self._pair_suffix(current)
             except CommandError as exc:
@@ -277,6 +297,17 @@ class Command(BaseCommand):
             if target is None:
                 raise CommandError(f"{name} is not an alias - run es_bootstrap_aliases first")
             old[name] = target
+
+        # fleet-level resume: alias targets stamped with the current code mapping were completed
+        # by this very code - skip, so a crashed --all run finishes only the remainder. --force
+        # rebuilds anyway; --sweep-wrecks bypasses too (analyzer-only changes are invisible to
+        # the stamp, a sweep must never be suppressed by it).
+        if (
+            not opts["force"]
+            and not opts["sweep_wrecks"]
+            and all(self._resumable(es, doc_class, old[doc_class._index._name]) for doc_class in docs)
+        ):
+            return f"up-to-date ({list(old.values())} built from current mapping) - skipped, --force to rebuild"
 
         if opts["sweep_wrecks"]:
             for name, old_target in old.items():

--- a/src/hope/apps/household/management/commands/es_reindex.py
+++ b/src/hope/apps/household/management/commands/es_reindex.py
@@ -60,7 +60,7 @@ Read-only state report::
 
 from datetime import UTC, datetime
 import re
-from typing import Any
+from typing import TYPE_CHECKING, Any
 import uuid
 
 from constance import config
@@ -79,6 +79,9 @@ from hope.apps.household.services.index_management import (
     versioned_doc,
 )
 from hope.apps.utils.elasticsearch_utils import populate_index
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 DELTA_SINCE_BUFFER_MINUTES = 5
 
@@ -294,7 +297,12 @@ class Command(BaseCommand):
                 es.indices.delete(index=target)
                 self.stdout.write(self.style.WARNING(f"  rebuilt {target} (mapping changed since it was created)"))
             create_versioned_index(es, doc_class, suffix=suffix, attach_alias=False)
-            populate_index(vdoc().get_queryset(), vdoc, chunk_size=opts["chunk_size"])
+            queryset = vdoc().get_queryset()
+            db_count = queryset.count()
+            self.stdout.write(f"  populating {target} ({db_count} docs from db)")
+            self.stdout.flush()
+            populate_index(queryset, vdoc, chunk_size=opts["chunk_size"], progress_cb=self._progress(target, db_count))
+            self.stdout.write(f"  populated {target}")
 
         # the delta anchor covers the oldest target: for a fresh index creation_date == this run's
         # populate start, for a resumed one it reaches back to everything the crashed run may have missed
@@ -320,6 +328,13 @@ class Command(BaseCommand):
         self._delta(pid, since=final_start)
         note = ", resumed dark pair" if resumed else ""
         return f"reindexed {list(old.values())} -> _{suffix}, aliases swapped (old kept for rollback){note}"
+
+    def _progress(self, target: str, db_count: int) -> "Callable[[int], None]":
+        def report(n: int) -> None:
+            self.stdout.write(f"    {target}: {n}/{db_count}")
+            self.stdout.flush()
+
+        return report
 
     @staticmethod
     def _pair_suffix(old: dict) -> str:

--- a/src/hope/apps/utils/elasticsearch_utils.py
+++ b/src/hope/apps/utils/elasticsearch_utils.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 import enum
 import logging
 from typing import TYPE_CHECKING, Any
@@ -17,15 +18,36 @@ if TYPE_CHECKING:
     from django_elasticsearch_dsl import Document
 
 
-def populate_index(queryset: "QuerySet", doc: Any, parallel: bool = False, chunk_size: int = 2000) -> None:
+PROGRESS_EVERY = 1_000
+
+
+def populate_index(
+    queryset: "QuerySet",
+    doc: Any,
+    parallel: bool = False,
+    chunk_size: int = 2000,
+    progress_cb: Callable[[int], None] | None = None,
+) -> None:
     if not config.IS_ELASTICSEARCH_ENABLED:  # pragma: no cover
         return
     # atomic() so iterator() opens a plain (lazy) server-side cursor: outside a transaction
     # Django declares it WITH HOLD, which materializes the ENTIRE result set on DECLARE
     # before the first row arrives - minutes-to-hours on big programs under IO pressure
     with transaction.atomic():
-        qs = queryset.iterator(chunk_size=chunk_size)
+        qs: Any = queryset.iterator(chunk_size=chunk_size)
+        if progress_cb is not None:
+            qs = _reporting(qs, progress_cb)
         doc().update(qs, parallel=parallel)
+
+
+def _reporting(rows: Any, cb: Callable[[int], None]) -> Any:
+    n = 0
+    for row in rows:
+        yield row
+        n += 1
+        if n % PROGRESS_EVERY == 0:
+            cb(n)
+    cb(n)
 
 
 def remove_elasticsearch_documents_by_matching_ids(

--- a/src/hope/apps/utils/elasticsearch_utils.py
+++ b/src/hope/apps/utils/elasticsearch_utils.py
@@ -3,6 +3,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from constance import config
+from django.db import transaction
 from elasticsearch import NotFoundError
 from elasticsearch.dsl import connections
 
@@ -19,8 +20,12 @@ if TYPE_CHECKING:
 def populate_index(queryset: "QuerySet", doc: Any, parallel: bool = False, chunk_size: int = 2000) -> None:
     if not config.IS_ELASTICSEARCH_ENABLED:  # pragma: no cover
         return
-    qs = queryset.iterator(chunk_size=chunk_size)
-    doc().update(qs, parallel=parallel)
+    # atomic() so iterator() opens a plain (lazy) server-side cursor: outside a transaction
+    # Django declares it WITH HOLD, which materializes the ENTIRE result set on DECLARE
+    # before the first row arrives - minutes-to-hours on big programs under IO pressure
+    with transaction.atomic():
+        qs = queryset.iterator(chunk_size=chunk_size)
+        doc().update(qs, parallel=parallel)
 
 
 def remove_elasticsearch_documents_by_matching_ids(

--- a/src/hope/apps/utils/elasticsearch_utils.py
+++ b/src/hope/apps/utils/elasticsearch_utils.py
@@ -34,6 +34,12 @@ def populate_index(
     # Django declares it WITH HOLD, which materializes the ENTIRE result set on DECLARE
     # before the first row arrives - minutes-to-hours on big programs under IO pressure
     with transaction.atomic():
+        # cursors are planned for partial reads (cursor_tuple_fraction=0.1) -> plain index
+        # scan -> one RANDOM heap page read per row on a big scattered table. We always read
+        # the FULL result, and saying so buys a bitmap heap scan (sequential, prefetched):
+        # measured 7x faster chunk fetches on remote disks. SET LOCAL dies with this txn.
+        with transaction.get_connection().cursor() as c:
+            c.execute("SET LOCAL cursor_tuple_fraction = 1.0")
         qs: Any = queryset.iterator(chunk_size=chunk_size)
         if progress_cb is not None:
             qs = _reporting(qs, progress_cb)

--- a/tests/unit/apps/household/test_es_reindex.py
+++ b/tests/unit/apps/household/test_es_reindex.py
@@ -162,6 +162,21 @@ def es_sanity_window(index_names: list[str]) -> MagicMock:
 
 
 @pytest.fixture
+def es_up_to_date(program: Program) -> MagicMock:
+    """Alias already on _v2 whose mapping stamp MATCHES the current code mapping (completed run)."""
+    from hope.apps.household.services.index_management import mapping_content_hash
+
+    docs = [get_individual_doc(str(program.id)), get_household_doc(str(program.id))]
+    hashes = {f"{doc._index._name}_v2": mapping_content_hash(doc._index.to_dict().get("mappings")) for doc in docs}
+    es = _make_es(alias_version="v2", swap_flips_to="v3")
+    es.indices.exists.side_effect = lambda **kw: kw["index"] in hashes
+    es.indices.get_mapping.side_effect = lambda **kw: {
+        kw["index"]: {"mappings": {"_meta": {"hope_mapping_hash": hashes[kw["index"]]}}}
+    }
+    return es
+
+
+@pytest.fixture
 def es_locked() -> MagicMock:
     es = _make_es()
     es.indices.create.side_effect = BadRequestError("resource_already_exists_exception", MagicMock(), None)
@@ -419,6 +434,48 @@ def test_status_reports_alias_and_versions(program: Program, es_aliased: MagicMo
     assert "ALIAS ->" in out.getvalue()
     assert "versions=[1]" in out.getvalue()
     es_aliased.indices.create.assert_not_called()
+
+
+@override_config(IS_ELASTICSEARCH_ENABLED=True)
+def test_up_to_date_program_is_skipped(program: Program, es_up_to_date: MagicMock) -> None:
+    out = StringIO()
+    with patch(GET_CONN, return_value=es_up_to_date), patch(DELTA_CALL) as delta, patch(POPULATE) as populate:
+        call_command(CMD, program=str(program.id), stdout=out)
+
+    assert "up-to-date" in out.getvalue()
+    populate.assert_not_called()
+    delta.assert_not_called()
+    es_up_to_date.indices.update_aliases.assert_not_called()
+
+
+@override_config(IS_ELASTICSEARCH_ENABLED=True)
+def test_force_rebuilds_an_up_to_date_program(
+    program: Program, index_names: list[str], es_up_to_date: MagicMock
+) -> None:
+    with patch(GET_CONN, return_value=es_up_to_date), patch(DELTA_CALL), patch(POPULATE) as populate:
+        call_command(CMD, program=str(program.id), force=True, stdout=StringIO())
+
+    populated = [call.args[1]._index._name for call in populate.call_args_list]
+    assert sorted(populated) == sorted(f"{n}_v3" for n in index_names)
+    assert es_up_to_date.indices.update_aliases.call_count == 1
+
+
+@override_config(IS_ELASTICSEARCH_ENABLED=True)
+def test_sweep_wrecks_bypasses_the_up_to_date_skip(program: Program, es_up_to_date: MagicMock) -> None:
+    with patch(GET_CONN, return_value=es_up_to_date), patch(DELTA_CALL), patch(POPULATE) as populate:
+        call_command(CMD, program=str(program.id), sweep_wrecks=True, stdout=StringIO())
+
+    populate.assert_called()
+
+
+@override_config(IS_ELASTICSEARCH_ENABLED=True)
+def test_dry_run_reports_up_to_date_programs(program: Program, es_up_to_date: MagicMock) -> None:
+    out = StringIO()
+    with patch(GET_CONN, return_value=es_up_to_date):
+        call_command(CMD, program=str(program.id), dry_run=True, stdout=out)
+
+    assert "would skip" in out.getvalue()
+    es_up_to_date.indices.create.assert_not_called()
 
 
 @override_config(IS_ELASTICSEARCH_ENABLED=True)


### PR DESCRIPTION
Found during the eph-1 M2 canary: `es_reindex` sat silently for 20+ minutes before the first bulk write. The populate queryset iterator runs outside a transaction, so Django declares its server-side cursor `WITH HOLD` - PostgreSQL then materializes the ENTIRE result set on `DECLARE` (visible as `IO DataFileRead` in `pg_stat_activity`) before returning a single row. On a loaded DB that is minutes per program; on prod-sized programs (2.1M individuals) it would be far worse.

Wrapping the populate in `transaction.atomic()` makes the cursor a plain lazy one: rows stream immediately and bulk indexing starts within seconds.

Also includes the mypy fix for `EsForm.clean()` (`BaseForm.clean()` returns `dict | None`).