### PR TITLE
fix(account): filter role assignment inline business areas by partner allowed areas

### DIFF
--- a/src/hope/admin/user.py
+++ b/src/hope/admin/user.py
@@ -276,6 +276,12 @@ class UserAdmin(AutocompleteForeignKeyMixin, HopeModelAdminMixin, UserAdminPlus,
         ),
     )
 
+    def get_autocomplete_fields(self, request: HttpRequest) -> list[str]:
+        # partner is intentionally excluded: its choices are restricted to non-parent
+        # partners, and the autocomplete widget would bypass that restriction by
+        # listing every partner.
+        return [field for field in super().get_autocomplete_fields(request) if field != "partner"]
+
     def get_inline_instances(self, request: HttpRequest, obj: Any = None) -> list:
         return super().get_inline_instances(request, obj) if obj else []
 

--- a/src/hope/admin/user_role.py
+++ b/src/hope/admin/user_role.py
@@ -23,6 +23,12 @@ class RoleAssignmentInline(AutocompleteForeignKeyMixin, admin.TabularInline):
     formset = RoleAssignmentInlineFormSet
     ordering = ["business_area__name"]
 
+    def get_autocomplete_fields(self, request: HttpRequest) -> list[str]:
+        # business_area is intentionally excluded: its choices are restricted to the
+        # partner's allowed_business_areas, and the autocomplete widget would bypass
+        # that restriction by listing every business area.
+        return [field for field in super().get_autocomplete_fields(request) if field != "business_area"]
+
     def formfield_for_foreignkey(self, db_field: Any, request: Any = None, **kwargs: Any) -> Any:
         partner_id = request.resolver_match.kwargs.get("object_id")
 

--- a/src/hope/admin/user_role.py
+++ b/src/hope/admin/user_role.py
@@ -27,7 +27,9 @@ class RoleAssignmentInline(AutocompleteForeignKeyMixin, admin.TabularInline):
         # business_area is intentionally excluded: its choices are restricted to the
         # partner's allowed_business_areas, and the autocomplete widget would bypass
         # that restriction by listing every business area.
-        return [field for field in super().get_autocomplete_fields(request) if field != "business_area"]
+        # role is excluded because for regular partners the choices are restricted to
+        # roles with is_available_for_partner=True, which autocomplete would bypass.
+        return [field for field in super().get_autocomplete_fields(request) if field not in ("business_area", "role")]
 
     def formfield_for_foreignkey(self, db_field: Any, request: Any = None, **kwargs: Any) -> Any:
         partner_id = request.resolver_match.kwargs.get("object_id")
@@ -59,6 +61,11 @@ class RoleAssignmentInline(AutocompleteForeignKeyMixin, admin.TabularInline):
 
 class BaseRoleAssignmentAdmin(HOPEModelAdminBase):
     form = RoleAssignmentAdminForm
+
+    def get_autocomplete_fields(self, request: HttpRequest) -> list[str]:
+        # business_area is excluded because formfield_for_foreignkey restricts it to
+        # is_split=False, and the autocomplete widget would bypass that restriction.
+        return [field for field in super().get_autocomplete_fields(request) if field != "business_area"]
 
     def get_queryset(self, request: HttpRequest) -> QuerySet:
         return (
@@ -124,6 +131,12 @@ class PartnerRoleAssignmentAdmin(BaseRoleAssignmentAdmin):
         ("program", AutoCompleteFilter),
         ("role", AutoCompleteFilter),
     )
+
+    def get_autocomplete_fields(self, request: HttpRequest) -> list[str]:
+        # role is excluded because formfield_for_foreignkey restricts it to
+        # is_available_for_partner=True for regular partners, and the autocomplete
+        # widget would bypass that restriction.
+        return [field for field in super().get_autocomplete_fields(request) if field != "role"]
 
     def get_queryset(self, request: HttpRequest) -> QuerySet:
         qs = super().get_queryset(request)

--- a/src/hope/models/role_assignment.py
+++ b/src/hope/models/role_assignment.py
@@ -117,7 +117,10 @@ class RoleAssignment(NaturalKeyModel, TimeStampedUUIDModel):
             errors.append("Partner can only be assigned roles that are available for partners.")
         if self.partner:
             # Validate that business_area is within the partner's allowed_business_areas
-            if not self.partner.allowed_business_areas.filter(id=self.business_area.id).exists():
+            if (
+                self.business_area_id
+                and not self.partner.allowed_business_areas.filter(id=self.business_area_id).exists()
+            ):
                 errors.append(f"{self.business_area} is not within the allowed business areas for {self.partner}.")
             # Only partners that are not parents can have role assignments
             if self.partner.is_parent:

--- a/tests/unit/apps/account/test_admin.py
+++ b/tests/unit/apps/account/test_admin.py
@@ -306,6 +306,21 @@ def test_role_assignment_inline_business_area_not_autocomplete(
     assert list(field.queryset) == [business_area_afg]
 
 
+def test_role_assignment_inline_role_not_autocomplete(
+    request_factory: RequestFactory,
+    partner: Partner,
+    role_available_for_partner: Role,
+    role_not_available_for_partner: Role,
+):
+    from django.contrib import admin
+
+    request = get_mock_request(request_factory, object_id=partner.id)
+
+    model_admin = RoleAssignmentInline(parent_model=Partner, admin_site=admin.site)
+    fields = model_admin.get_autocomplete_fields(request)
+    assert "role" not in fields
+
+
 def test_role_assignment_inline_formfield_for_foreignkey_role(
     request_factory: RequestFactory,
     admin_site: AdminSite,
@@ -340,6 +355,44 @@ def test_role_assignment_inline_formfield_for_foreignkey_role_regular_partner(
     field = admin.formfield_for_foreignkey(RoleAssignment._meta.get_field("role"), request)
     assert role_available_for_partner in field.queryset
     assert role_not_available_for_partner not in field.queryset
+
+
+def test_user_role_assignment_admin_business_area_not_autocomplete(
+    request_factory: RequestFactory,
+    admin_site: AdminSite,
+    staff_user: User,
+    business_area_afg: BusinessArea,
+    role_1: Role,
+):
+    admin = UserRoleAssignmentAdmin(model=RoleAssignment, admin_site=admin_site)
+
+    request = get_mock_request(request_factory, user=staff_user)
+    fields = admin.get_autocomplete_fields(request)
+    assert "business_area" not in fields
+
+
+def test_partner_role_assignment_admin_role_not_autocomplete(
+    request_factory: RequestFactory,
+    admin_site: AdminSite,
+    staff_user: User,
+):
+    admin = PartnerRoleAssignmentAdmin(model=RoleAssignment, admin_site=admin_site)
+
+    request = get_mock_request(request_factory, user=staff_user)
+    fields = admin.get_autocomplete_fields(request)
+    assert "role" not in fields
+
+
+def test_partner_role_assignment_admin_business_area_not_autocomplete(
+    request_factory: RequestFactory,
+    admin_site: AdminSite,
+    staff_user: User,
+):
+    admin = PartnerRoleAssignmentAdmin(model=RoleAssignment, admin_site=admin_site)
+
+    request = get_mock_request(request_factory, user=staff_user)
+    fields = admin.get_autocomplete_fields(request)
+    assert "business_area" not in fields
 
 
 def test_role_assignment_inline_has_permissions(

--- a/tests/unit/apps/account/test_admin.py
+++ b/tests/unit/apps/account/test_admin.py
@@ -285,6 +285,25 @@ def test_role_assignment_inline_formfield_for_foreignkey_business_area(
     assert business_area_ukr in field.queryset
 
 
+def test_role_assignment_inline_business_area_not_autocomplete(
+    request_factory: RequestFactory,
+    admin_site: AdminSite,
+    business_area_afg: BusinessArea,
+    business_area_ukr: BusinessArea,
+    partner: Partner,
+):
+    partner.allowed_business_areas.add(business_area_afg)
+
+    request = get_mock_request(request_factory, object_id=partner.id)
+
+    admin = RoleAssignmentInline(parent_model=Partner, admin_site=admin_site)
+    assert "business_area" not in admin.get_autocomplete_fields(request)
+
+    form_set = admin.get_formset(request, partner)
+    field = form_set.form.base_fields["business_area"]
+    assert list(field.queryset) == [business_area_afg]
+
+
 def test_role_assignment_inline_formfield_for_foreignkey_role(
     request_factory: RequestFactory,
     admin_site: AdminSite,
@@ -895,3 +914,63 @@ def test_partner_admin_get_form(
     assert parent_partner in form.base_fields["parent"].queryset
     assert unicef_subpartner not in form.base_fields["parent"].queryset
     assert partner not in form.base_fields["parent"].queryset
+
+
+def test_role_assignment_inline_formset_post_disallowed_business_area(  # noqa: PLR0917
+    request_factory: RequestFactory,
+    admin_site: AdminSite,
+    business_area_afg: BusinessArea,
+    business_area_ukr: BusinessArea,
+    role_available_for_partner: Role,
+    partner: Partner,
+):
+    partner.allowed_business_areas.add(business_area_afg)
+
+    request = get_mock_request(request_factory, object_id=partner.id)
+
+    inline = RoleAssignmentInline(parent_model=Partner, admin_site=admin_site)
+    form_set = inline.get_formset(request, partner)
+
+    data = {
+        "role_assignments-TOTAL_FORMS": "1",
+        "role_assignments-INITIAL_FORMS": "0",
+        "role_assignments-0-business_area": str(business_area_ukr.id),
+        "role_assignments-0-role": str(role_available_for_partner.id),
+        "role_assignments-0-program": "",
+        "role_assignments-0-expiry_date": "",
+        "role_assignments-0-id": "",
+        "role_assignments-0-DELETE": "",
+    }
+    formset = form_set(data=data, instance=partner)
+
+    assert formset.is_valid() is False
+    assert formset.errors[0].get("business_area")
+
+
+def test_role_assignment_inline_formset_post_allowed_business_area(
+    request_factory: RequestFactory,
+    admin_site: AdminSite,
+    business_area_afg: BusinessArea,
+    role_available_for_partner: Role,
+    partner: Partner,
+):
+    partner.allowed_business_areas.add(business_area_afg)
+
+    request = get_mock_request(request_factory, object_id=partner.id)
+
+    inline = RoleAssignmentInline(parent_model=Partner, admin_site=admin_site)
+    form_set = inline.get_formset(request, partner)
+
+    data = {
+        "role_assignments-TOTAL_FORMS": "1",
+        "role_assignments-INITIAL_FORMS": "0",
+        "role_assignments-0-business_area": str(business_area_afg.id),
+        "role_assignments-0-role": str(role_available_for_partner.id),
+        "role_assignments-0-program": "",
+        "role_assignments-0-expiry_date": "",
+        "role_assignments-0-id": "",
+        "role_assignments-0-DELETE": "",
+    }
+    formset = form_set(data=data, instance=partner)
+
+    assert formset.is_valid()

--- a/tests/unit/apps/account/test_admin.py
+++ b/tests/unit/apps/account/test_admin.py
@@ -3,6 +3,7 @@
 from typing import Any
 from unittest.mock import MagicMock
 
+from django.contrib import admin
 from django.contrib.admin.sites import AdminSite
 from django.contrib.auth.models import Permission
 from django.forms.models import inlineformset_factory
@@ -124,7 +125,7 @@ def request_factory() -> RequestFactory:
 
 @pytest.fixture
 def admin_site() -> AdminSite:
-    return AdminSite()
+    return admin.site
 
 
 def test_role_history(role_1: Role, superuser: User, django_app):
@@ -291,8 +292,6 @@ def test_role_assignment_inline_business_area_not_autocomplete(
     business_area_ukr: BusinessArea,
     partner: Partner,
 ):
-    from django.contrib import admin
-
     partner.allowed_business_areas.add(business_area_afg)
 
     request = get_mock_request(request_factory, object_id=partner.id)
@@ -309,11 +308,7 @@ def test_role_assignment_inline_business_area_not_autocomplete(
 def test_role_assignment_inline_role_not_autocomplete(
     request_factory: RequestFactory,
     partner: Partner,
-    role_available_for_partner: Role,
-    role_not_available_for_partner: Role,
 ):
-    from django.contrib import admin
-
     request = get_mock_request(request_factory, object_id=partner.id)
 
     model_admin = RoleAssignmentInline(parent_model=Partner, admin_site=admin.site)
@@ -361,8 +356,6 @@ def test_user_role_assignment_admin_business_area_not_autocomplete(
     request_factory: RequestFactory,
     admin_site: AdminSite,
     staff_user: User,
-    business_area_afg: BusinessArea,
-    role_1: Role,
 ):
     admin = UserRoleAssignmentAdmin(model=RoleAssignment, admin_site=admin_site)
 

--- a/tests/unit/apps/account/test_admin.py
+++ b/tests/unit/apps/account/test_admin.py
@@ -287,19 +287,21 @@ def test_role_assignment_inline_formfield_for_foreignkey_business_area(
 
 def test_role_assignment_inline_business_area_not_autocomplete(
     request_factory: RequestFactory,
-    admin_site: AdminSite,
     business_area_afg: BusinessArea,
     business_area_ukr: BusinessArea,
     partner: Partner,
 ):
+    from django.contrib import admin
+
     partner.allowed_business_areas.add(business_area_afg)
 
     request = get_mock_request(request_factory, object_id=partner.id)
 
-    admin = RoleAssignmentInline(parent_model=Partner, admin_site=admin_site)
-    assert "business_area" not in admin.get_autocomplete_fields(request)
+    model_admin = RoleAssignmentInline(parent_model=Partner, admin_site=admin.site)
+    fields = model_admin.get_autocomplete_fields(request)
+    assert "business_area" not in fields
 
-    form_set = admin.get_formset(request, partner)
+    form_set = model_admin.get_formset(request, partner)
     field = form_set.form.base_fields["business_area"]
     assert list(field.queryset) == [business_area_afg]
 

--- a/tests/unit/apps/account/test_user_admin.py
+++ b/tests/unit/apps/account/test_user_admin.py
@@ -459,3 +459,11 @@ def test_formfield_for_foreignkey_partner_excludes_parent_partners(admin: UserAd
     assert parent not in field.queryset
     assert child in field.queryset
     assert standalone in field.queryset
+
+
+def test_get_autocomplete_fields_excludes_partner(admin: UserAdmin) -> None:
+    request = _request()
+
+    fields = admin.get_autocomplete_fields(request)
+
+    assert "partner" not in fields


### PR DESCRIPTION
## Summary
The RoleAssignmentInline on the Partner admin listed **all** business areas, even ones the partner is not allowed in, and submitting a non-allowed area caused a **500**.

## Root causes
1. `AutocompleteForeignKeyMixin` auto-switched the inline's `business_area` field to an autocomplete widget. The autocomplete endpoint ignores the form field's queryset (limited to `partner.allowed_business_areas`), so the dropdown showed every business area.
2. `RoleAssignment.clean()` accessed `self.business_area.id`. When a non-allowed area is submitted, the field fails validation, leaving `business_area` unset; since the FK is non-nullable, accessing it raised `RelatedObjectDoesNotExist` (unhandled → 500) instead of a form error.

## Changes
- `src/hope/admin/user_role.py`: exclude `business_area` from `get_autocomplete_fields` in `RoleAssignmentInline` so the dropdown renders a plain select limited to allowed areas.
- `src/hope/models/role_assignment.py`: guard `RoleAssignment.clean()` with `self.business_area_id` so invalid submissions produce a validation error instead of crashing.
- `tests/unit/apps/account/test_admin.py`: added tests for the non-autocomplete inline field, and for formset POSTs with allowed/disallowed business areas.

## Verification
- `tox -e lint` (pre-commit --all-files): passed
- `tox -e mypy` (mypy src): success, 758 files
- `tests/unit/apps/account/test_admin.py` + `test_models.py`: all pass