### PR TITLE
feat(account): add help text to account model fields

### DIFF
--- a/src/hope/apps/payment/migrations/0006_migration.py
+++ b/src/hope/apps/payment/migrations/0006_migration.py
@@ -17,6 +17,7 @@ class Migration(migrations.Migration):
                 blank=True,
                 default=dict,
                 encoder=django.core.serializers.json.DjangoJSONEncoder,
+                help_text="Additional account-specific fields",
             ),
         ),
         migrations.AlterField(

--- a/src/hope/apps/payment/migrations/0026_migration.py
+++ b/src/hope/apps/payment/migrations/0026_migration.py
@@ -44,6 +44,7 @@ class Migration(migrations.Migration):
             model_name="account",
             name="individual",
             field=models.ForeignKey(
+                help_text="The individual this account belongs to",
                 on_delete=django.db.models.deletion.CASCADE,
                 related_name="accounts",
                 to="household.individual",

--- a/src/hope/apps/payment/migrations/0027_migration.py
+++ b/src/hope/apps/payment/migrations/0027_migration.py
@@ -21,6 +21,7 @@ class Migration(migrations.Migration):
             name="financial_institution",
             field=models.ForeignKey(
                 blank=True,
+                help_text="The financial institution holding this account",
                 null=True,
                 on_delete=django.db.models.deletion.PROTECT,
                 to="payment.financialinstitution",

--- a/src/hope/apps/payment/migrations/0034_migration.py
+++ b/src/hope/apps/payment/migrations/0034_migration.py
@@ -22,6 +22,12 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name="account",
             name="number",
-            field=models.CharField(blank=True, db_index=True, max_length=256, null=True),
+            field=models.CharField(
+                blank=True,
+                db_index=True,
+                help_text="The account number or wallet identifier",
+                max_length=256,
+                null=True,
+            ),
         ),
     ]

--- a/src/hope/apps/payment/migrations/0035_migration.py
+++ b/src/hope/apps/payment/migrations/0035_migration.py
@@ -13,6 +13,10 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name="account",
             name="account_type",
-            field=models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, to="payment.accounttype"),
+            field=models.ForeignKey(
+                help_text="The type of account (e.g. bank, wallet)",
+                on_delete=django.db.models.deletion.PROTECT,
+                to="payment.accounttype",
+            ),
         ),
     ]

--- a/src/hope/models/account.py
+++ b/src/hope/models/account.py
@@ -17,19 +17,33 @@ class Account(MergeStatusModel, TimeStampedUUIDModel, SignatureMixin):
         "household.Individual",
         on_delete=models.CASCADE,
         related_name="accounts",
+        help_text="The individual this account belongs to",
     )
     account_type = models.ForeignKey(
         "payment.AccountType",
         on_delete=models.PROTECT,
+        help_text="The type of account (e.g. bank, wallet)",
     )
     financial_institution = models.ForeignKey(
         "payment.FinancialInstitution",
         on_delete=models.PROTECT,
         null=True,
         blank=True,
+        help_text="The financial institution holding this account",
     )
-    number = models.CharField(max_length=256, blank=True, null=True, db_index=True)
-    data = JSONField(default=dict, blank=True, encoder=DjangoJSONEncoder)
+    number = models.CharField(
+        max_length=256,
+        blank=True,
+        null=True,
+        db_index=True,
+        help_text="The account number or wallet identifier",
+    )
+    data = JSONField(
+        default=dict,
+        blank=True,
+        encoder=DjangoJSONEncoder,
+        help_text="Additional account-specific fields",
+    )
     unique_key = models.CharField(max_length=256, blank=True, null=True, editable=False)
     is_unique = models.BooleanField(default=True, db_index=True)
     active = models.BooleanField(default=True, db_index=True)  # False for duplicated/withdrawn individual


### PR DESCRIPTION
## Summary

Adds `help_text` to the `Account` model fields in `src/hope/models/account.py`:

- `individual` - The individual this account belongs to
- `account_type` - The type of account (e.g. bank, wallet)
- `financial_institution` - The financial institution holding this account
- `number` - The account number or wallet identifier
- `data` - Additional account-specific fields

Help text is applied to existing migrations (0006, 0026, 0027, 0034, 0035) instead of creating a new migration. `number`, `individual`, and `account_type` are already readonly in `AccountAdmin`.\n\n## Validation\n\n- `python manage.py makemigrations --check --dry-run` reports no changes\n- `ruff check` passes on all modified files