### PR TITLE
Feature/export embedings

### DIFF
--- a/docs/components/hde.md
+++ b/docs/components/hde.md
@@ -3,3 +3,6 @@
 It provides users with powerful capabilities to identify and remove duplicate records within the system, ensuring that data remains clean, consistent, and reliable.
 
 > <https://unicef.github.io/hope-dedup-engine/>{:target="_blank"}
+
+For the one-shot encode-only / embeddings zip flow, see
+[Export encodings](../guide-dev/export-encodings.md).

--- a/docs/guide-dev/export-encodings.md
+++ b/docs/guide-dev/export-encodings.md
@@ -1,0 +1,174 @@
+---
+title: Export encodings
+---
+
+# Export encodings (`export_encodings`)
+
+One-shot management command that encodes Country Office (CO) face photos via the
+[Deduplication Engine](../components/hde.md) (`encode_only`) and requests a zip of
+embeddings as a **signed URL**. Progress is tracked in a JSON state file in Django
+default storage so every mode is idempotent and safe to re-run.
+
+There is no admin UI, Celery task, or REST route in HOPE for this flow — only this command.
+
+## Prerequisites
+
+- Deduplication Engine reachable over HTTP with Token auth.
+- Individuals in the target business area(s) with a non-empty `photo`, not withdrawn/duplicate/removed.
+- Engine image registration uses **filename mode**: HOPE sends
+  `{reference_pk: individual.id, filename: individual.photo.name}`. The engine must be able to
+  open that blob key in its Hope storage (shared Azure/Azurite, or filenames that already exist there).
+- `--dedup-url` and `--dedup-token` are **required** on every run (not read from env).
+
+## Command
+
+```bash
+python manage.py export_encodings \
+  --mode submit|status|export \
+  --state-file encodings/<run-name>.json \
+  --dedup-url https://dedup.example.org/ \
+  --dedup-token <token> \
+  [--business-areas afghanistan,ukraine] \
+  [--chunk-size 10000] \
+  [--upload-batch-size 5000] \
+  [--export-format npy|jsonl]
+```
+
+| Flag | Required | Notes |
+|------|----------|--------|
+| `--mode` | yes | `submit`, `status`, or `export` |
+| `--state-file` | yes | Key in Django **default storage** (not a host path). Local default: `/data/uploads/<key>` |
+| `--dedup-url` | yes | Engine base URL (trailing slash optional) |
+| `--dedup-token` | yes | `Authorization: Token …` value |
+| `--business-areas` | submit only | Comma-separated BA slugs |
+| `--chunk-size` | no | Default `10000`. Pinned in the state file on first submit |
+| `--upload-batch-size` | no | Default `5000`. Pinned on first submit; changing it on resume aborts |
+| `--export-format` | export only | `npy` (default) or `jsonl` |
+
+### Where is the state file?
+
+`--state-file` is a storage key. With local `FileSystemStorage`:
+
+```text
+/data/uploads/encodings/<run-name>.json
+```
+
+In Docker:
+
+```bash
+docker exec <hope-backend> cat /data/uploads/encodings/<run-name>.json
+```
+
+## Typical workflow
+
+Run the three modes in order. Re-run `status` / `export` until finished.
+
+```bash
+# 1) Create sets, register images, start encode_only
+python manage.py export_encodings \
+  --mode submit \
+  --state-file encodings/run1.json \
+  --business-areas afghanistan \
+  --chunk-size 10000 \
+  --dedup-url https://dedup.example.org/ \
+  --dedup-token "$TOKEN"
+
+# 2) Poll set states (safe while encoding is still running)
+python manage.py export_encodings \
+  --mode status \
+  --state-file encodings/run1.json \
+  --dedup-url https://dedup.example.org/ \
+  --dedup-token "$TOKEN"
+
+# 3) Request zip / poll signed URL (only when all chunks of a CO are Encoded+)
+python manage.py export_encodings \
+  --mode export \
+  --state-file encodings/run1.json \
+  --export-format npy \
+  --dedup-url https://dedup.example.org/ \
+  --dedup-token "$TOKEN"
+```
+
+### Mode: `submit`
+
+For each business area, selects individuals with photos (ordered by `id`), slices them into
+`--chunk-size` groups, and for each unfinished chunk:
+
+1. `POST deduplication_sets/` — group reference id `enc-{ba}-{run_id}-{index:05d}`
+2. `POST {set}/images/` in batches of `--upload-batch-size`
+3. `POST {set}/ready/` then `POST {set}/process/?encode_only=true`
+4. Updates the state file after each step (`uploaded_batches` enables resume mid-upload)
+
+Use a **new** `--state-file` if you change `--chunk-size` or `--upload-batch-size` for a new run
+(those values are locked in an existing state file).
+
+### Mode: `status`
+
+For each submitted chunk, `GET deduplication_sets/{id}/` and refresh `engine_state` in the state file.
+Prints a per-CO summary (e.g. `Encoding in progress=3, Encoded=8`).
+
+### Mode: `export`
+
+Runs only for COs whose chunks are all in an exportable engine state:
+`Encoded`, `Deduplicated`, or `Approved`.
+
+Export slots in the state file are keyed by `{co_slug}:{format}` (so `npy` and `jsonl` are independent).
+
+#### Does `export` POST or GET?
+
+Yes — same `--mode export`, two engine calls depending on state-file contents:
+
+| State file for `{co}:{format}` | Engine call | Purpose |
+|--------------------------------|-------------|---------|
+| No entry, or `key` missing/null | **`POST /encodings_exports/`** | Start zip job; store returned blob `key` as `pending` |
+| `key` is set | **`GET /encodings_exports/status/?key=…`** | Poll / renew signed URL |
+
+Details for the GET path:
+
+- `ready` → store `url` + `expires_at` (re-running renews the SAS URL; no re-zip)
+- `failed` → clear `key` so the next export run POSTs again
+- `pending` → wait; if older than 2 hours, clear and POST under a new key
+
+## State file shape (summary)
+
+```json
+{
+  "run_id": "a1b2c3d4",
+  "chunk_size": 10000,
+  "upload_batch_size": 5000,
+  "business_areas": ["afghanistan"],
+  "chunks": [
+    {
+      "reference_id": "enc-afghanistan-a1b2c3d4-00000",
+      "set_id": "uuid",
+      "image_count": 10000,
+      "step": "processed",
+      "engine_state": "Encoded"
+    }
+  ],
+  "exports": {
+    "afghanistan:npy": {
+      "key": "exports/1/afghanistan/afghanistan-….npy.zip",
+      "format": "npy",
+      "state": "ready",
+      "url": "https://…",
+      "expires_at": "…"
+    }
+  }
+}
+```
+
+The deliverable is the signed `url` (plus `manifest.json` inside the zip).
+
+## Chunking and scale
+
+Each chunk is its own Dedup set **group**, so engine workers can encode chunks in parallel.
+Smaller `--chunk-size` (e.g. `2` in local tests) creates more sets and exercises multi-chunk
+status/export; production typically uses `10000`.
+
+## Local notes
+
+- From inside the HOPE backend container, `127.0.0.1:8000` is HOPE itself. Point `--dedup-url`
+  at a host/network address that reaches the Dedup API (or a local forwarder).
+- Filename-only testing: seed `Individual.photo.name` to blob keys that already exist in Dedup’s
+  Hope storage; the command never opens photo bytes in HOPE.

--- a/src/hope/apps/registration_data/management/commands/export_encodings.py
+++ b/src/hope/apps/registration_data/management/commands/export_encodings.py
@@ -1,0 +1,461 @@
+"""One-shot tool to encode CO images via the Deduplication Engine and collect embeddings.
+
+Splits individuals of the given business areas into deterministic chunks, submits each
+chunk as its own deduplication set group (so engine workers process chunks in parallel),
+runs encode-only processing, and later collects the embeddings into shareable
+``.jsonl.gz`` files plus a ``manifest.json``.
+
+All progress is tracked in a JSON state file, so every mode is idempotent and safe to
+re-run after a crash or interruption.
+
+Usage:
+
+    manage.py export_encodings --mode submit --state-file run1.json \
+        --business-areas afghanistan,ukraine --dedup-url https://... --dedup-token ...
+
+    manage.py export_encodings --mode status --state-file run1.json ...
+
+    manage.py export_encodings --mode collect --state-file run1.json --output-dir out/ ...
+"""
+
+from argparse import ArgumentParser
+import base64
+import gzip
+import hashlib
+import io
+import json
+import os
+import time
+from typing import Any
+import uuid
+
+from django.core.files.base import ContentFile
+from django.core.files.storage import default_storage
+from django.core.management.base import BaseCommand, CommandError
+from django.db.models import Q, QuerySet
+import requests
+
+from hope.models import BusinessArea, Individual
+
+DEFAULT_UPLOAD_BATCH_SIZES = {"base64": 200, "filename": 5000}
+ENCODINGS_PAGE_SIZE = 1000
+# Engine set states in which embeddings are retrievable.
+COLLECTIBLE_STATES = {"Encoded", "Deduplicated", "Approved"}
+FAILED_STATES = {"Encoding failed", "Deduplication failed", "Failed"}
+
+
+class DedupEngineClient:
+    """Minimal client for the Deduplication Engine REST API (token auth)."""
+
+    MAX_ATTEMPTS = 3
+    BACKOFF_SECONDS = 5
+
+    class DedupEngineError(Exception):
+        pass
+
+    def __init__(self, base_url: str, token: str) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.session = requests.Session()
+        self.session.headers["Authorization"] = f"Token {token}"
+
+    def _request(self, method: str, path: str, **kwargs: Any) -> requests.Response:
+        url = f"{self.base_url}/{path}"
+        last_error: Exception | None = None
+        for attempt in range(1, self.MAX_ATTEMPTS + 1):
+            try:
+                response = self.session.request(method, url, timeout=300, **kwargs)
+            except requests.RequestException as exc:
+                last_error = exc
+            else:
+                if response.status_code < 500:
+                    if response.status_code >= 400:
+                        raise self.DedupEngineError(
+                            f"{method} {url} failed with {response.status_code}: {response.text[:1000]}"
+                        )
+                    return response
+                last_error = self.DedupEngineError(
+                    f"{method} {url} failed with {response.status_code}: {response.text[:1000]}"
+                )
+            if attempt < self.MAX_ATTEMPTS:
+                time.sleep(self.BACKOFF_SECONDS * attempt)
+        raise self.DedupEngineError(f"{method} {url} failed after {self.MAX_ATTEMPTS} attempts") from last_error
+
+    def create_set(self, reference_pk: str, name: str) -> dict:
+        response = self._request(
+            "POST",
+            "deduplication_sets/",
+            json={"reference_pk": reference_pk, "name": name, "notify": False},
+        )
+        return response.json()
+
+    def register_images(self, set_id: str, items: list[dict]) -> None:
+        self._request("POST", f"deduplication_sets/{set_id}/images/", json=items)
+
+    def mark_ready(self, set_id: str) -> None:
+        self._request("POST", f"deduplication_sets/{set_id}/ready/")
+
+    def process(self, set_id: str, encode_only: bool = True) -> None:
+        params = {"encode_only": "true"} if encode_only else {}
+        self._request("POST", f"deduplication_sets/{set_id}/process/", params=params)
+
+    def get_set(self, set_id: str) -> dict:
+        return self._request("GET", f"deduplication_sets/{set_id}/").json()
+
+    def get_encodings_page(self, set_id: str, page: int, page_size: int) -> dict:
+        response = self._request(
+            "GET",
+            f"deduplication_sets/{set_id}/encodings/",
+            params={"page": page, "page_size": page_size},
+        )
+        return response.json()
+
+
+class Command(BaseCommand):
+    help = "Encode CO images via the Deduplication Engine (encode_only) and collect embeddings for sharing."
+
+    def add_arguments(self, parser: ArgumentParser) -> None:
+        parser.add_argument("--mode", required=True, choices=["submit", "status", "collect"])
+        parser.add_argument(
+            "--state-file",
+            required=True,
+            help="Default-storage key of the JSON state file for this run (survives pod restarts).",
+        )
+        parser.add_argument(
+            "--business-areas",
+            help="Comma-separated business area slugs to encode (required for submit).",
+        )
+        parser.add_argument("--dedup-url", default=os.environ.get("DEDUPLICATION_ENGINE_API_URL"))
+        parser.add_argument("--dedup-token", default=os.environ.get("DEDUPLICATION_ENGINE_API_KEY"))
+        parser.add_argument("--chunk-size", type=int, default=10000)
+        parser.add_argument(
+            "--image-transfer",
+            choices=["base64", "filename"],
+            default="base64",
+            help="base64: image content in the payload (current engine). "
+            "filename: storage path only (requires the shared-blob-storage engine build).",
+        )
+        parser.add_argument(
+            "--upload-batch-size",
+            type=int,
+            default=None,
+            help="Images per registration request. Defaults: 200 (base64) / 5000 (filename).",
+        )
+        parser.add_argument(
+            "--output-dir",
+            help="Default-storage prefix for embedding files and manifest (required for collect).",
+        )
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        if not options["dedup_url"] or not options["dedup_token"]:
+            raise CommandError(
+                "Deduplication engine URL/token missing: pass --dedup-url/--dedup-token or set "
+                "DEDUPLICATION_ENGINE_API_URL/DEDUPLICATION_ENGINE_API_KEY."
+            )
+        self.client = DedupEngineClient(options["dedup_url"], options["dedup_token"])
+        self.state_key = options["state_file"]
+        self.state = self._load_state()
+
+        mode = options["mode"]
+        if mode == "submit":
+            self._run_submit(options)
+        elif mode == "status":
+            self._run_status()
+        else:
+            self._run_collect(options)
+
+    # ----- state file (kept in Django default storage so it survives pod restarts) -----
+
+    def _load_state(self) -> dict:
+        if default_storage.exists(self.state_key):
+            with default_storage.open(self.state_key, "rb") as f:
+                return json.load(f)
+        return {}
+
+    def _save_state(self) -> None:
+        self._save_to_storage(self.state_key, json.dumps(self.state, indent=2).encode())
+
+    @staticmethod
+    def _save_to_storage(name: str, data: bytes) -> None:
+        # Storage.save() mangles existing names instead of overwriting, so delete first.
+        if default_storage.exists(name):
+            default_storage.delete(name)
+        default_storage.save(name, ContentFile(data))
+
+    # ----- submit -----
+
+    def _individuals_queryset(self, business_area_slug: str) -> QuerySet[Individual]:
+        return (
+            Individual.all_objects.filter(is_removed=False, business_area__slug=business_area_slug)
+            .exclude(Q(photo="") | Q(withdrawn=True) | Q(duplicate=True))
+            .order_by("id")
+            .only("id", "photo")
+        )
+
+    def _run_submit(self, options: dict) -> None:
+        if not options["business_areas"]:
+            raise CommandError("--business-areas is required for submit mode.")
+        slugs = [slug.strip() for slug in options["business_areas"].split(",") if slug.strip()]
+        existing = set(BusinessArea.objects.filter(slug__in=slugs).values_list("slug", flat=True))
+        if missing := set(slugs) - existing:
+            raise CommandError(f"Unknown business area slug(s): {', '.join(sorted(missing))}")
+
+        upload_batch_size = options["upload_batch_size"] or DEFAULT_UPLOAD_BATCH_SIZES[options["image_transfer"]]
+        if not self.state:
+            self.state = {
+                "run_id": uuid.uuid4().hex[:8],
+                "chunk_size": options["chunk_size"],
+                "image_transfer": options["image_transfer"],
+                "upload_batch_size": upload_batch_size,
+                "business_areas": slugs,
+                "chunks": [],
+            }
+            self._save_state()
+        else:
+            # Resume: pinned parameters must match, otherwise batch-offset resume would corrupt uploads.
+            for key, value in (
+                ("chunk_size", options["chunk_size"]),
+                ("image_transfer", options["image_transfer"]),
+                ("upload_batch_size", upload_batch_size),
+            ):
+                if self.state[key] != value:
+                    raise CommandError(
+                        f"State file was created with {key}={self.state[key]}, but current value is {value}. "
+                        "Re-run with matching parameters or use a new state file."
+                    )
+            if set(self.state["business_areas"]) != set(slugs):
+                raise CommandError(
+                    f"State file was created for business areas {self.state['business_areas']}; "
+                    "use a new state file for a different selection."
+                )
+
+        chunk_size = self.state["chunk_size"]
+        chunks_by_reference = {chunk["reference_id"]: chunk for chunk in self.state["chunks"]}
+
+        for slug in self.state["business_areas"]:
+            queryset = self._individuals_queryset(slug)
+            total = queryset.count()
+            self.stdout.write(f"{slug}: {total} individuals with photos")
+            for index in range((total + chunk_size - 1) // chunk_size):
+                reference_id = f"enc-{slug}-{self.state['run_id']}-{index:05d}"
+                chunk = chunks_by_reference.get(reference_id)
+                if chunk is None:
+                    chunk = {
+                        "reference_id": reference_id,
+                        "business_area": slug,
+                        "index": index,
+                        "set_id": None,
+                        "image_count": 0,
+                        "first_individual_id": None,
+                        "last_individual_id": None,
+                        "step": "pending",
+                        "uploaded_batches": 0,
+                        "missing_files": [],
+                        "engine_state": None,
+                        "collected": False,
+                        "status_counts": {},
+                    }
+                    self.state["chunks"].append(chunk)
+                    chunks_by_reference[reference_id] = chunk
+                if chunk["step"] == "processed":
+                    continue
+                individuals = list(queryset[index * chunk_size : (index + 1) * chunk_size])
+                self._submit_chunk(chunk, individuals)
+
+        self._print_summary()
+
+    def _submit_chunk(self, chunk: dict, individuals: list[Individual]) -> None:
+        reference_id = chunk["reference_id"]
+        if not individuals:
+            chunk["step"] = "processed"
+            self._save_state()
+            return
+
+        chunk["first_individual_id"] = str(individuals[0].id)
+        chunk["last_individual_id"] = str(individuals[-1].id)
+
+        if chunk["set_id"] is None:
+            response = self.client.create_set(reference_pk=reference_id, name=reference_id)
+            chunk["set_id"] = response["id"]
+            chunk["step"] = "created"
+            self._save_state()
+
+        batch_size = self.state["upload_batch_size"]
+        if chunk["step"] in ("created", "uploading"):
+            chunk["step"] = "uploading"
+            batches = [individuals[i : i + batch_size] for i in range(0, len(individuals), batch_size)]
+            for batch_index, batch in enumerate(batches):
+                if batch_index < chunk["uploaded_batches"]:
+                    continue
+                items, missing = self._build_image_items(batch)
+                if items:
+                    self.client.register_images(chunk["set_id"], items)
+                chunk["image_count"] += len(items)
+                chunk["missing_files"].extend(missing)
+                chunk["uploaded_batches"] = batch_index + 1
+                self._save_state()
+            chunk["step"] = "uploaded"
+            self._save_state()
+
+        if chunk["step"] == "uploaded":
+            self.client.mark_ready(chunk["set_id"])
+            chunk["step"] = "ready"
+            self._save_state()
+
+        if chunk["step"] == "ready":
+            self.client.process(chunk["set_id"], encode_only=True)
+            chunk["step"] = "processed"
+            chunk["engine_state"] = "Processing"
+            self._save_state()
+
+        self.stdout.write(f"  {reference_id}: submitted {chunk['image_count']} images (set {chunk['set_id']})")
+
+    def _build_image_items(self, individuals: list[Individual]) -> tuple[list[dict], list[str]]:
+        items = []
+        missing = []
+        use_base64 = self.state["image_transfer"] == "base64"
+        for individual in individuals:
+            item = {"reference_pk": str(individual.id), "filename": individual.photo.name}
+            if use_base64:
+                try:
+                    with individual.photo.open("rb") as f:
+                        item["image"] = base64.b64encode(f.read()).decode("ascii")
+                except OSError:
+                    missing.append(str(individual.id))
+                    continue
+            items.append(item)
+        return items, missing
+
+    # ----- status -----
+
+    def _run_status(self) -> None:
+        self._require_chunks()
+        for chunk in self.state["chunks"]:
+            if chunk["set_id"] and not chunk["collected"]:
+                chunk["engine_state"] = self.client.get_set(chunk["set_id"])["state"]
+        self._save_state()
+        self._print_summary()
+
+    # ----- collect -----
+
+    def _run_collect(self, options: dict) -> None:
+        self._require_chunks()
+        if not options["output_dir"]:
+            raise CommandError("--output-dir is required for collect mode.")
+        output_prefix = options["output_dir"].rstrip("/")
+
+        for chunk in self.state["chunks"]:
+            if chunk["collected"] or not chunk["set_id"]:
+                continue
+            chunk["engine_state"] = self.client.get_set(chunk["set_id"])["state"]
+            self._save_state()
+            if chunk["engine_state"] not in COLLECTIBLE_STATES:
+                continue
+            self._collect_chunk(chunk, output_prefix)
+
+        self._print_summary()
+        self._maybe_write_manifest(output_prefix)
+
+    def _collect_chunk(self, chunk: dict, output_prefix: str) -> None:
+        file_name = f"{chunk['reference_id']}.jsonl.gz"
+        status_counts: dict[str, int] = {}
+        digest = hashlib.sha256()
+        lines_written = 0
+        model_version = None
+
+        buffer = io.BytesIO()
+        with gzip.GzipFile(fileobj=buffer, mode="wb") as out:
+            page = 1
+            while True:
+                data = self.client.get_encodings_page(chunk["set_id"], page, ENCODINGS_PAGE_SIZE)
+                for item in data["results"]:
+                    model_version = item.get("model_version") or model_version
+                    status_code = str(item.get("status_code", ""))
+                    status_counts[status_code] = status_counts.get(status_code, 0) + 1
+                    line = json.dumps(
+                        {
+                            "individual_id": item["reference_pk"],
+                            "filename": item.get("filename"),
+                            "embedding": item.get("embedding"),
+                            "status_code": item.get("status_code"),
+                            "model_version": item.get("model_version"),
+                        }
+                    )
+                    out.write(line.encode() + b"\n")
+                    digest.update(line.encode())
+                    lines_written += 1
+                if not data.get("next"):
+                    break
+                page += 1
+
+        # The file lands in storage atomically only after all pages were fetched.
+        self._save_to_storage(f"{output_prefix}/{file_name}", buffer.getvalue())
+        chunk["collected"] = True
+        chunk["status_counts"] = status_counts
+        chunk["embeddings_file"] = file_name
+        chunk["embeddings_sha256"] = digest.hexdigest()
+        chunk["model_version"] = model_version
+        self._save_state()
+        self.stdout.write(
+            f"  {chunk['reference_id']}: collected {lines_written} encodings -> {output_prefix}/{file_name}"
+        )
+
+    def _maybe_write_manifest(self, output_prefix: str) -> None:
+        chunks = self.state["chunks"]
+        pending = [
+            chunk for chunk in chunks if not chunk["collected"] and (chunk["engine_state"] or "") not in FAILED_STATES
+        ]
+        if pending:
+            self.stdout.write(f"{len(pending)} chunk(s) not yet collected; manifest not written. Re-run later.")
+            return
+
+        totals: dict[str, int] = {}
+        for chunk in chunks:
+            for code, count in chunk["status_counts"].items():
+                totals[code] = totals.get(code, 0) + count
+        manifest = {
+            "run_id": self.state["run_id"],
+            "business_areas": self.state["business_areas"],
+            "chunk_size": self.state["chunk_size"],
+            "generated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "model_versions": sorted({c["model_version"] for c in chunks if c.get("model_version")}),
+            "total_images": sum(chunk["image_count"] for chunk in chunks),
+            "status_counts": totals,
+            "missing_files_count": sum(len(chunk["missing_files"]) for chunk in chunks),
+            "files": [
+                {
+                    "name": chunk["embeddings_file"],
+                    "sha256": chunk["embeddings_sha256"],
+                    "business_area": chunk["business_area"],
+                    "reference_id": chunk["reference_id"],
+                    "status_counts": chunk["status_counts"],
+                }
+                for chunk in chunks
+                if chunk["collected"]
+            ],
+            "failed_chunks": [chunk["reference_id"] for chunk in chunks if not chunk["collected"]],
+        }
+        manifest_key = f"{output_prefix}/manifest.json"
+        self._save_to_storage(manifest_key, json.dumps(manifest, indent=2).encode())
+        self.stdout.write(self.style.SUCCESS(f"Manifest written to {manifest_key}"))
+
+    # ----- helpers -----
+
+    def _require_chunks(self) -> None:
+        if not self.state.get("chunks"):
+            raise CommandError("State file has no submitted chunks; run submit mode first.")
+
+    def _print_summary(self) -> None:
+        by_area: dict[str, dict[str, int]] = {}
+        for chunk in self.state.get("chunks", []):
+            area_stats = by_area.setdefault(chunk["business_area"], {})
+            if chunk["collected"]:
+                status = "collected"
+            elif chunk["step"] != "processed":
+                status = f"submit:{chunk['step']}"
+            else:
+                status = chunk["engine_state"] or "unknown"
+            area_stats[status] = area_stats.get(status, 0) + 1
+        self.stdout.write("Summary:")
+        for area, stats in sorted(by_area.items()):
+            parts = ", ".join(f"{status}={count}" for status, count in sorted(stats.items()))
+            self.stdout.write(f"  {area}: {parts}")

--- a/src/hope/apps/registration_data/management/commands/export_encodings.py
+++ b/src/hope/apps/registration_data/management/commands/export_encodings.py
@@ -1,28 +1,26 @@
-"""One-shot tool to encode CO images via the Deduplication Engine and collect embeddings.
+"""One-shot tool to encode CO images via the Deduplication Engine and export the embeddings.
 
 Splits individuals of the given business areas into deterministic chunks, submits each
-chunk as its own deduplication set group (so engine workers process chunks in parallel),
-runs encode-only processing, and later collects the embeddings into shareable
-``.jsonl.gz`` files plus a ``manifest.json``.
+chunk as its own deduplication set group (so engine workers process chunks in parallel)
+and runs encode-only processing. Once all chunks of a CO are encoded, the export mode
+asks the engine to zip that CO's embeddings onto its dedicated Azure storage and stores
+the resulting signed URL — the shareable deliverable — in the state file.
 
-All progress is tracked in a JSON state file, so every mode is idempotent and safe to
-re-run after a crash or interruption.
+All progress is tracked in a JSON state file kept in Django default storage, so every
+mode is idempotent and safe to re-run after a crash, interruption, or pod restart.
 
 Usage:
 
-    manage.py export_encodings --mode submit --state-file run1.json \
+    manage.py export_encodings --mode submit --state-file encodings/run1.json \
         --business-areas afghanistan,ukraine --dedup-url https://... --dedup-token ...
 
-    manage.py export_encodings --mode status --state-file run1.json ...
+    manage.py export_encodings --mode status --state-file encodings/run1.json ...
 
-    manage.py export_encodings --mode collect --state-file run1.json --output-dir out/ ...
+    manage.py export_encodings --mode export --state-file encodings/run1.json ...
 """
 
 from argparse import ArgumentParser
-import base64
-import gzip
-import hashlib
-import io
+from datetime import UTC, datetime
 import json
 import os
 import time
@@ -37,11 +35,13 @@ import requests
 
 from hope.models import BusinessArea, Individual
 
-DEFAULT_UPLOAD_BATCH_SIZES = {"base64": 200, "filename": 5000}
-ENCODINGS_PAGE_SIZE = 1000
-# Engine set states in which embeddings are retrievable.
-COLLECTIBLE_STATES = {"Encoded", "Deduplicated", "Approved"}
+DEFAULT_UPLOAD_BATCH_SIZE = 5000
+# Engine set states in which embeddings exist and the set can be exported.
+EXPORTABLE_STATES = {"Encoded", "Deduplicated", "Approved"}
 FAILED_STATES = {"Encoding failed", "Deduplication failed", "Failed"}
+# A pending export older than this is assumed dead (task crashed before writing
+# its error blob) and is re-requested under a fresh key.
+EXPORT_PENDING_TIMEOUT_SECONDS = 2 * 60 * 60
 
 
 class DedupEngineClient:
@@ -101,20 +101,23 @@ class DedupEngineClient:
     def get_set(self, set_id: str) -> dict:
         return self._request("GET", f"deduplication_sets/{set_id}/").json()
 
-    def get_encodings_page(self, set_id: str, page: int, page_size: int) -> dict:
+    def create_export(self, reference_pk: str, set_ids: list[str], export_format: str) -> dict:
         response = self._request(
-            "GET",
-            f"deduplication_sets/{set_id}/encodings/",
-            params={"page": page, "page_size": page_size},
+            "POST",
+            "encodings_exports/",
+            json={"reference_pk": reference_pk, "deduplication_set_ids": set_ids, "format": export_format},
         )
         return response.json()
 
+    def export_status(self, key: str) -> dict:
+        return self._request("GET", "encodings_exports/status/", params={"key": key}).json()
+
 
 class Command(BaseCommand):
-    help = "Encode CO images via the Deduplication Engine (encode_only) and collect embeddings for sharing."
+    help = "Encode CO images via the Deduplication Engine (encode_only) and export embeddings as signed zip URLs."
 
     def add_arguments(self, parser: ArgumentParser) -> None:
-        parser.add_argument("--mode", required=True, choices=["submit", "status", "collect"])
+        parser.add_argument("--mode", required=True, choices=["submit", "status", "export"])
         parser.add_argument(
             "--state-file",
             required=True,
@@ -128,21 +131,16 @@ class Command(BaseCommand):
         parser.add_argument("--dedup-token", default=os.environ.get("DEDUPLICATION_ENGINE_API_KEY"))
         parser.add_argument("--chunk-size", type=int, default=10000)
         parser.add_argument(
-            "--image-transfer",
-            choices=["base64", "filename"],
-            default="base64",
-            help="base64: image content in the payload (current engine). "
-            "filename: storage path only (requires the shared-blob-storage engine build).",
-        )
-        parser.add_argument(
             "--upload-batch-size",
             type=int,
-            default=None,
-            help="Images per registration request. Defaults: 200 (base64) / 5000 (filename).",
+            default=DEFAULT_UPLOAD_BATCH_SIZE,
+            help="Images per registration request.",
         )
         parser.add_argument(
-            "--output-dir",
-            help="Default-storage prefix for embedding files and manifest (required for collect).",
+            "--export-format",
+            choices=["npy", "jsonl"],
+            default="npy",
+            help="Export zip format: npy (float32 matrix + index, ~4-5x smaller) or jsonl (self-describing).",
         )
 
     def handle(self, *args: Any, **options: Any) -> None:
@@ -161,7 +159,7 @@ class Command(BaseCommand):
         elif mode == "status":
             self._run_status()
         else:
-            self._run_collect(options)
+            self._run_export(options["export_format"])
 
     # ----- state file (kept in Django default storage so it survives pod restarts) -----
 
@@ -172,14 +170,11 @@ class Command(BaseCommand):
         return {}
 
     def _save_state(self) -> None:
-        self._save_to_storage(self.state_key, json.dumps(self.state, indent=2).encode())
-
-    @staticmethod
-    def _save_to_storage(name: str, data: bytes) -> None:
+        data = json.dumps(self.state, indent=2).encode()
         # Storage.save() mangles existing names instead of overwriting, so delete first.
-        if default_storage.exists(name):
-            default_storage.delete(name)
-        default_storage.save(name, ContentFile(data))
+        if default_storage.exists(self.state_key):
+            default_storage.delete(self.state_key)
+        default_storage.save(self.state_key, ContentFile(data))
 
     # ----- submit -----
 
@@ -199,23 +194,21 @@ class Command(BaseCommand):
         if missing := set(slugs) - existing:
             raise CommandError(f"Unknown business area slug(s): {', '.join(sorted(missing))}")
 
-        upload_batch_size = options["upload_batch_size"] or DEFAULT_UPLOAD_BATCH_SIZES[options["image_transfer"]]
         if not self.state:
             self.state = {
                 "run_id": uuid.uuid4().hex[:8],
                 "chunk_size": options["chunk_size"],
-                "image_transfer": options["image_transfer"],
-                "upload_batch_size": upload_batch_size,
+                "upload_batch_size": options["upload_batch_size"],
                 "business_areas": slugs,
                 "chunks": [],
+                "exports": {},
             }
             self._save_state()
         else:
             # Resume: pinned parameters must match, otherwise batch-offset resume would corrupt uploads.
             for key, value in (
                 ("chunk_size", options["chunk_size"]),
-                ("image_transfer", options["image_transfer"]),
-                ("upload_batch_size", upload_batch_size),
+                ("upload_batch_size", options["upload_batch_size"]),
             ):
                 if self.state[key] != value:
                     raise CommandError(
@@ -249,10 +242,7 @@ class Command(BaseCommand):
                         "last_individual_id": None,
                         "step": "pending",
                         "uploaded_batches": 0,
-                        "missing_files": [],
                         "engine_state": None,
-                        "collected": False,
-                        "status_counts": {},
                     }
                     self.state["chunks"].append(chunk)
                     chunks_by_reference[reference_id] = chunk
@@ -286,11 +276,11 @@ class Command(BaseCommand):
             for batch_index, batch in enumerate(batches):
                 if batch_index < chunk["uploaded_batches"]:
                     continue
-                items, missing = self._build_image_items(batch)
-                if items:
-                    self.client.register_images(chunk["set_id"], items)
+                items = [
+                    {"reference_pk": str(individual.id), "filename": individual.photo.name} for individual in batch
+                ]
+                self.client.register_images(chunk["set_id"], items)
                 chunk["image_count"] += len(items)
-                chunk["missing_files"].extend(missing)
                 chunk["uploaded_batches"] = batch_index + 1
                 self._save_state()
             chunk["step"] = "uploaded"
@@ -309,134 +299,88 @@ class Command(BaseCommand):
 
         self.stdout.write(f"  {reference_id}: submitted {chunk['image_count']} images (set {chunk['set_id']})")
 
-    def _build_image_items(self, individuals: list[Individual]) -> tuple[list[dict], list[str]]:
-        items = []
-        missing = []
-        use_base64 = self.state["image_transfer"] == "base64"
-        for individual in individuals:
-            item = {"reference_pk": str(individual.id), "filename": individual.photo.name}
-            if use_base64:
-                try:
-                    with individual.photo.open("rb") as f:
-                        item["image"] = base64.b64encode(f.read()).decode("ascii")
-                except OSError:
-                    missing.append(str(individual.id))
-                    continue
-            items.append(item)
-        return items, missing
-
     # ----- status -----
 
     def _run_status(self) -> None:
         self._require_chunks()
         for chunk in self.state["chunks"]:
-            if chunk["set_id"] and not chunk["collected"]:
+            if chunk["set_id"] and chunk["engine_state"] not in EXPORTABLE_STATES:
                 chunk["engine_state"] = self.client.get_set(chunk["set_id"])["state"]
         self._save_state()
         self._print_summary()
 
-    # ----- collect -----
+    # ----- export -----
 
-    def _run_collect(self, options: dict) -> None:
+    def _run_export(self, export_format: str) -> None:
         self._require_chunks()
-        if not options["output_dir"]:
-            raise CommandError("--output-dir is required for collect mode.")
-        output_prefix = options["output_dir"].rstrip("/")
+        exports = self.state.setdefault("exports", {})
 
-        for chunk in self.state["chunks"]:
-            if chunk["collected"] or not chunk["set_id"]:
+        for slug in self.state["business_areas"]:
+            chunks = [chunk for chunk in self.state["chunks"] if chunk["business_area"] == slug]
+            not_ready = self._refresh_and_find_not_exportable(chunks)
+            if not_ready:
+                self.stdout.write(
+                    f"{slug}: skipped, {len(not_ready)} chunk(s) not encoded yet "
+                    f"(e.g. {not_ready[0]['reference_id']}: {not_ready[0]['engine_state'] or not_ready[0]['step']})"
+                )
                 continue
-            chunk["engine_state"] = self.client.get_set(chunk["set_id"])["state"]
-            self._save_state()
-            if chunk["engine_state"] not in COLLECTIBLE_STATES:
-                continue
-            self._collect_chunk(chunk, output_prefix)
+
+            # One export slot per CO and format: both npy and jsonl can coexist for a CO.
+            export = exports.get(f"{slug}:{export_format}")
+            if not export or not export.get("key"):
+                self._request_export(slug, chunks, export_format)
+            else:
+                self._poll_export(slug, export, export_format)
 
         self._print_summary()
-        self._maybe_write_manifest(output_prefix)
 
-    def _collect_chunk(self, chunk: dict, output_prefix: str) -> None:
-        file_name = f"{chunk['reference_id']}.jsonl.gz"
-        status_counts: dict[str, int] = {}
-        digest = hashlib.sha256()
-        lines_written = 0
-        model_version = None
-
-        buffer = io.BytesIO()
-        with gzip.GzipFile(fileobj=buffer, mode="wb") as out:
-            page = 1
-            while True:
-                data = self.client.get_encodings_page(chunk["set_id"], page, ENCODINGS_PAGE_SIZE)
-                for item in data["results"]:
-                    model_version = item.get("model_version") or model_version
-                    status_code = str(item.get("status_code", ""))
-                    status_counts[status_code] = status_counts.get(status_code, 0) + 1
-                    line = json.dumps(
-                        {
-                            "individual_id": item["reference_pk"],
-                            "filename": item.get("filename"),
-                            "embedding": item.get("embedding"),
-                            "status_code": item.get("status_code"),
-                            "model_version": item.get("model_version"),
-                        }
-                    )
-                    out.write(line.encode() + b"\n")
-                    digest.update(line.encode())
-                    lines_written += 1
-                if not data.get("next"):
-                    break
-                page += 1
-
-        # The file lands in storage atomically only after all pages were fetched.
-        self._save_to_storage(f"{output_prefix}/{file_name}", buffer.getvalue())
-        chunk["collected"] = True
-        chunk["status_counts"] = status_counts
-        chunk["embeddings_file"] = file_name
-        chunk["embeddings_sha256"] = digest.hexdigest()
-        chunk["model_version"] = model_version
-        self._save_state()
-        self.stdout.write(
-            f"  {chunk['reference_id']}: collected {lines_written} encodings -> {output_prefix}/{file_name}"
-        )
-
-    def _maybe_write_manifest(self, output_prefix: str) -> None:
-        chunks = self.state["chunks"]
-        pending = [
-            chunk for chunk in chunks if not chunk["collected"] and (chunk["engine_state"] or "") not in FAILED_STATES
-        ]
-        if pending:
-            self.stdout.write(f"{len(pending)} chunk(s) not yet collected; manifest not written. Re-run later.")
-            return
-
-        totals: dict[str, int] = {}
+    def _refresh_and_find_not_exportable(self, chunks: list[dict]) -> list[dict]:
+        not_ready = []
         for chunk in chunks:
-            for code, count in chunk["status_counts"].items():
-                totals[code] = totals.get(code, 0) + count
-        manifest = {
-            "run_id": self.state["run_id"],
-            "business_areas": self.state["business_areas"],
-            "chunk_size": self.state["chunk_size"],
-            "generated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
-            "model_versions": sorted({c["model_version"] for c in chunks if c.get("model_version")}),
-            "total_images": sum(chunk["image_count"] for chunk in chunks),
-            "status_counts": totals,
-            "missing_files_count": sum(len(chunk["missing_files"]) for chunk in chunks),
-            "files": [
-                {
-                    "name": chunk["embeddings_file"],
-                    "sha256": chunk["embeddings_sha256"],
-                    "business_area": chunk["business_area"],
-                    "reference_id": chunk["reference_id"],
-                    "status_counts": chunk["status_counts"],
-                }
-                for chunk in chunks
-                if chunk["collected"]
-            ],
-            "failed_chunks": [chunk["reference_id"] for chunk in chunks if not chunk["collected"]],
+            if chunk["step"] != "processed":
+                not_ready.append(chunk)
+                continue
+            if chunk["engine_state"] not in EXPORTABLE_STATES:
+                chunk["engine_state"] = self.client.get_set(chunk["set_id"])["state"]
+                self._save_state()
+            if chunk["engine_state"] not in EXPORTABLE_STATES:
+                not_ready.append(chunk)
+        return not_ready
+
+    def _request_export(self, slug: str, chunks: list[dict], export_format: str) -> None:
+        set_ids = [chunk["set_id"] for chunk in sorted(chunks, key=lambda c: c["index"])]
+        response = self.client.create_export(reference_pk=slug, set_ids=set_ids, export_format=export_format)
+        self.state["exports"][f"{slug}:{export_format}"] = {
+            "key": response["key"],
+            "format": export_format,
+            "state": "pending",
+            "requested_at": datetime.now(UTC).isoformat(),
         }
-        manifest_key = f"{output_prefix}/manifest.json"
-        self._save_to_storage(manifest_key, json.dumps(manifest, indent=2).encode())
-        self.stdout.write(self.style.SUCCESS(f"Manifest written to {manifest_key}"))
+        self._save_state()
+        self.stdout.write(f"{slug}: export requested ({export_format}), key {response['key']}")
+
+    def _poll_export(self, slug: str, export: dict, export_format: str) -> None:
+        status = self.client.export_status(export["key"])
+        if status["state"] == "ready":
+            # Re-polling a ready export renews the signed URL (the engine re-signs on every call).
+            export.update(state="ready", url=status["url"], expires_at=status.get("expires_at"))
+            self._save_state()
+            self.stdout.write(self.style.SUCCESS(f"{slug}: export ready, url valid until {export['expires_at']}"))
+        elif status["state"] == "failed":
+            self.stdout.write(
+                self.style.ERROR(f"{slug}: export failed ({status.get('error')}); key cleared, re-run export to retry.")
+            )
+            export.update(key=None, state="failed", error=status.get("error"))
+            self._save_state()
+        else:  # pending
+            requested_at = datetime.fromisoformat(export["requested_at"])
+            age = (datetime.now(UTC) - requested_at).total_seconds()
+            if age > EXPORT_PENDING_TIMEOUT_SECONDS:
+                self.stdout.write(f"{slug}: export pending for {age / 3600:.1f}h, assuming dead; re-requesting.")
+                chunks = [chunk for chunk in self.state["chunks"] if chunk["business_area"] == slug]
+                self._request_export(slug, chunks, export_format)
+            else:
+                self.stdout.write(f"{slug}: export still pending (key {export['key']}); re-run later.")
 
     # ----- helpers -----
 
@@ -448,9 +392,7 @@ class Command(BaseCommand):
         by_area: dict[str, dict[str, int]] = {}
         for chunk in self.state.get("chunks", []):
             area_stats = by_area.setdefault(chunk["business_area"], {})
-            if chunk["collected"]:
-                status = "collected"
-            elif chunk["step"] != "processed":
+            if chunk["step"] != "processed":
                 status = f"submit:{chunk['step']}"
             else:
                 status = chunk["engine_state"] or "unknown"
@@ -458,4 +400,10 @@ class Command(BaseCommand):
         self.stdout.write("Summary:")
         for area, stats in sorted(by_area.items()):
             parts = ", ".join(f"{status}={count}" for status, count in sorted(stats.items()))
-            self.stdout.write(f"  {area}: {parts}")
+            export_infos = [
+                f"export {export['format']}: {export['state']}"
+                for entry_key, export in sorted(self.state.get("exports", {}).items())
+                if entry_key.startswith(f"{area}:")
+            ]
+            export_info = f"; {', '.join(export_infos)}" if export_infos else ""
+            self.stdout.write(f"  {area}: {parts}{export_info}")

--- a/src/hope/apps/registration_data/management/commands/export_encodings.py
+++ b/src/hope/apps/registration_data/management/commands/export_encodings.py
@@ -9,20 +9,26 @@ the resulting signed URL — the shareable deliverable — in the state file.
 All progress is tracked in a JSON state file kept in Django default storage, so every
 mode is idempotent and safe to re-run after a crash, interruption, or pod restart.
 
+Export mode: POST /encodings_exports/ when the state file has no key for that CO+format;
+GET /encodings_exports/status/?key=… when a key is already stored (poll / renew URL).
+
+Full usage instructions: docs/guide-dev/export-encodings.md
+
 Usage:
 
     manage.py export_encodings --mode submit --state-file encodings/run1.json \
         --business-areas afghanistan,ukraine --dedup-url https://... --dedup-token ...
 
-    manage.py export_encodings --mode status --state-file encodings/run1.json ...
+    manage.py export_encodings --mode status --state-file encodings/run1.json \
+        --dedup-url https://... --dedup-token ...
 
-    manage.py export_encodings --mode export --state-file encodings/run1.json ...
+    manage.py export_encodings --mode export --state-file encodings/run1.json \
+        --dedup-url https://... --dedup-token ...
 """
 
 from argparse import ArgumentParser
 from datetime import UTC, datetime
 import json
-import os
 import time
 from typing import Any
 import uuid
@@ -127,8 +133,8 @@ class Command(BaseCommand):
             "--business-areas",
             help="Comma-separated business area slugs to encode (required for submit).",
         )
-        parser.add_argument("--dedup-url", default=os.environ.get("DEDUPLICATION_ENGINE_API_URL"))
-        parser.add_argument("--dedup-token", default=os.environ.get("DEDUPLICATION_ENGINE_API_KEY"))
+        parser.add_argument("--dedup-url")
+        parser.add_argument("--dedup-token")
         parser.add_argument("--chunk-size", type=int, default=10000)
         parser.add_argument(
             "--upload-batch-size",
@@ -145,10 +151,7 @@ class Command(BaseCommand):
 
     def handle(self, *args: Any, **options: Any) -> None:
         if not options["dedup_url"] or not options["dedup_token"]:
-            raise CommandError(
-                "Deduplication engine URL/token missing: pass --dedup-url/--dedup-token or set "
-                "DEDUPLICATION_ENGINE_API_URL/DEDUPLICATION_ENGINE_API_KEY."
-            )
+            raise CommandError("Deduplication engine URL/token missing: pass --dedup-url and --dedup-token.")
         self.client = DedupEngineClient(options["dedup_url"], options["dedup_token"])
         self.state_key = options["state_file"]
         self.state = self._load_state()

--- a/src/hope/apps/registration_data/management/commands/export_encodings.py
+++ b/src/hope/apps/registration_data/management/commands/export_encodings.py
@@ -30,7 +30,7 @@ from argparse import ArgumentParser
 from datetime import UTC, datetime
 import json
 import time
-from typing import Any
+from typing import Any, cast
 import uuid
 
 from django.core.files.base import ContentFile
@@ -181,12 +181,13 @@ class Command(BaseCommand):
 
     # ----- submit -----
 
-    def _individuals_queryset(self, business_area_slug: str) -> QuerySet[Individual]:
-        return (
+    def _individuals_queryset(self, business_area_slug: str) -> QuerySet[Individual, Individual]:
+        return cast(
+            "QuerySet[Individual, Individual]",
             Individual.all_objects.filter(is_removed=False, business_area__slug=business_area_slug)
             .exclude(Q(photo="") | Q(withdrawn=True) | Q(duplicate=True))
             .order_by("id")
-            .only("id", "photo")
+            .only("id", "photo"),
         )
 
     def _run_submit(self, options: dict) -> None:

--- a/tests/unit/apps/registration_data/test_export_encodings_command.py
+++ b/tests/unit/apps/registration_data/test_export_encodings_command.py
@@ -1,5 +1,4 @@
-import base64
-import gzip
+from datetime import UTC, datetime, timedelta
 import json
 from unittest import mock
 from unittest.mock import patch
@@ -25,7 +24,11 @@ def mock_client() -> mock.MagicMock:
         client = client_class.return_value
         client.create_set.side_effect = lambda reference_pk, name: {"id": str(uuid.uuid4())}
         client.get_set.return_value = {"state": "Encoded"}
-        client.get_encodings_page.return_value = {"results": [], "next": None}
+        client.create_export.side_effect = lambda reference_pk, set_ids, export_format: {
+            "key": f"exports/1/{reference_pk}/{reference_pk}-{uuid.uuid4().hex[:6]}.{export_format}.zip",
+            "state": "pending",
+        }
+        client.export_status.return_value = {"state": "pending"}
         yield client
 
 
@@ -39,11 +42,6 @@ def state_key() -> str:
     return f"export-encodings-tests/{uuid.uuid4().hex}/state.json"
 
 
-@pytest.fixture
-def output_prefix() -> str:
-    return f"export-encodings-tests/{uuid.uuid4().hex}/out"
-
-
 def read_state(state_key: str) -> dict:
     with default_storage.open(state_key, "rb") as f:
         return json.load(f)
@@ -53,11 +51,6 @@ def write_state(state_key: str, state: dict) -> None:
     if default_storage.exists(state_key):
         default_storage.delete(state_key)
     default_storage.save(state_key, ContentFile(json.dumps(state).encode()))
-
-
-def read_gzip_lines(name: str) -> list[dict]:
-    with default_storage.open(name, "rb") as f, gzip.GzipFile(fileobj=f) as gz:
-        return [json.loads(line) for line in gz]
 
 
 def submit(state_key: str, extra: list[str] | None = None) -> None:
@@ -74,17 +67,8 @@ def submit(state_key: str, extra: list[str] | None = None) -> None:
     )
 
 
-def collect(state_key: str, output_prefix: str) -> None:
-    call_command(
-        "export_encodings",
-        "--mode",
-        "collect",
-        "--state-file",
-        state_key,
-        "--output-dir",
-        output_prefix,
-        *COMMON_ARGS,
-    )
+def export(state_key: str, extra: list[str] | None = None) -> None:
+    call_command("export_encodings", "--mode", "export", "--state-file", state_key, *COMMON_ARGS, *(extra or []))
 
 
 def test_submit_chunks_deterministically_and_processes_each_chunk(
@@ -96,10 +80,9 @@ def test_submit_chunks_deterministically_and_processes_each_chunk(
     IndividualFactory(business_area=afghanistan, photo="w.jpg", withdrawn=True)
     IndividualFactory(business_area=afghanistan, photo="d.jpg", duplicate=True)
 
-    submit(state_key, ["--chunk-size", "2", "--image-transfer", "filename"])
+    submit(state_key, ["--chunk-size", "2"])
 
     state = read_state(state_key)
-    assert state["image_transfer"] == "filename"
     assert state["upload_batch_size"] == 5000
     assert len(state["chunks"]) == 3  # 5 individuals / chunk size 2
     assert [chunk["index"] for chunk in state["chunks"]] == [0, 1, 2]
@@ -113,29 +96,11 @@ def test_submit_chunks_deterministically_and_processes_each_chunk(
     assert mock_client.process.call_count == 3
     mock_client.process.assert_called_with(state["chunks"][2]["set_id"], encode_only=True)
 
-    # Chunk membership is deterministic: ordered by individual id.
-    uploaded_pks = [
-        item["reference_pk"] for call_args in mock_client.register_images.call_args_list for item in call_args.args[1]
-    ]
-    assert uploaded_pks == sorted(str(individual.id) for individual in individuals)
-
-
-def test_submit_base64_sends_image_content_and_records_missing_files(
-    mock_client: mock.MagicMock, afghanistan: object, state_key: str
-) -> None:
-    with_file = IndividualFactory(business_area=afghanistan, photo=ContentFile(b"image-bytes", name="ok.png"))
-    without_file = IndividualFactory(business_area=afghanistan, photo="does_not_exist.jpg")
-
-    submit(state_key, ["--image-transfer", "base64"])
-
+    # Filename-mode payload: reference_pk + storage key only, no image content.
     items = [item for call_args in mock_client.register_images.call_args_list for item in call_args.args[1]]
-    assert len(items) == 1
-    assert items[0]["reference_pk"] == str(with_file.id)
-    assert base64.b64decode(items[0]["image"]) == b"image-bytes"
-
-    state = read_state(state_key)
-    assert state["chunks"][0]["missing_files"] == [str(without_file.id)]
-    assert state["chunks"][0]["image_count"] == 1
+    assert all(set(item) == {"reference_pk", "filename"} for item in items)
+    # Chunk membership is deterministic: ordered by individual id.
+    assert [item["reference_pk"] for item in items] == sorted(str(individual.id) for individual in individuals)
 
 
 def test_submit_resume_skips_already_uploaded_batches_and_processed_chunks(
@@ -144,7 +109,7 @@ def test_submit_resume_skips_already_uploaded_batches_and_processed_chunks(
     for i in range(4):
         IndividualFactory(business_area=afghanistan, photo=f"photo_{i}.jpg")
 
-    submit(state_key, ["--chunk-size", "4", "--image-transfer", "filename", "--upload-batch-size", "2"])
+    submit(state_key, ["--chunk-size", "4", "--upload-batch-size", "2"])
     assert mock_client.register_images.call_count == 2
 
     # Simulate a crash after the first of two batches was uploaded.
@@ -156,7 +121,7 @@ def test_submit_resume_skips_already_uploaded_batches_and_processed_chunks(
     mock_client.register_images.reset_mock()
     mock_client.create_set.reset_mock()
 
-    submit(state_key, ["--chunk-size", "4", "--image-transfer", "filename", "--upload-batch-size", "2"])
+    submit(state_key, ["--chunk-size", "4", "--upload-batch-size", "2"])
 
     mock_client.create_set.assert_not_called()  # set already exists
     assert mock_client.register_images.call_count == 1  # only the second batch
@@ -166,7 +131,7 @@ def test_submit_resume_skips_already_uploaded_batches_and_processed_chunks(
 
     # A fully processed state file is a no-op on re-run.
     mock_client.register_images.reset_mock()
-    submit(state_key, ["--chunk-size", "4", "--image-transfer", "filename", "--upload-batch-size", "2"])
+    submit(state_key, ["--chunk-size", "4", "--upload-batch-size", "2"])
     mock_client.register_images.assert_not_called()
 
 
@@ -174,10 +139,10 @@ def test_submit_rejects_conflicting_pinned_parameters(
     mock_client: mock.MagicMock, afghanistan: object, state_key: str
 ) -> None:
     IndividualFactory(business_area=afghanistan, photo="photo.jpg")
-    submit(state_key, ["--image-transfer", "filename"])
+    submit(state_key, ["--upload-batch-size", "1000"])
 
-    with pytest.raises(CommandError, match="image_transfer"):
-        submit(state_key, ["--image-transfer", "base64"])
+    with pytest.raises(CommandError, match="upload_batch_size"):
+        submit(state_key, ["--upload-batch-size", "2000"])
 
 
 def test_submit_rejects_unknown_business_area(mock_client: mock.MagicMock, state_key: str) -> None:
@@ -196,7 +161,7 @@ def test_submit_rejects_unknown_business_area(mock_client: mock.MagicMock, state
 
 def test_status_updates_engine_state(mock_client: mock.MagicMock, afghanistan: object, state_key: str) -> None:
     IndividualFactory(business_area=afghanistan, photo="photo.jpg")
-    submit(state_key, ["--image-transfer", "filename"])
+    submit(state_key)
 
     mock_client.get_set.return_value = {"state": "Encoding"}
     call_command("export_encodings", "--mode", "status", "--state-file", state_key, *COMMON_ARGS)
@@ -205,106 +170,180 @@ def test_status_updates_engine_state(mock_client: mock.MagicMock, afghanistan: o
     assert state["chunks"][0]["engine_state"] == "Encoding"
 
 
-def test_collect_writes_embeddings_file_and_manifest(
-    mock_client: mock.MagicMock, afghanistan: object, state_key: str, output_prefix: str
+def test_export_requests_export_when_all_chunks_encoded(
+    mock_client: mock.MagicMock, afghanistan: object, state_key: str
 ) -> None:
-    individual = IndividualFactory(business_area=afghanistan, photo="photo.jpg")
-    submit(state_key, ["--image-transfer", "filename"])
+    for i in range(3):
+        IndividualFactory(business_area=afghanistan, photo=f"photo_{i}.jpg")
+    submit(state_key, ["--chunk-size", "2"])
 
     mock_client.get_set.return_value = {"state": "Encoded"}
-    mock_client.get_encodings_page.return_value = {
-        "results": [
-            {
-                "reference_pk": str(individual.id),
-                "filename": "photo.jpg",
-                "embedding": [0.1, 0.2],
-                "status_code": 200,
-                "model_version": "model-v1",
-            },
-            {
-                "reference_pk": str(uuid.uuid4()),
-                "filename": "other.jpg",
-                "embedding": None,
-                "status_code": 412,
-                "model_version": "model-v1",
-            },
-        ],
-        "next": None,
-    }
-
-    collect(state_key, output_prefix)
+    export(state_key)
 
     state = read_state(state_key)
-    chunk = state["chunks"][0]
-    assert chunk["collected"] is True
-    assert chunk["status_counts"] == {"200": 1, "412": 1}
-    assert chunk["model_version"] == "model-v1"
+    export_entry = state["exports"]["afghanistan:npy"]
+    assert export_entry["state"] == "pending"
+    assert export_entry["key"].startswith("exports/1/afghanistan/")
+    assert export_entry["format"] == "npy"  # default format
+    assert export_entry["requested_at"]
 
-    lines = read_gzip_lines(f"{output_prefix}/{chunk['embeddings_file']}")
-    assert lines[0]["individual_id"] == str(individual.id)
-    assert lines[0]["embedding"] == [0.1, 0.2]
-    assert lines[1]["status_code"] == 412
-    assert lines[1]["embedding"] is None
-
-    with default_storage.open(f"{output_prefix}/manifest.json", "rb") as f:
-        manifest = json.load(f)
-    assert manifest["run_id"] == state["run_id"]
-    assert manifest["model_versions"] == ["model-v1"]
-    assert manifest["status_counts"] == {"200": 1, "412": 1}
-    assert manifest["files"][0]["name"] == chunk["embeddings_file"]
-    assert manifest["failed_chunks"] == []
-
-    # Collect is idempotent: a second run does not refetch collected chunks.
-    mock_client.get_encodings_page.reset_mock()
-    collect(state_key, output_prefix)
-    mock_client.get_encodings_page.assert_not_called()
+    # Sets are passed in chunk-index order.
+    expected_set_ids = [chunk["set_id"] for chunk in state["chunks"]]
+    mock_client.create_export.assert_called_once_with(
+        reference_pk="afghanistan", set_ids=expected_set_ids, export_format="npy"
+    )
 
 
-def test_collect_skips_sets_that_are_not_encoded_yet_and_defers_manifest(
-    mock_client: mock.MagicMock, afghanistan: object, state_key: str, output_prefix: str
+def test_export_format_flag_is_passed_and_recorded(
+    mock_client: mock.MagicMock, afghanistan: object, state_key: str
 ) -> None:
     IndividualFactory(business_area=afghanistan, photo="photo.jpg")
-    submit(state_key, ["--image-transfer", "filename"])
+    submit(state_key)
+
+    export(state_key, ["--export-format", "jsonl"])
+
+    state = read_state(state_key)
+    export_entry = state["exports"]["afghanistan:jsonl"]
+    assert export_entry["format"] == "jsonl"
+    assert ".jsonl.zip" in export_entry["key"]
+    assert mock_client.create_export.call_args.kwargs["export_format"] == "jsonl"
+
+
+def test_both_export_formats_coexist_for_one_co(
+    mock_client: mock.MagicMock, afghanistan: object, state_key: str
+) -> None:
+    IndividualFactory(business_area=afghanistan, photo="photo.jpg")
+    submit(state_key)
+
+    export(state_key, ["--export-format", "jsonl"])  # requests jsonl export
+    mock_client.export_status.return_value = {
+        "state": "ready",
+        "url": "https://blob/a.jsonl.zip?sig=x",
+        "expires_at": "2026-08-13T12:00:00Z",
+    }
+    export(state_key, ["--export-format", "jsonl"])  # polls jsonl -> ready
+
+    # Requesting npy afterwards creates a second, independent export slot.
+    export(state_key, ["--export-format", "npy"])
+
+    state = read_state(state_key)
+    assert state["exports"]["afghanistan:jsonl"]["state"] == "ready"
+    assert state["exports"]["afghanistan:npy"]["state"] == "pending"
+    assert ".npy.zip" in state["exports"]["afghanistan:npy"]["key"]
+    assert mock_client.create_export.call_count == 2  # one per format
+    # The ready jsonl entry was untouched by the npy request.
+    assert state["exports"]["afghanistan:jsonl"]["url"].endswith("sig=x")
+
+
+def test_export_skips_co_with_unencoded_chunks(
+    mock_client: mock.MagicMock, afghanistan: object, state_key: str
+) -> None:
+    IndividualFactory(business_area=afghanistan, photo="photo.jpg")
+    submit(state_key)
 
     mock_client.get_set.return_value = {"state": "Encoding"}
-    collect(state_key, output_prefix)
+    export(state_key)
 
-    mock_client.get_encodings_page.assert_not_called()
-    assert not default_storage.exists(f"{output_prefix}/manifest.json")
-    state = read_state(state_key)
-    assert state["chunks"][0]["collected"] is False
+    mock_client.create_export.assert_not_called()
+    assert read_state(state_key)["exports"] == {}
 
 
-def test_collect_paginates_through_all_encoding_pages(
-    mock_client: mock.MagicMock, afghanistan: object, state_key: str, output_prefix: str
+def test_export_poll_stores_signed_url_and_renews_it_on_repoll(
+    mock_client: mock.MagicMock, afghanistan: object, state_key: str
 ) -> None:
     IndividualFactory(business_area=afghanistan, photo="photo.jpg")
-    submit(state_key, ["--image-transfer", "filename"])
+    submit(state_key)
+    export(state_key)  # requests the export, stores the key
 
-    def make_item() -> dict:
-        return {
-            "reference_pk": str(uuid.uuid4()),
-            "filename": "x.jpg",
-            "embedding": [0.5],
-            "status_code": 200,
-            "model_version": "model-v1",
-        }
+    mock_client.export_status.return_value = {
+        "state": "ready",
+        "url": "https://blob/exports/1/afghanistan/a.zip?sig=first",
+        "expires_at": "2026-08-13T12:00:00Z",
+    }
+    export(state_key)  # polls -> ready
 
-    mock_client.get_encodings_page.side_effect = [
-        {"results": [make_item(), make_item()], "next": "http://next"},
-        {"results": [make_item()], "next": None},
-    ]
-
-    collect(state_key, output_prefix)
-
-    assert mock_client.get_encodings_page.call_count == 2
     state = read_state(state_key)
-    assert len(read_gzip_lines(f"{output_prefix}/{state['chunks'][0]['embeddings_file']}")) == 3
+    export_entry = state["exports"]["afghanistan:npy"]
+    assert export_entry["state"] == "ready"
+    assert export_entry["url"].endswith("sig=first")
+    assert export_entry["expires_at"] == "2026-08-13T12:00:00Z"
+    mock_client.export_status.assert_called_once_with(export_entry["key"])
+
+    # Re-running export on a ready CO re-polls the same key and renews the URL.
+    mock_client.export_status.return_value = {
+        "state": "ready",
+        "url": "https://blob/exports/1/afghanistan/a.zip?sig=renewed",
+        "expires_at": "2026-08-20T12:00:00Z",
+    }
+    export(state_key)
+    state = read_state(state_key)
+    assert state["exports"]["afghanistan:npy"]["url"].endswith("sig=renewed")
+    mock_client.create_export.assert_called_once()  # never re-requested
 
 
-def test_status_and_collect_require_submitted_state(mock_client: mock.MagicMock, state_key: str) -> None:
+def test_export_failed_clears_key_and_next_run_rerequests(
+    mock_client: mock.MagicMock, afghanistan: object, state_key: str
+) -> None:
+    IndividualFactory(business_area=afghanistan, photo="photo.jpg")
+    submit(state_key)
+    export(state_key)
+
+    mock_client.export_status.return_value = {"state": "failed", "error": "boom"}
+    export(state_key)
+
+    state = read_state(state_key)
+    export_entry = state["exports"]["afghanistan:npy"]
+    assert export_entry["state"] == "failed"
+    assert export_entry["key"] is None
+    assert export_entry["error"] == "boom"
+
+    # Next run re-POSTs under a fresh key.
+    export(state_key)
+    assert mock_client.create_export.call_count == 2
+    state = read_state(state_key)
+    assert state["exports"]["afghanistan:npy"]["state"] == "pending"
+    assert state["exports"]["afghanistan:npy"]["key"]
+
+
+def test_export_reposts_after_pending_timeout(mock_client: mock.MagicMock, afghanistan: object, state_key: str) -> None:
+    IndividualFactory(business_area=afghanistan, photo="photo.jpg")
+    submit(state_key)
+    export(state_key)
+
+    state = read_state(state_key)
+    old_key = state["exports"]["afghanistan:npy"]["key"]
+    state["exports"]["afghanistan:npy"]["requested_at"] = (datetime.now(UTC) - timedelta(hours=3)).isoformat()
+    write_state(state_key, state)
+
+    mock_client.export_status.return_value = {"state": "pending"}
+    export(state_key)
+
+    assert mock_client.create_export.call_count == 2
+    state = read_state(state_key)
+    assert state["exports"]["afghanistan:npy"]["key"] != old_key
+    assert state["exports"]["afghanistan:npy"]["state"] == "pending"
+
+
+def test_export_still_pending_within_timeout_does_not_repost(
+    mock_client: mock.MagicMock, afghanistan: object, state_key: str
+) -> None:
+    IndividualFactory(business_area=afghanistan, photo="photo.jpg")
+    submit(state_key)
+    export(state_key)
+    old_key = read_state(state_key)["exports"]["afghanistan:npy"]["key"]
+
+    mock_client.export_status.return_value = {"state": "pending"}
+    export(state_key)
+
+    assert mock_client.create_export.call_count == 1
+    assert read_state(state_key)["exports"]["afghanistan:npy"]["key"] == old_key
+
+
+def test_status_and_export_require_submitted_state(mock_client: mock.MagicMock, state_key: str) -> None:
     with pytest.raises(CommandError, match="submit"):
         call_command("export_encodings", "--mode", "status", "--state-file", state_key, *COMMON_ARGS)
+    with pytest.raises(CommandError, match="submit"):
+        export(state_key)
 
 
 def test_missing_credentials_raise_command_error(state_key: str, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/apps/registration_data/test_export_encodings_command.py
+++ b/tests/unit/apps/registration_data/test_export_encodings_command.py
@@ -1,0 +1,320 @@
+import base64
+import gzip
+import json
+from unittest import mock
+from unittest.mock import patch
+import uuid
+
+from django.core.files.base import ContentFile
+from django.core.files.storage import default_storage
+from django.core.management import call_command
+from django.core.management.base import CommandError
+import pytest
+
+from extras.test_utils.factories import BusinessAreaFactory, IndividualFactory
+
+pytestmark = pytest.mark.django_db
+
+COMMAND_MODULE = "hope.apps.registration_data.management.commands.export_encodings"
+COMMON_ARGS = ["--dedup-url", "https://dedup.test", "--dedup-token", "token"]
+
+
+@pytest.fixture
+def mock_client() -> mock.MagicMock:
+    with patch(f"{COMMAND_MODULE}.DedupEngineClient") as client_class:
+        client = client_class.return_value
+        client.create_set.side_effect = lambda reference_pk, name: {"id": str(uuid.uuid4())}
+        client.get_set.return_value = {"state": "Encoded"}
+        client.get_encodings_page.return_value = {"results": [], "next": None}
+        yield client
+
+
+@pytest.fixture
+def afghanistan() -> object:
+    return BusinessAreaFactory(slug="afghanistan", name="Afghanistan")
+
+
+@pytest.fixture
+def state_key() -> str:
+    return f"export-encodings-tests/{uuid.uuid4().hex}/state.json"
+
+
+@pytest.fixture
+def output_prefix() -> str:
+    return f"export-encodings-tests/{uuid.uuid4().hex}/out"
+
+
+def read_state(state_key: str) -> dict:
+    with default_storage.open(state_key, "rb") as f:
+        return json.load(f)
+
+
+def write_state(state_key: str, state: dict) -> None:
+    if default_storage.exists(state_key):
+        default_storage.delete(state_key)
+    default_storage.save(state_key, ContentFile(json.dumps(state).encode()))
+
+
+def read_gzip_lines(name: str) -> list[dict]:
+    with default_storage.open(name, "rb") as f, gzip.GzipFile(fileobj=f) as gz:
+        return [json.loads(line) for line in gz]
+
+
+def submit(state_key: str, extra: list[str] | None = None) -> None:
+    call_command(
+        "export_encodings",
+        "--mode",
+        "submit",
+        "--state-file",
+        state_key,
+        "--business-areas",
+        "afghanistan",
+        *COMMON_ARGS,
+        *(extra or []),
+    )
+
+
+def collect(state_key: str, output_prefix: str) -> None:
+    call_command(
+        "export_encodings",
+        "--mode",
+        "collect",
+        "--state-file",
+        state_key,
+        "--output-dir",
+        output_prefix,
+        *COMMON_ARGS,
+    )
+
+
+def test_submit_chunks_deterministically_and_processes_each_chunk(
+    mock_client: mock.MagicMock, afghanistan: object, state_key: str
+) -> None:
+    individuals = [IndividualFactory(business_area=afghanistan, photo=f"photo_{i}.jpg") for i in range(5)]
+    # Excluded individuals must not be submitted.
+    IndividualFactory(business_area=afghanistan, photo="")
+    IndividualFactory(business_area=afghanistan, photo="w.jpg", withdrawn=True)
+    IndividualFactory(business_area=afghanistan, photo="d.jpg", duplicate=True)
+
+    submit(state_key, ["--chunk-size", "2", "--image-transfer", "filename"])
+
+    state = read_state(state_key)
+    assert state["image_transfer"] == "filename"
+    assert state["upload_batch_size"] == 5000
+    assert len(state["chunks"]) == 3  # 5 individuals / chunk size 2
+    assert [chunk["index"] for chunk in state["chunks"]] == [0, 1, 2]
+    assert all(chunk["step"] == "processed" for chunk in state["chunks"])
+    assert [chunk["image_count"] for chunk in state["chunks"]] == [2, 2, 1]
+    run_id = state["run_id"]
+    assert state["chunks"][0]["reference_id"] == f"enc-afghanistan-{run_id}-00000"
+
+    assert mock_client.create_set.call_count == 3
+    assert mock_client.mark_ready.call_count == 3
+    assert mock_client.process.call_count == 3
+    mock_client.process.assert_called_with(state["chunks"][2]["set_id"], encode_only=True)
+
+    # Chunk membership is deterministic: ordered by individual id.
+    uploaded_pks = [
+        item["reference_pk"] for call_args in mock_client.register_images.call_args_list for item in call_args.args[1]
+    ]
+    assert uploaded_pks == sorted(str(individual.id) for individual in individuals)
+
+
+def test_submit_base64_sends_image_content_and_records_missing_files(
+    mock_client: mock.MagicMock, afghanistan: object, state_key: str
+) -> None:
+    with_file = IndividualFactory(business_area=afghanistan, photo=ContentFile(b"image-bytes", name="ok.png"))
+    without_file = IndividualFactory(business_area=afghanistan, photo="does_not_exist.jpg")
+
+    submit(state_key, ["--image-transfer", "base64"])
+
+    items = [item for call_args in mock_client.register_images.call_args_list for item in call_args.args[1]]
+    assert len(items) == 1
+    assert items[0]["reference_pk"] == str(with_file.id)
+    assert base64.b64decode(items[0]["image"]) == b"image-bytes"
+
+    state = read_state(state_key)
+    assert state["chunks"][0]["missing_files"] == [str(without_file.id)]
+    assert state["chunks"][0]["image_count"] == 1
+
+
+def test_submit_resume_skips_already_uploaded_batches_and_processed_chunks(
+    mock_client: mock.MagicMock, afghanistan: object, state_key: str
+) -> None:
+    for i in range(4):
+        IndividualFactory(business_area=afghanistan, photo=f"photo_{i}.jpg")
+
+    submit(state_key, ["--chunk-size", "4", "--image-transfer", "filename", "--upload-batch-size", "2"])
+    assert mock_client.register_images.call_count == 2
+
+    # Simulate a crash after the first of two batches was uploaded.
+    state = read_state(state_key)
+    state["chunks"][0]["step"] = "uploading"
+    state["chunks"][0]["uploaded_batches"] = 1
+    state["chunks"][0]["image_count"] = 2
+    write_state(state_key, state)
+    mock_client.register_images.reset_mock()
+    mock_client.create_set.reset_mock()
+
+    submit(state_key, ["--chunk-size", "4", "--image-transfer", "filename", "--upload-batch-size", "2"])
+
+    mock_client.create_set.assert_not_called()  # set already exists
+    assert mock_client.register_images.call_count == 1  # only the second batch
+    state = read_state(state_key)
+    assert state["chunks"][0]["step"] == "processed"
+    assert state["chunks"][0]["image_count"] == 4
+
+    # A fully processed state file is a no-op on re-run.
+    mock_client.register_images.reset_mock()
+    submit(state_key, ["--chunk-size", "4", "--image-transfer", "filename", "--upload-batch-size", "2"])
+    mock_client.register_images.assert_not_called()
+
+
+def test_submit_rejects_conflicting_pinned_parameters(
+    mock_client: mock.MagicMock, afghanistan: object, state_key: str
+) -> None:
+    IndividualFactory(business_area=afghanistan, photo="photo.jpg")
+    submit(state_key, ["--image-transfer", "filename"])
+
+    with pytest.raises(CommandError, match="image_transfer"):
+        submit(state_key, ["--image-transfer", "base64"])
+
+
+def test_submit_rejects_unknown_business_area(mock_client: mock.MagicMock, state_key: str) -> None:
+    with pytest.raises(CommandError, match="nosuchplace"):
+        call_command(
+            "export_encodings",
+            "--mode",
+            "submit",
+            "--state-file",
+            state_key,
+            "--business-areas",
+            "nosuchplace",
+            *COMMON_ARGS,
+        )
+
+
+def test_status_updates_engine_state(mock_client: mock.MagicMock, afghanistan: object, state_key: str) -> None:
+    IndividualFactory(business_area=afghanistan, photo="photo.jpg")
+    submit(state_key, ["--image-transfer", "filename"])
+
+    mock_client.get_set.return_value = {"state": "Encoding"}
+    call_command("export_encodings", "--mode", "status", "--state-file", state_key, *COMMON_ARGS)
+
+    state = read_state(state_key)
+    assert state["chunks"][0]["engine_state"] == "Encoding"
+
+
+def test_collect_writes_embeddings_file_and_manifest(
+    mock_client: mock.MagicMock, afghanistan: object, state_key: str, output_prefix: str
+) -> None:
+    individual = IndividualFactory(business_area=afghanistan, photo="photo.jpg")
+    submit(state_key, ["--image-transfer", "filename"])
+
+    mock_client.get_set.return_value = {"state": "Encoded"}
+    mock_client.get_encodings_page.return_value = {
+        "results": [
+            {
+                "reference_pk": str(individual.id),
+                "filename": "photo.jpg",
+                "embedding": [0.1, 0.2],
+                "status_code": 200,
+                "model_version": "model-v1",
+            },
+            {
+                "reference_pk": str(uuid.uuid4()),
+                "filename": "other.jpg",
+                "embedding": None,
+                "status_code": 412,
+                "model_version": "model-v1",
+            },
+        ],
+        "next": None,
+    }
+
+    collect(state_key, output_prefix)
+
+    state = read_state(state_key)
+    chunk = state["chunks"][0]
+    assert chunk["collected"] is True
+    assert chunk["status_counts"] == {"200": 1, "412": 1}
+    assert chunk["model_version"] == "model-v1"
+
+    lines = read_gzip_lines(f"{output_prefix}/{chunk['embeddings_file']}")
+    assert lines[0]["individual_id"] == str(individual.id)
+    assert lines[0]["embedding"] == [0.1, 0.2]
+    assert lines[1]["status_code"] == 412
+    assert lines[1]["embedding"] is None
+
+    with default_storage.open(f"{output_prefix}/manifest.json", "rb") as f:
+        manifest = json.load(f)
+    assert manifest["run_id"] == state["run_id"]
+    assert manifest["model_versions"] == ["model-v1"]
+    assert manifest["status_counts"] == {"200": 1, "412": 1}
+    assert manifest["files"][0]["name"] == chunk["embeddings_file"]
+    assert manifest["failed_chunks"] == []
+
+    # Collect is idempotent: a second run does not refetch collected chunks.
+    mock_client.get_encodings_page.reset_mock()
+    collect(state_key, output_prefix)
+    mock_client.get_encodings_page.assert_not_called()
+
+
+def test_collect_skips_sets_that_are_not_encoded_yet_and_defers_manifest(
+    mock_client: mock.MagicMock, afghanistan: object, state_key: str, output_prefix: str
+) -> None:
+    IndividualFactory(business_area=afghanistan, photo="photo.jpg")
+    submit(state_key, ["--image-transfer", "filename"])
+
+    mock_client.get_set.return_value = {"state": "Encoding"}
+    collect(state_key, output_prefix)
+
+    mock_client.get_encodings_page.assert_not_called()
+    assert not default_storage.exists(f"{output_prefix}/manifest.json")
+    state = read_state(state_key)
+    assert state["chunks"][0]["collected"] is False
+
+
+def test_collect_paginates_through_all_encoding_pages(
+    mock_client: mock.MagicMock, afghanistan: object, state_key: str, output_prefix: str
+) -> None:
+    IndividualFactory(business_area=afghanistan, photo="photo.jpg")
+    submit(state_key, ["--image-transfer", "filename"])
+
+    def make_item() -> dict:
+        return {
+            "reference_pk": str(uuid.uuid4()),
+            "filename": "x.jpg",
+            "embedding": [0.5],
+            "status_code": 200,
+            "model_version": "model-v1",
+        }
+
+    mock_client.get_encodings_page.side_effect = [
+        {"results": [make_item(), make_item()], "next": "http://next"},
+        {"results": [make_item()], "next": None},
+    ]
+
+    collect(state_key, output_prefix)
+
+    assert mock_client.get_encodings_page.call_count == 2
+    state = read_state(state_key)
+    assert len(read_gzip_lines(f"{output_prefix}/{state['chunks'][0]['embeddings_file']}")) == 3
+
+
+def test_status_and_collect_require_submitted_state(mock_client: mock.MagicMock, state_key: str) -> None:
+    with pytest.raises(CommandError, match="submit"):
+        call_command("export_encodings", "--mode", "status", "--state-file", state_key, *COMMON_ARGS)
+
+
+def test_missing_credentials_raise_command_error(state_key: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("DEDUPLICATION_ENGINE_API_URL", raising=False)
+    monkeypatch.delenv("DEDUPLICATION_ENGINE_API_KEY", raising=False)
+    with pytest.raises(CommandError, match="missing"):
+        call_command(
+            "export_encodings",
+            "--mode",
+            "status",
+            "--state-file",
+            state_key,
+        )

--- a/tests/unit/apps/registration_data/test_export_encodings_command.py
+++ b/tests/unit/apps/registration_data/test_export_encodings_command.py
@@ -1,5 +1,6 @@
 from datetime import UTC, datetime, timedelta
 import json
+from typing import Any
 from unittest import mock
 from unittest.mock import patch
 import uuid
@@ -11,11 +12,17 @@ from django.core.management.base import CommandError
 import pytest
 
 from extras.test_utils.factories import BusinessAreaFactory, IndividualFactory
+from hope.models import BusinessArea, Individual
 
 pytestmark = pytest.mark.django_db
 
 COMMAND_MODULE = "hope.apps.registration_data.management.commands.export_encodings"
-COMMON_ARGS = ["--dedup-url", "https://dedup.test", "--dedup-token", "token"]
+DEDUP_URL = "https://dedup.test"
+DEDUP_TOKEN = "token"
+
+SET_ID_0 = "00000000-0000-0000-0000-000000000000"
+SET_ID_1 = "11111111-1111-1111-1111-111111111111"
+PENDING_EXPORT_KEY = "exports/1/afghanistan/afghanistan-pending.npy.zip"
 
 
 @pytest.fixture
@@ -33,7 +40,7 @@ def mock_client() -> mock.MagicMock:
 
 
 @pytest.fixture
-def afghanistan() -> object:
+def afghanistan(db: Any) -> BusinessArea:
     return BusinessAreaFactory(slug="afghanistan", name="Afghanistan")
 
 
@@ -42,18 +49,379 @@ def state_key() -> str:
     return f"export-encodings-tests/{uuid.uuid4().hex}/state.json"
 
 
-def read_state(state_key: str) -> dict:
-    with default_storage.open(state_key, "rb") as f:
-        return json.load(f)
+@pytest.fixture
+def individuals_for_chunk_submit(afghanistan: BusinessArea) -> list[Individual]:
+    eligible = [
+        IndividualFactory(business_area=afghanistan, photo="photo_0.jpg"),
+        IndividualFactory(business_area=afghanistan, photo="photo_1.jpg"),
+        IndividualFactory(business_area=afghanistan, photo="photo_2.jpg"),
+        IndividualFactory(business_area=afghanistan, photo="photo_3.jpg"),
+        IndividualFactory(business_area=afghanistan, photo="photo_4.jpg"),
+    ]
+    IndividualFactory(business_area=afghanistan, photo="")
+    IndividualFactory(business_area=afghanistan, photo="w.jpg", withdrawn=True)
+    IndividualFactory(business_area=afghanistan, photo="d.jpg", duplicate=True)
+    return sorted(eligible, key=lambda individual: individual.id)
 
 
-def write_state(state_key: str, state: dict) -> None:
-    if default_storage.exists(state_key):
-        default_storage.delete(state_key)
+@pytest.fixture
+def four_individuals_with_photos(afghanistan: BusinessArea) -> list[Individual]:
+    return [
+        IndividualFactory(business_area=afghanistan, photo="photo_0.jpg"),
+        IndividualFactory(business_area=afghanistan, photo="photo_1.jpg"),
+        IndividualFactory(business_area=afghanistan, photo="photo_2.jpg"),
+        IndividualFactory(business_area=afghanistan, photo="photo_3.jpg"),
+    ]
+
+
+@pytest.fixture
+def partially_uploaded_submit_state(
+    four_individuals_with_photos: list[Individual],
+    state_key: str,
+) -> str:
+    state = {
+        "run_id": "abc12345",
+        "chunk_size": 4,
+        "upload_batch_size": 2,
+        "business_areas": ["afghanistan"],
+        "chunks": [
+            {
+                "reference_id": "enc-afghanistan-abc12345-00000",
+                "business_area": "afghanistan",
+                "index": 0,
+                "set_id": SET_ID_0,
+                "image_count": 2,
+                "first_individual_id": None,
+                "last_individual_id": None,
+                "step": "uploading",
+                "uploaded_batches": 1,
+                "engine_state": None,
+            }
+        ],
+        "exports": {},
+    }
     default_storage.save(state_key, ContentFile(json.dumps(state).encode()))
+    return state_key
 
 
-def submit(state_key: str, extra: list[str] | None = None) -> None:
+@pytest.fixture
+def fully_processed_submit_state(
+    four_individuals_with_photos: list[Individual],
+    state_key: str,
+) -> str:
+    state = {
+        "run_id": "abc12345",
+        "chunk_size": 4,
+        "upload_batch_size": 2,
+        "business_areas": ["afghanistan"],
+        "chunks": [
+            {
+                "reference_id": "enc-afghanistan-abc12345-00000",
+                "business_area": "afghanistan",
+                "index": 0,
+                "set_id": SET_ID_0,
+                "image_count": 4,
+                "first_individual_id": None,
+                "last_individual_id": None,
+                "step": "processed",
+                "uploaded_batches": 2,
+                "engine_state": "Processing",
+            }
+        ],
+        "exports": {},
+    }
+    default_storage.save(state_key, ContentFile(json.dumps(state).encode()))
+    return state_key
+
+
+@pytest.fixture
+def submit_state_with_batch_size_1000(afghanistan: BusinessArea, state_key: str) -> str:
+    state = {
+        "run_id": "abc12345",
+        "chunk_size": 10000,
+        "upload_batch_size": 1000,
+        "business_areas": ["afghanistan"],
+        "chunks": [],
+        "exports": {},
+    }
+    default_storage.save(state_key, ContentFile(json.dumps(state).encode()))
+    return state_key
+
+
+@pytest.fixture
+def processing_chunk_state(state_key: str) -> str:
+    state = {
+        "run_id": "abc12345",
+        "chunk_size": 10000,
+        "upload_batch_size": 5000,
+        "business_areas": ["afghanistan"],
+        "chunks": [
+            {
+                "reference_id": "enc-afghanistan-abc12345-00000",
+                "business_area": "afghanistan",
+                "index": 0,
+                "set_id": SET_ID_0,
+                "image_count": 1,
+                "first_individual_id": None,
+                "last_individual_id": None,
+                "step": "processed",
+                "uploaded_batches": 1,
+                "engine_state": "Processing",
+            }
+        ],
+        "exports": {},
+    }
+    default_storage.save(state_key, ContentFile(json.dumps(state).encode()))
+    return state_key
+
+
+@pytest.fixture
+def encoded_chunk_state(state_key: str) -> str:
+    state = {
+        "run_id": "abc12345",
+        "chunk_size": 10000,
+        "upload_batch_size": 5000,
+        "business_areas": ["afghanistan"],
+        "chunks": [
+            {
+                "reference_id": "enc-afghanistan-abc12345-00000",
+                "business_area": "afghanistan",
+                "index": 0,
+                "set_id": SET_ID_0,
+                "image_count": 1,
+                "first_individual_id": None,
+                "last_individual_id": None,
+                "step": "processed",
+                "uploaded_batches": 1,
+                "engine_state": "Encoded",
+            }
+        ],
+        "exports": {},
+    }
+    default_storage.save(state_key, ContentFile(json.dumps(state).encode()))
+    return state_key
+
+
+@pytest.fixture
+def encoded_two_chunk_state(state_key: str) -> str:
+    # Chunks are stored out of index order on purpose: export must sort by index.
+    state = {
+        "run_id": "abc12345",
+        "chunk_size": 2,
+        "upload_batch_size": 5000,
+        "business_areas": ["afghanistan"],
+        "chunks": [
+            {
+                "reference_id": "enc-afghanistan-abc12345-00001",
+                "business_area": "afghanistan",
+                "index": 1,
+                "set_id": SET_ID_1,
+                "image_count": 1,
+                "first_individual_id": None,
+                "last_individual_id": None,
+                "step": "processed",
+                "uploaded_batches": 1,
+                "engine_state": "Encoded",
+            },
+            {
+                "reference_id": "enc-afghanistan-abc12345-00000",
+                "business_area": "afghanistan",
+                "index": 0,
+                "set_id": SET_ID_0,
+                "image_count": 2,
+                "first_individual_id": None,
+                "last_individual_id": None,
+                "step": "processed",
+                "uploaded_batches": 1,
+                "engine_state": "Encoded",
+            },
+        ],
+        "exports": {},
+    }
+    default_storage.save(state_key, ContentFile(json.dumps(state).encode()))
+    return state_key
+
+
+@pytest.fixture
+def pending_export_state(state_key: str) -> str:
+    state = {
+        "run_id": "abc12345",
+        "chunk_size": 10000,
+        "upload_batch_size": 5000,
+        "business_areas": ["afghanistan"],
+        "chunks": [
+            {
+                "reference_id": "enc-afghanistan-abc12345-00000",
+                "business_area": "afghanistan",
+                "index": 0,
+                "set_id": SET_ID_0,
+                "image_count": 1,
+                "first_individual_id": None,
+                "last_individual_id": None,
+                "step": "processed",
+                "uploaded_batches": 1,
+                "engine_state": "Encoded",
+            }
+        ],
+        "exports": {
+            "afghanistan:npy": {
+                "key": PENDING_EXPORT_KEY,
+                "format": "npy",
+                "state": "pending",
+                "requested_at": datetime.now(UTC).isoformat(),
+            }
+        },
+    }
+    default_storage.save(state_key, ContentFile(json.dumps(state).encode()))
+    return state_key
+
+
+@pytest.fixture
+def ready_export_state(state_key: str) -> str:
+    state = {
+        "run_id": "abc12345",
+        "chunk_size": 10000,
+        "upload_batch_size": 5000,
+        "business_areas": ["afghanistan"],
+        "chunks": [
+            {
+                "reference_id": "enc-afghanistan-abc12345-00000",
+                "business_area": "afghanistan",
+                "index": 0,
+                "set_id": SET_ID_0,
+                "image_count": 1,
+                "first_individual_id": None,
+                "last_individual_id": None,
+                "step": "processed",
+                "uploaded_batches": 1,
+                "engine_state": "Encoded",
+            }
+        ],
+        "exports": {
+            "afghanistan:npy": {
+                "key": PENDING_EXPORT_KEY,
+                "format": "npy",
+                "state": "ready",
+                "url": "https://blob/exports/1/afghanistan/a.zip?sig=first",
+                "expires_at": "2026-08-13T12:00:00Z",
+                "requested_at": datetime.now(UTC).isoformat(),
+            }
+        },
+    }
+    default_storage.save(state_key, ContentFile(json.dumps(state).encode()))
+    return state_key
+
+
+@pytest.fixture
+def failed_export_state(state_key: str) -> str:
+    state = {
+        "run_id": "abc12345",
+        "chunk_size": 10000,
+        "upload_batch_size": 5000,
+        "business_areas": ["afghanistan"],
+        "chunks": [
+            {
+                "reference_id": "enc-afghanistan-abc12345-00000",
+                "business_area": "afghanistan",
+                "index": 0,
+                "set_id": SET_ID_0,
+                "image_count": 1,
+                "first_individual_id": None,
+                "last_individual_id": None,
+                "step": "processed",
+                "uploaded_batches": 1,
+                "engine_state": "Encoded",
+            }
+        ],
+        "exports": {
+            "afghanistan:npy": {
+                "key": None,
+                "format": "npy",
+                "state": "failed",
+                "error": "boom",
+                "requested_at": datetime.now(UTC).isoformat(),
+            }
+        },
+    }
+    default_storage.save(state_key, ContentFile(json.dumps(state).encode()))
+    return state_key
+
+
+@pytest.fixture
+def timed_out_export_state(state_key: str) -> str:
+    state = {
+        "run_id": "abc12345",
+        "chunk_size": 10000,
+        "upload_batch_size": 5000,
+        "business_areas": ["afghanistan"],
+        "chunks": [
+            {
+                "reference_id": "enc-afghanistan-abc12345-00000",
+                "business_area": "afghanistan",
+                "index": 0,
+                "set_id": SET_ID_0,
+                "image_count": 1,
+                "first_individual_id": None,
+                "last_individual_id": None,
+                "step": "processed",
+                "uploaded_batches": 1,
+                "engine_state": "Encoded",
+            }
+        ],
+        "exports": {
+            "afghanistan:npy": {
+                "key": PENDING_EXPORT_KEY,
+                "format": "npy",
+                "state": "pending",
+                "requested_at": (datetime.now(UTC) - timedelta(hours=3)).isoformat(),
+            }
+        },
+    }
+    default_storage.save(state_key, ContentFile(json.dumps(state).encode()))
+    return state_key
+
+
+@pytest.fixture
+def jsonl_ready_export_state(state_key: str) -> str:
+    state = {
+        "run_id": "abc12345",
+        "chunk_size": 10000,
+        "upload_batch_size": 5000,
+        "business_areas": ["afghanistan"],
+        "chunks": [
+            {
+                "reference_id": "enc-afghanistan-abc12345-00000",
+                "business_area": "afghanistan",
+                "index": 0,
+                "set_id": SET_ID_0,
+                "image_count": 1,
+                "first_individual_id": None,
+                "last_individual_id": None,
+                "step": "processed",
+                "uploaded_batches": 1,
+                "engine_state": "Encoded",
+            }
+        ],
+        "exports": {
+            "afghanistan:jsonl": {
+                "key": "exports/1/afghanistan/afghanistan-ready.jsonl.zip",
+                "format": "jsonl",
+                "state": "ready",
+                "url": "https://blob/a.jsonl.zip?sig=x",
+                "expires_at": "2026-08-13T12:00:00Z",
+                "requested_at": datetime.now(UTC).isoformat(),
+            }
+        },
+    }
+    default_storage.save(state_key, ContentFile(json.dumps(state).encode()))
+    return state_key
+
+
+def test_submit_chunks_deterministically_and_processes_each_chunk(
+    mock_client: mock.MagicMock,
+    individuals_for_chunk_submit: list[Individual],
+    state_key: str,
+) -> None:
     call_command(
         "export_encodings",
         "--mode",
@@ -62,87 +430,164 @@ def submit(state_key: str, extra: list[str] | None = None) -> None:
         state_key,
         "--business-areas",
         "afghanistan",
-        *COMMON_ARGS,
-        *(extra or []),
+        "--dedup-url",
+        DEDUP_URL,
+        "--dedup-token",
+        DEDUP_TOKEN,
+        "--chunk-size",
+        "2",
     )
 
+    with default_storage.open(state_key, "rb") as handle:
+        state = json.load(handle)
 
-def export(state_key: str, extra: list[str] | None = None) -> None:
-    call_command("export_encodings", "--mode", "export", "--state-file", state_key, *COMMON_ARGS, *(extra or []))
-
-
-def test_submit_chunks_deterministically_and_processes_each_chunk(
-    mock_client: mock.MagicMock, afghanistan: object, state_key: str
-) -> None:
-    individuals = [IndividualFactory(business_area=afghanistan, photo=f"photo_{i}.jpg") for i in range(5)]
-    # Excluded individuals must not be submitted.
-    IndividualFactory(business_area=afghanistan, photo="")
-    IndividualFactory(business_area=afghanistan, photo="w.jpg", withdrawn=True)
-    IndividualFactory(business_area=afghanistan, photo="d.jpg", duplicate=True)
-
-    submit(state_key, ["--chunk-size", "2"])
-
-    state = read_state(state_key)
     assert state["upload_batch_size"] == 5000
-    assert len(state["chunks"]) == 3  # 5 individuals / chunk size 2
-    assert [chunk["index"] for chunk in state["chunks"]] == [0, 1, 2]
-    assert all(chunk["step"] == "processed" for chunk in state["chunks"])
-    assert [chunk["image_count"] for chunk in state["chunks"]] == [2, 2, 1]
-    run_id = state["run_id"]
-    assert state["chunks"][0]["reference_id"] == f"enc-afghanistan-{run_id}-00000"
-
+    assert len(state["chunks"]) == 3
+    assert state["chunks"][0]["index"] == 0
+    assert state["chunks"][1]["index"] == 1
+    assert state["chunks"][2]["index"] == 2
+    assert state["chunks"][0]["step"] == "processed"
+    assert state["chunks"][1]["step"] == "processed"
+    assert state["chunks"][2]["step"] == "processed"
+    assert state["chunks"][0]["image_count"] == 2
+    assert state["chunks"][1]["image_count"] == 2
+    assert state["chunks"][2]["image_count"] == 1
+    assert state["chunks"][0]["reference_id"] == f"enc-afghanistan-{state['run_id']}-00000"
     assert mock_client.create_set.call_count == 3
     assert mock_client.mark_ready.call_count == 3
     assert mock_client.process.call_count == 3
     mock_client.process.assert_called_with(state["chunks"][2]["set_id"], encode_only=True)
 
-    # Filename-mode payload: reference_pk + storage key only, no image content.
-    items = [item for call_args in mock_client.register_images.call_args_list for item in call_args.args[1]]
-    assert all(set(item) == {"reference_pk", "filename"} for item in items)
-    # Chunk membership is deterministic: ordered by individual id.
-    assert [item["reference_pk"] for item in items] == sorted(str(individual.id) for individual in individuals)
 
-
-def test_submit_resume_skips_already_uploaded_batches_and_processed_chunks(
-    mock_client: mock.MagicMock, afghanistan: object, state_key: str
+def test_submit_registers_images_in_id_order_with_filename_payload(
+    mock_client: mock.MagicMock,
+    individuals_for_chunk_submit: list[Individual],
+    state_key: str,
 ) -> None:
-    for i in range(4):
-        IndividualFactory(business_area=afghanistan, photo=f"photo_{i}.jpg")
+    call_command(
+        "export_encodings",
+        "--mode",
+        "submit",
+        "--state-file",
+        state_key,
+        "--business-areas",
+        "afghanistan",
+        "--dedup-url",
+        DEDUP_URL,
+        "--dedup-token",
+        DEDUP_TOKEN,
+        "--chunk-size",
+        "2",
+    )
 
-    submit(state_key, ["--chunk-size", "4", "--upload-batch-size", "2"])
-    assert mock_client.register_images.call_count == 2
+    first_batch = mock_client.register_images.call_args_list[0].args[1]
+    second_batch = mock_client.register_images.call_args_list[1].args[1]
+    third_batch = mock_client.register_images.call_args_list[2].args[1]
+    assert first_batch == [
+        {
+            "reference_pk": str(individuals_for_chunk_submit[0].id),
+            "filename": individuals_for_chunk_submit[0].photo.name,
+        },
+        {
+            "reference_pk": str(individuals_for_chunk_submit[1].id),
+            "filename": individuals_for_chunk_submit[1].photo.name,
+        },
+    ]
+    assert second_batch == [
+        {
+            "reference_pk": str(individuals_for_chunk_submit[2].id),
+            "filename": individuals_for_chunk_submit[2].photo.name,
+        },
+        {
+            "reference_pk": str(individuals_for_chunk_submit[3].id),
+            "filename": individuals_for_chunk_submit[3].photo.name,
+        },
+    ]
+    assert third_batch == [
+        {
+            "reference_pk": str(individuals_for_chunk_submit[4].id),
+            "filename": individuals_for_chunk_submit[4].photo.name,
+        },
+    ]
 
-    # Simulate a crash after the first of two batches was uploaded.
-    state = read_state(state_key)
-    state["chunks"][0]["step"] = "uploading"
-    state["chunks"][0]["uploaded_batches"] = 1
-    state["chunks"][0]["image_count"] = 2
-    write_state(state_key, state)
-    mock_client.register_images.reset_mock()
-    mock_client.create_set.reset_mock()
 
-    submit(state_key, ["--chunk-size", "4", "--upload-batch-size", "2"])
+def test_submit_resume_skips_already_uploaded_batches(
+    mock_client: mock.MagicMock,
+    partially_uploaded_submit_state: str,
+) -> None:
+    call_command(
+        "export_encodings",
+        "--mode",
+        "submit",
+        "--state-file",
+        partially_uploaded_submit_state,
+        "--business-areas",
+        "afghanistan",
+        "--dedup-url",
+        DEDUP_URL,
+        "--dedup-token",
+        DEDUP_TOKEN,
+        "--chunk-size",
+        "4",
+        "--upload-batch-size",
+        "2",
+    )
 
-    mock_client.create_set.assert_not_called()  # set already exists
-    assert mock_client.register_images.call_count == 1  # only the second batch
-    state = read_state(state_key)
+    mock_client.create_set.assert_not_called()
+    assert mock_client.register_images.call_count == 1
+
+    with default_storage.open(partially_uploaded_submit_state, "rb") as handle:
+        state = json.load(handle)
     assert state["chunks"][0]["step"] == "processed"
     assert state["chunks"][0]["image_count"] == 4
 
-    # A fully processed state file is a no-op on re-run.
-    mock_client.register_images.reset_mock()
-    submit(state_key, ["--chunk-size", "4", "--upload-batch-size", "2"])
+
+def test_submit_fully_processed_is_noop_on_rerun(
+    mock_client: mock.MagicMock,
+    fully_processed_submit_state: str,
+) -> None:
+    call_command(
+        "export_encodings",
+        "--mode",
+        "submit",
+        "--state-file",
+        fully_processed_submit_state,
+        "--business-areas",
+        "afghanistan",
+        "--dedup-url",
+        DEDUP_URL,
+        "--dedup-token",
+        DEDUP_TOKEN,
+        "--chunk-size",
+        "4",
+        "--upload-batch-size",
+        "2",
+    )
+
+    mock_client.create_set.assert_not_called()
     mock_client.register_images.assert_not_called()
 
 
 def test_submit_rejects_conflicting_pinned_parameters(
-    mock_client: mock.MagicMock, afghanistan: object, state_key: str
+    mock_client: mock.MagicMock,
+    submit_state_with_batch_size_1000: str,
 ) -> None:
-    IndividualFactory(business_area=afghanistan, photo="photo.jpg")
-    submit(state_key, ["--upload-batch-size", "1000"])
-
     with pytest.raises(CommandError, match="upload_batch_size"):
-        submit(state_key, ["--upload-batch-size", "2000"])
+        call_command(
+            "export_encodings",
+            "--mode",
+            "submit",
+            "--state-file",
+            submit_state_with_batch_size_1000,
+            "--business-areas",
+            "afghanistan",
+            "--dedup-url",
+            DEDUP_URL,
+            "--dedup-token",
+            DEDUP_TOKEN,
+            "--upload-batch-size",
+            "2000",
+        )
 
 
 def test_submit_rejects_unknown_business_area(mock_client: mock.MagicMock, state_key: str) -> None:
@@ -155,54 +600,90 @@ def test_submit_rejects_unknown_business_area(mock_client: mock.MagicMock, state
             state_key,
             "--business-areas",
             "nosuchplace",
-            *COMMON_ARGS,
+            "--dedup-url",
+            DEDUP_URL,
+            "--dedup-token",
+            DEDUP_TOKEN,
         )
 
 
-def test_status_updates_engine_state(mock_client: mock.MagicMock, afghanistan: object, state_key: str) -> None:
-    IndividualFactory(business_area=afghanistan, photo="photo.jpg")
-    submit(state_key)
-
+def test_status_updates_engine_state(
+    mock_client: mock.MagicMock,
+    processing_chunk_state: str,
+) -> None:
     mock_client.get_set.return_value = {"state": "Encoding"}
-    call_command("export_encodings", "--mode", "status", "--state-file", state_key, *COMMON_ARGS)
 
-    state = read_state(state_key)
+    call_command(
+        "export_encodings",
+        "--mode",
+        "status",
+        "--state-file",
+        processing_chunk_state,
+        "--dedup-url",
+        DEDUP_URL,
+        "--dedup-token",
+        DEDUP_TOKEN,
+    )
+
+    mock_client.get_set.assert_called_once_with(SET_ID_0)
+    with default_storage.open(processing_chunk_state, "rb") as handle:
+        state = json.load(handle)
     assert state["chunks"][0]["engine_state"] == "Encoding"
 
 
 def test_export_requests_export_when_all_chunks_encoded(
-    mock_client: mock.MagicMock, afghanistan: object, state_key: str
+    mock_client: mock.MagicMock,
+    encoded_two_chunk_state: str,
 ) -> None:
-    for i in range(3):
-        IndividualFactory(business_area=afghanistan, photo=f"photo_{i}.jpg")
-    submit(state_key, ["--chunk-size", "2"])
+    call_command(
+        "export_encodings",
+        "--mode",
+        "export",
+        "--state-file",
+        encoded_two_chunk_state,
+        "--dedup-url",
+        DEDUP_URL,
+        "--dedup-token",
+        DEDUP_TOKEN,
+    )
 
-    mock_client.get_set.return_value = {"state": "Encoded"}
-    export(state_key)
+    with default_storage.open(encoded_two_chunk_state, "rb") as handle:
+        state = json.load(handle)
 
-    state = read_state(state_key)
     export_entry = state["exports"]["afghanistan:npy"]
     assert export_entry["state"] == "pending"
     assert export_entry["key"].startswith("exports/1/afghanistan/")
-    assert export_entry["format"] == "npy"  # default format
+    assert export_entry["format"] == "npy"
     assert export_entry["requested_at"]
-
-    # Sets are passed in chunk-index order.
-    expected_set_ids = [chunk["set_id"] for chunk in state["chunks"]]
+    # Sets are passed in chunk-index order even though the state file stores them reversed.
     mock_client.create_export.assert_called_once_with(
-        reference_pk="afghanistan", set_ids=expected_set_ids, export_format="npy"
+        reference_pk="afghanistan",
+        set_ids=[SET_ID_0, SET_ID_1],
+        export_format="npy",
     )
 
 
 def test_export_format_flag_is_passed_and_recorded(
-    mock_client: mock.MagicMock, afghanistan: object, state_key: str
+    mock_client: mock.MagicMock,
+    encoded_chunk_state: str,
 ) -> None:
-    IndividualFactory(business_area=afghanistan, photo="photo.jpg")
-    submit(state_key)
+    call_command(
+        "export_encodings",
+        "--mode",
+        "export",
+        "--state-file",
+        encoded_chunk_state,
+        "--dedup-url",
+        DEDUP_URL,
+        "--dedup-token",
+        DEDUP_TOKEN,
+        "--export-format",
+        "jsonl",
+    )
 
-    export(state_key, ["--export-format", "jsonl"])
+    with default_storage.open(encoded_chunk_state, "rb") as handle:
+        state = json.load(handle)
 
-    state = read_state(state_key)
     export_entry = state["exports"]["afghanistan:jsonl"]
     assert export_entry["format"] == "jsonl"
     assert ".jsonl.zip" in export_entry["key"]
@@ -210,140 +691,240 @@ def test_export_format_flag_is_passed_and_recorded(
 
 
 def test_both_export_formats_coexist_for_one_co(
-    mock_client: mock.MagicMock, afghanistan: object, state_key: str
+    mock_client: mock.MagicMock,
+    jsonl_ready_export_state: str,
 ) -> None:
-    IndividualFactory(business_area=afghanistan, photo="photo.jpg")
-    submit(state_key)
+    call_command(
+        "export_encodings",
+        "--mode",
+        "export",
+        "--state-file",
+        jsonl_ready_export_state,
+        "--dedup-url",
+        DEDUP_URL,
+        "--dedup-token",
+        DEDUP_TOKEN,
+        "--export-format",
+        "npy",
+    )
 
-    export(state_key, ["--export-format", "jsonl"])  # requests jsonl export
-    mock_client.export_status.return_value = {
-        "state": "ready",
-        "url": "https://blob/a.jsonl.zip?sig=x",
-        "expires_at": "2026-08-13T12:00:00Z",
-    }
-    export(state_key, ["--export-format", "jsonl"])  # polls jsonl -> ready
+    with default_storage.open(jsonl_ready_export_state, "rb") as handle:
+        state = json.load(handle)
 
-    # Requesting npy afterwards creates a second, independent export slot.
-    export(state_key, ["--export-format", "npy"])
-
-    state = read_state(state_key)
-    assert state["exports"]["afghanistan:jsonl"]["state"] == "ready"
     assert state["exports"]["afghanistan:npy"]["state"] == "pending"
     assert ".npy.zip" in state["exports"]["afghanistan:npy"]["key"]
-    assert mock_client.create_export.call_count == 2  # one per format
+    mock_client.create_export.assert_called_once()
     # The ready jsonl entry was untouched by the npy request.
+    assert state["exports"]["afghanistan:jsonl"]["state"] == "ready"
     assert state["exports"]["afghanistan:jsonl"]["url"].endswith("sig=x")
 
 
 def test_export_skips_co_with_unencoded_chunks(
-    mock_client: mock.MagicMock, afghanistan: object, state_key: str
+    mock_client: mock.MagicMock,
+    processing_chunk_state: str,
 ) -> None:
-    IndividualFactory(business_area=afghanistan, photo="photo.jpg")
-    submit(state_key)
-
     mock_client.get_set.return_value = {"state": "Encoding"}
-    export(state_key)
+
+    call_command(
+        "export_encodings",
+        "--mode",
+        "export",
+        "--state-file",
+        processing_chunk_state,
+        "--dedup-url",
+        DEDUP_URL,
+        "--dedup-token",
+        DEDUP_TOKEN,
+    )
 
     mock_client.create_export.assert_not_called()
-    assert read_state(state_key)["exports"] == {}
+    with default_storage.open(processing_chunk_state, "rb") as handle:
+        state = json.load(handle)
+    assert state["exports"] == {}
 
 
-def test_export_poll_stores_signed_url_and_renews_it_on_repoll(
-    mock_client: mock.MagicMock, afghanistan: object, state_key: str
+def test_export_poll_stores_signed_url(
+    mock_client: mock.MagicMock,
+    pending_export_state: str,
 ) -> None:
-    IndividualFactory(business_area=afghanistan, photo="photo.jpg")
-    submit(state_key)
-    export(state_key)  # requests the export, stores the key
-
     mock_client.export_status.return_value = {
         "state": "ready",
         "url": "https://blob/exports/1/afghanistan/a.zip?sig=first",
         "expires_at": "2026-08-13T12:00:00Z",
     }
-    export(state_key)  # polls -> ready
 
-    state = read_state(state_key)
+    call_command(
+        "export_encodings",
+        "--mode",
+        "export",
+        "--state-file",
+        pending_export_state,
+        "--dedup-url",
+        DEDUP_URL,
+        "--dedup-token",
+        DEDUP_TOKEN,
+    )
+
+    mock_client.export_status.assert_called_once_with(PENDING_EXPORT_KEY)
+    with default_storage.open(pending_export_state, "rb") as handle:
+        state = json.load(handle)
     export_entry = state["exports"]["afghanistan:npy"]
     assert export_entry["state"] == "ready"
     assert export_entry["url"].endswith("sig=first")
     assert export_entry["expires_at"] == "2026-08-13T12:00:00Z"
-    mock_client.export_status.assert_called_once_with(export_entry["key"])
 
-    # Re-running export on a ready CO re-polls the same key and renews the URL.
+
+def test_export_renews_signed_url_on_repoll(
+    mock_client: mock.MagicMock,
+    ready_export_state: str,
+) -> None:
     mock_client.export_status.return_value = {
         "state": "ready",
         "url": "https://blob/exports/1/afghanistan/a.zip?sig=renewed",
         "expires_at": "2026-08-20T12:00:00Z",
     }
-    export(state_key)
-    state = read_state(state_key)
+
+    call_command(
+        "export_encodings",
+        "--mode",
+        "export",
+        "--state-file",
+        ready_export_state,
+        "--dedup-url",
+        DEDUP_URL,
+        "--dedup-token",
+        DEDUP_TOKEN,
+    )
+
+    mock_client.create_export.assert_not_called()
+    with default_storage.open(ready_export_state, "rb") as handle:
+        state = json.load(handle)
     assert state["exports"]["afghanistan:npy"]["url"].endswith("sig=renewed")
-    mock_client.create_export.assert_called_once()  # never re-requested
+    assert state["exports"]["afghanistan:npy"]["expires_at"] == "2026-08-20T12:00:00Z"
 
 
-def test_export_failed_clears_key_and_next_run_rerequests(
-    mock_client: mock.MagicMock, afghanistan: object, state_key: str
+def test_export_failed_clears_key(
+    mock_client: mock.MagicMock,
+    pending_export_state: str,
 ) -> None:
-    IndividualFactory(business_area=afghanistan, photo="photo.jpg")
-    submit(state_key)
-    export(state_key)
-
     mock_client.export_status.return_value = {"state": "failed", "error": "boom"}
-    export(state_key)
 
-    state = read_state(state_key)
+    call_command(
+        "export_encodings",
+        "--mode",
+        "export",
+        "--state-file",
+        pending_export_state,
+        "--dedup-url",
+        DEDUP_URL,
+        "--dedup-token",
+        DEDUP_TOKEN,
+    )
+
+    with default_storage.open(pending_export_state, "rb") as handle:
+        state = json.load(handle)
     export_entry = state["exports"]["afghanistan:npy"]
     assert export_entry["state"] == "failed"
     assert export_entry["key"] is None
     assert export_entry["error"] == "boom"
 
-    # Next run re-POSTs under a fresh key.
-    export(state_key)
-    assert mock_client.create_export.call_count == 2
-    state = read_state(state_key)
+
+def test_export_rerequests_after_failed(
+    mock_client: mock.MagicMock,
+    failed_export_state: str,
+) -> None:
+    call_command(
+        "export_encodings",
+        "--mode",
+        "export",
+        "--state-file",
+        failed_export_state,
+        "--dedup-url",
+        DEDUP_URL,
+        "--dedup-token",
+        DEDUP_TOKEN,
+    )
+
+    mock_client.create_export.assert_called_once()
+    with default_storage.open(failed_export_state, "rb") as handle:
+        state = json.load(handle)
     assert state["exports"]["afghanistan:npy"]["state"] == "pending"
     assert state["exports"]["afghanistan:npy"]["key"]
 
 
-def test_export_reposts_after_pending_timeout(mock_client: mock.MagicMock, afghanistan: object, state_key: str) -> None:
-    IndividualFactory(business_area=afghanistan, photo="photo.jpg")
-    submit(state_key)
-    export(state_key)
+def test_export_reposts_after_pending_timeout(
+    mock_client: mock.MagicMock,
+    timed_out_export_state: str,
+) -> None:
+    call_command(
+        "export_encodings",
+        "--mode",
+        "export",
+        "--state-file",
+        timed_out_export_state,
+        "--dedup-url",
+        DEDUP_URL,
+        "--dedup-token",
+        DEDUP_TOKEN,
+    )
 
-    state = read_state(state_key)
-    old_key = state["exports"]["afghanistan:npy"]["key"]
-    state["exports"]["afghanistan:npy"]["requested_at"] = (datetime.now(UTC) - timedelta(hours=3)).isoformat()
-    write_state(state_key, state)
-
-    mock_client.export_status.return_value = {"state": "pending"}
-    export(state_key)
-
-    assert mock_client.create_export.call_count == 2
-    state = read_state(state_key)
-    assert state["exports"]["afghanistan:npy"]["key"] != old_key
+    mock_client.create_export.assert_called_once()
+    with default_storage.open(timed_out_export_state, "rb") as handle:
+        state = json.load(handle)
+    assert state["exports"]["afghanistan:npy"]["key"] != PENDING_EXPORT_KEY
     assert state["exports"]["afghanistan:npy"]["state"] == "pending"
 
 
 def test_export_still_pending_within_timeout_does_not_repost(
-    mock_client: mock.MagicMock, afghanistan: object, state_key: str
+    mock_client: mock.MagicMock,
+    pending_export_state: str,
 ) -> None:
-    IndividualFactory(business_area=afghanistan, photo="photo.jpg")
-    submit(state_key)
-    export(state_key)
-    old_key = read_state(state_key)["exports"]["afghanistan:npy"]["key"]
+    call_command(
+        "export_encodings",
+        "--mode",
+        "export",
+        "--state-file",
+        pending_export_state,
+        "--dedup-url",
+        DEDUP_URL,
+        "--dedup-token",
+        DEDUP_TOKEN,
+    )
 
-    mock_client.export_status.return_value = {"state": "pending"}
-    export(state_key)
+    mock_client.create_export.assert_not_called()
+    with default_storage.open(pending_export_state, "rb") as handle:
+        state = json.load(handle)
+    assert state["exports"]["afghanistan:npy"]["key"] == PENDING_EXPORT_KEY
 
-    assert mock_client.create_export.call_count == 1
-    assert read_state(state_key)["exports"]["afghanistan:npy"]["key"] == old_key
 
-
-def test_status_and_export_require_submitted_state(mock_client: mock.MagicMock, state_key: str) -> None:
+def test_status_requires_submitted_state(mock_client: mock.MagicMock, state_key: str) -> None:
     with pytest.raises(CommandError, match="submit"):
-        call_command("export_encodings", "--mode", "status", "--state-file", state_key, *COMMON_ARGS)
+        call_command(
+            "export_encodings",
+            "--mode",
+            "status",
+            "--state-file",
+            state_key,
+            "--dedup-url",
+            DEDUP_URL,
+            "--dedup-token",
+            DEDUP_TOKEN,
+        )
+
+
+def test_export_requires_submitted_state(mock_client: mock.MagicMock, state_key: str) -> None:
     with pytest.raises(CommandError, match="submit"):
-        export(state_key)
+        call_command(
+            "export_encodings",
+            "--mode",
+            "export",
+            "--state-file",
+            state_key,
+            "--dedup-url",
+            DEDUP_URL,
+            "--dedup-token",
+            DEDUP_TOKEN,
+        )
 
 
 def test_missing_credentials_raise_command_error(state_key: str, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
One-shot management command that encodes Country Office (CO) face photos via the
Deduplication Engine (`encode_only`) and requests a zip of
embeddings as a **signed URL**. Progress is tracked in a JSON state file in Django
default storage so every mode is idempotent and safe to re-run.

There is no admin UI, Celery task, or REST route in HOPE for this flow — only this command.

More details in `docs/guide-dev/export-encodings.md`