### PR TITLE
[FEATURE] set phone_no_valid on bulk-created individuals

### DIFF
--- a/src/hope/apps/generic_import/generic_upload_service/importer.py
+++ b/src/hope/apps/generic_import/generic_upload_service/importer.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any
 
 from django.forms import modelform_factory
 
+from hope.apps.utils.phone import is_valid_phone_number
 from hope.models import (
     Account,
     AccountType,
@@ -402,6 +403,10 @@ class Importer:
                 individual.first_registration_date = timezone.now()
             if not getattr(individual, "last_registration_date", None):
                 individual.last_registration_date = timezone.now()
+            if individual.phone_no:
+                individual.phone_no_valid = is_valid_phone_number(str(individual.phone_no))
+            if individual.phone_no_alternative:
+                individual.phone_no_alternative_valid = is_valid_phone_number(str(individual.phone_no_alternative))
         Individual.objects.bulk_create(self.individuals_to_create)
 
     def _save_documents(self) -> None:

--- a/src/hope/apps/registration_data/tasks/rdi_xlsx_people_create.py
+++ b/src/hope/apps/registration_data/tasks/rdi_xlsx_people_create.py
@@ -357,6 +357,7 @@ class RdiXlsxPeopleCreateTask(RdiXlsxCreateTask):
                     populate_pdu_with_null_values(registration_data_import.program, obj_to_create.flex_fields)
                     self.handle_pdu_fields(row, first_row, obj_to_create)
                 self._create_hh_ind(obj_to_create, row, first_row)
+        self.execute_individuals_additional_steps(self.individuals)
 
         PendingIndividual.objects.bulk_create(self.individuals)
         PendingHousehold.objects.bulk_update(

--- a/tests/unit/apps/generic_import/test_importer.py
+++ b/tests/unit/apps/generic_import/test_importer.py
@@ -1016,3 +1016,34 @@ def test_importer_sets_phone_no_valid_on_imported_individual(rdi: RegistrationDa
     individual = Individual.pending_objects.get(id=individual_temp_id)
     assert str(individual.phone_no) == "+258841625891"
     assert individual.phone_no_valid is True
+
+
+@pytest.mark.django_db
+def test_importer_sets_phone_no_alternative_valid_on_imported_individual(rdi: RegistrationDataImport) -> None:
+    individual_temp_id = uuid.uuid4().hex
+    individuals_data = [
+        {
+            "id": individual_temp_id,
+            "given_name": "Alternative",
+            "family_name": "Phone",
+            "full_name": "Alternative Phone",
+            "sex": "MALE",
+            "birth_date": "1990-01-01",
+            "phone_no_alternative": "+258841625891",
+        }
+    ]
+    importer = Importer(
+        registration_data_import=rdi,
+        households_data=[],
+        individuals_data=individuals_data,
+        documents_data=[],
+        accounts_data=[],
+        identities_data=[],
+    )
+
+    importer.import_data()
+
+    assert importer.errors == []
+    individual = Individual.pending_objects.get(id=individual_temp_id)
+    assert str(individual.phone_no_alternative) == "+258841625891"
+    assert individual.phone_no_alternative_valid is True

--- a/tests/unit/apps/generic_import/test_importer.py
+++ b/tests/unit/apps/generic_import/test_importer.py
@@ -985,3 +985,34 @@ def test_importer_household_empty_currency_string_is_null(rdi: RegistrationDataI
     assert importer.errors == []
     household = Household.pending_objects.get(id=household_temp_id)
     assert household.currency is None
+
+
+@pytest.mark.django_db
+def test_importer_sets_phone_no_valid_on_imported_individual(rdi: RegistrationDataImport) -> None:
+    individual_temp_id = uuid.uuid4().hex
+    individuals_data = [
+        {
+            "id": individual_temp_id,
+            "given_name": "Valid",
+            "family_name": "Phone",
+            "full_name": "Valid Phone",
+            "sex": "MALE",
+            "birth_date": "1990-01-01",
+            "phone_no": "+258841625891",
+        }
+    ]
+    importer = Importer(
+        registration_data_import=rdi,
+        households_data=[],
+        individuals_data=individuals_data,
+        documents_data=[],
+        accounts_data=[],
+        identities_data=[],
+    )
+
+    importer.import_data()
+
+    assert importer.errors == []
+    individual = Individual.pending_objects.get(id=individual_temp_id)
+    assert str(individual.phone_no) == "+258841625891"
+    assert individual.phone_no_valid is True

--- a/tests/unit/apps/registration_data/test_rdi_people_create.py
+++ b/tests/unit/apps/registration_data/test_rdi_people_create.py
@@ -306,3 +306,43 @@ def test_execute(
         "card_expiry_date": "2016-06-27T00:00:00",
         "name_of_cardholder": "Name2",
     }
+
+
+def test_execute_sets_phone_no_valid_on_imported_individual(
+    rdi_people_dependencies: dict[str, object],
+    registration_data_import: object,
+    import_data: object,
+    business_area: object,
+    program: Program,
+) -> None:
+    assert rdi_people_dependencies
+    RdiXlsxPeopleCreateTask().execute(
+        registration_data_import.id,
+        import_data.id,
+        business_area.id,
+        program.id,
+    )
+
+    individual = PendingIndividual.objects.get(full_name="Derek Index4")
+
+    assert str(individual.phone_no) == "+48605899013"
+    assert individual.phone_no_valid is True
+
+
+def test_execute_sets_phone_no_valid_on_every_imported_individual_with_a_phone_number(
+    rdi_people_dependencies: dict[str, object],
+    registration_data_import: object,
+    import_data: object,
+    business_area: object,
+    program: Program,
+) -> None:
+    assert rdi_people_dependencies
+    RdiXlsxPeopleCreateTask().execute(
+        registration_data_import.id,
+        import_data.id,
+        business_area.id,
+        program.id,
+    )
+
+    assert PendingIndividual.objects.filter(phone_no_valid=True).count() == 5
+    assert PendingIndividual.objects.filter(phone_no_valid__isnull=True).count() == 0


### PR DESCRIPTION
[AB#333565](https://unicef.visualstudio.com/4e044e8d-bc28-4768-8074-f80ff6e4a0e5/_workitems/edit/333565)
RdiXlsxPeopleCreateTask and the generic importer bulk_create individuals, bypassing Individual.save(), so phone_no_valid was never computed. 
RapidPro verification requires it and because of that returned no eligible records.