### PR TITLE
[AB#320656]-Fix Payments table column sorting

### DIFF
--- a/src/frontend/src/containers/tables/paymentmodule/PaymentsTable/PaymentsTableHeadCells.tsx
+++ b/src/frontend/src/containers/tables/paymentmodule/PaymentsTable/PaymentsTableHeadCells.tsx
@@ -76,7 +76,7 @@ export const headCells: HeadCell<PaymentList>[] = [
   {
     disablePadding: false,
     label: 'Reconciliation',
-    id: 'mark',
+    id: 'reconciliation_rank',
     numeric: false,
   },
 ];
@@ -150,7 +150,7 @@ export const headCellsPeople: HeadCell<PaymentList>[] = [
   {
     disablePadding: false,
     label: 'Reconciliation',
-    id: 'mark',
+    id: 'reconciliation_rank',
     numeric: false,
   },
 ];

--- a/src/frontend/src/containers/tables/paymentmodule/PaymentsTable/PaymentsTableHeadCells.tsx
+++ b/src/frontend/src/containers/tables/paymentmodule/PaymentsTable/PaymentsTableHeadCells.tsx
@@ -39,6 +39,7 @@ export const headCells: HeadCell<PaymentList>[] = [
     label: 'Collector',
     id: 'collector_id',
     numeric: false,
+    disableSort: true,
   },
   {
     disablePadding: false,

--- a/src/hope/apps/payment/api/filters.py
+++ b/src/hope/apps/payment/api/filters.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from django.db.models import Q, QuerySet
+from django.db.models import Case, IntegerField, Q, QuerySet, Value, When
 import django_filters
 from django_filters import FilterSet, OrderingFilter
 
@@ -297,9 +297,31 @@ class PaymentSearchFilter(FilterSet):
             ("household__size", "household__size"),
             ("collector__full_name", "collector__full_name"),
             ("created_at", "created_at"),
+            ("household__admin2__name", "household__admin2__name"),
+            ("collector_id", "collector_id"),
+            ("financial_service_provider__name", "financial_service_provider__name"),
+            ("entitlement_quantity_usd", "entitlement_quantity_usd"),
+            ("delivered_quantity", "delivered_quantity"),
+            ("fsp_auth_code", "fsp_auth_code"),
+            ("mark", "mark"),
         )
     )
 
     class Meta:
         model = Payment
         fields = []
+
+    def filter_queryset(self, queryset: QuerySet) -> "QuerySet[Payment]":
+        queryset = queryset.annotate(
+            mark=Case(
+                When(status=Payment.STATUS_DISTRIBUTION_SUCCESS, then=Value(1)),
+                When(status=Payment.STATUS_DISTRIBUTION_PARTIAL, then=Value(2)),
+                When(status=Payment.STATUS_NOT_DISTRIBUTED, then=Value(3)),
+                When(status=Payment.STATUS_ERROR, then=Value(4)),
+                When(status=Payment.STATUS_FORCE_FAILED, then=Value(5)),
+                When(status=Payment.STATUS_MANUALLY_CANCELLED, then=Value(6)),
+                When(status=Payment.STATUS_PENDING, then=Value(7)),
+                output_field=IntegerField(),
+            )
+        )
+        return super().filter_queryset(queryset)

--- a/src/hope/apps/payment/api/filters.py
+++ b/src/hope/apps/payment/api/filters.py
@@ -324,8 +324,6 @@ class PaymentSearchFilter(FilterSet):
         fields = []
 
     def filter_queryset(self, queryset: QuerySet) -> "QuerySet[Payment]":
-        # Every status must map to a value: an uncovered status would fall through to NULL,
-        # which Postgres sorts arbitrarily among itself and lumps at one end of the page.
         queryset = queryset.annotate(
             reconciliation_rank=Case(
                 # PARTIAL is also in DELIVERED_STATUSES, so it has to be matched first.

--- a/src/hope/apps/payment/api/filters.py
+++ b/src/hope/apps/payment/api/filters.py
@@ -271,6 +271,19 @@ class PaymentVerificationRecordFilter(FilterSet):
         return qs.filter(unicef_id__istartswith=value)
 
 
+class StableOrderingFilter(OrderingFilter):
+    """OrderingFilter that always appends a unique tie-breaker.
+
+    `order_by()` replaces the model's `Meta.ordering`, so rows tied on the requested column have
+    no defined relative order. With LIMIT/OFFSET pagination that lets a row appear on two pages
+    or on none, because each page is a separate query and Postgres may re-plan it.
+    """
+
+    def filter(self, qs: QuerySet, value: Any) -> QuerySet:
+        ordering = [self.get_ordering_value(param) for param in value] if value else ["-created_at"]
+        return qs.order_by(*ordering, "pk")
+
+
 class PaymentSearchFilter(FilterSet):
     collector_full_name = django_filters.CharFilter(
         field_name="collector__full_name",
@@ -290,7 +303,7 @@ class PaymentSearchFilter(FilterSet):
     )
     collector_id = django_filters.CharFilter(field_name="collector_id")
 
-    ordering = OrderingFilter(
+    ordering = StableOrderingFilter(
         fields=(
             ("unicef_id", "unicef_id"),
             ("household__unicef_id", "household__unicef_id"),
@@ -298,12 +311,11 @@ class PaymentSearchFilter(FilterSet):
             ("collector__full_name", "collector__full_name"),
             ("created_at", "created_at"),
             ("household__admin2__name", "household__admin2__name"),
-            ("collector_id", "collector_id"),
             ("financial_service_provider__name", "financial_service_provider__name"),
             ("entitlement_quantity_usd", "entitlement_quantity_usd"),
             ("delivered_quantity", "delivered_quantity"),
             ("fsp_auth_code", "fsp_auth_code"),
-            ("mark", "mark"),
+            ("reconciliation_rank", "reconciliation_rank"),
         )
     )
 
@@ -312,15 +324,19 @@ class PaymentSearchFilter(FilterSet):
         fields = []
 
     def filter_queryset(self, queryset: QuerySet) -> "QuerySet[Payment]":
+        # Every status must map to a value: an uncovered status would fall through to NULL,
+        # which Postgres sorts arbitrarily among itself and lumps at one end of the page.
         queryset = queryset.annotate(
-            mark=Case(
-                When(status=Payment.STATUS_DISTRIBUTION_SUCCESS, then=Value(1)),
+            reconciliation_rank=Case(
+                # PARTIAL is also in DELIVERED_STATUSES, so it has to be matched first.
                 When(status=Payment.STATUS_DISTRIBUTION_PARTIAL, then=Value(2)),
+                When(status__in=Payment.DELIVERED_STATUSES, then=Value(1)),
                 When(status=Payment.STATUS_NOT_DISTRIBUTED, then=Value(3)),
                 When(status=Payment.STATUS_ERROR, then=Value(4)),
                 When(status=Payment.STATUS_FORCE_FAILED, then=Value(5)),
                 When(status=Payment.STATUS_MANUALLY_CANCELLED, then=Value(6)),
-                When(status=Payment.STATUS_PENDING, then=Value(7)),
+                When(status__in=Payment.PENDING_STATUSES, then=Value(7)),
+                default=Value(99),
                 output_field=IntegerField(),
             )
         )

--- a/tests/unit/apps/payment/test_payment_list_ordering.py
+++ b/tests/unit/apps/payment/test_payment_list_ordering.py
@@ -145,11 +145,3 @@ def test_payment_search_filter_breaks_ties_deterministically_without_ordering() 
     result = PaymentSearchFilter(data={}, queryset=Payment.objects.all()).qs
 
     assert list(result.values_list("pk", flat=True)) == sorted(payment.pk for payment in payments)
-
-
-def test_payment_search_filter_rejects_collector_id_ordering() -> None:
-    """The Collector column shows a snapshot name, so its UUID is not a meaningful sort key."""
-    filterset = PaymentSearchFilter(data={"ordering": "collector_id"}, queryset=Payment.objects.all())
-
-    assert not filterset.is_valid()
-    assert "ordering" in filterset.errors

--- a/tests/unit/apps/payment/test_payment_list_ordering.py
+++ b/tests/unit/apps/payment/test_payment_list_ordering.py
@@ -3,7 +3,12 @@ from datetime import timedelta
 from django.utils import timezone
 import pytest
 
-from extras.test_utils.factories import PaymentFactory, PaymentPlanFactory
+from extras.test_utils.factories import (
+    AreaFactory,
+    FinancialServiceProviderFactory,
+    PaymentFactory,
+    PaymentPlanFactory,
+)
 from hope.apps.payment.api.filters import PaymentSearchFilter
 from hope.models import Payment
 
@@ -41,3 +46,83 @@ def test_payment_search_filter_orders_by_created_at_descending(
     result = PaymentSearchFilter(data={"ordering": "-created_at"}, queryset=Payment.objects.all()).qs
 
     assert list(result.values_list("pk", flat=True)) == [newest.pk, middle.pk, oldest.pk]
+
+
+def test_payment_search_filter_orders_by_admin2_name() -> None:
+    plan = PaymentPlanFactory()
+    payment_b = PaymentFactory(parent=plan, household__admin2=AreaFactory(name="B District"))
+    payment_a = PaymentFactory(parent=plan, household__admin2=AreaFactory(name="A District"))
+
+    result = PaymentSearchFilter(data={"ordering": "household__admin2__name"}, queryset=Payment.objects.all()).qs
+
+    assert list(result.values_list("pk", flat=True)) == [payment_a.pk, payment_b.pk]
+
+
+def test_payment_search_filter_orders_by_collector_id() -> None:
+    plan = PaymentPlanFactory()
+    payment1 = PaymentFactory(parent=plan)
+    payment2 = PaymentFactory(parent=plan)
+    expected = sorted([payment1, payment2], key=lambda p: str(p.collector_id))
+
+    result = PaymentSearchFilter(data={"ordering": "collector_id"}, queryset=Payment.objects.all()).qs
+
+    assert list(result.values_list("pk", flat=True)) == [p.pk for p in expected]
+
+
+def test_payment_search_filter_orders_by_fsp_name() -> None:
+    plan = PaymentPlanFactory()
+    payment_b = PaymentFactory(parent=plan, financial_service_provider=FinancialServiceProviderFactory(name="B FSP"))
+    payment_a = PaymentFactory(parent=plan, financial_service_provider=FinancialServiceProviderFactory(name="A FSP"))
+
+    result = PaymentSearchFilter(
+        data={"ordering": "financial_service_provider__name"}, queryset=Payment.objects.all()
+    ).qs
+
+    assert list(result.values_list("pk", flat=True)) == [payment_a.pk, payment_b.pk]
+
+
+def test_payment_search_filter_orders_by_entitlement_quantity_usd() -> None:
+    plan = PaymentPlanFactory()
+    high = PaymentFactory(parent=plan, entitlement_quantity_usd=100)
+    low = PaymentFactory(parent=plan, entitlement_quantity_usd=10)
+
+    result = PaymentSearchFilter(data={"ordering": "entitlement_quantity_usd"}, queryset=Payment.objects.all()).qs
+
+    assert list(result.values_list("pk", flat=True)) == [low.pk, high.pk]
+
+
+def test_payment_search_filter_orders_by_delivered_quantity() -> None:
+    plan = PaymentPlanFactory()
+    high = PaymentFactory(parent=plan, delivered_quantity=100)
+    low = PaymentFactory(parent=plan, delivered_quantity=10)
+
+    result = PaymentSearchFilter(data={"ordering": "delivered_quantity"}, queryset=Payment.objects.all()).qs
+
+    assert list(result.values_list("pk", flat=True)) == [low.pk, high.pk]
+
+
+def test_payment_search_filter_orders_by_fsp_auth_code() -> None:
+    plan = PaymentPlanFactory()
+    payment_b = PaymentFactory(parent=plan, fsp_auth_code="B-CODE")
+    payment_a = PaymentFactory(parent=plan, fsp_auth_code="A-CODE")
+
+    result = PaymentSearchFilter(data={"ordering": "fsp_auth_code"}, queryset=Payment.objects.all()).qs
+
+    assert list(result.values_list("pk", flat=True)) == [payment_a.pk, payment_b.pk]
+
+
+def test_payment_search_filter_orders_by_mark() -> None:
+    plan = PaymentPlanFactory()
+    success = PaymentFactory(parent=plan, status=Payment.STATUS_DISTRIBUTION_SUCCESS)
+    partial = PaymentFactory(parent=plan, status=Payment.STATUS_DISTRIBUTION_PARTIAL)
+    not_distributed = PaymentFactory(parent=plan, status=Payment.STATUS_NOT_DISTRIBUTED)
+    pending = PaymentFactory(parent=plan, status=Payment.STATUS_PENDING)
+
+    result = PaymentSearchFilter(data={"ordering": "mark"}, queryset=Payment.objects.all()).qs
+
+    assert list(result.values_list("pk", flat=True)) == [
+        success.pk,
+        partial.pk,
+        not_distributed.pk,
+        pending.pk,
+    ]

--- a/tests/unit/apps/payment/test_payment_list_ordering.py
+++ b/tests/unit/apps/payment/test_payment_list_ordering.py
@@ -48,70 +48,108 @@ def test_payment_search_filter_orders_by_created_at_descending(
     assert list(result.values_list("pk", flat=True)) == [newest.pk, middle.pk, oldest.pk]
 
 
-def test_payment_search_filter_orders_by_admin2_name() -> None:
+@pytest.mark.parametrize(
+    ("ordering", "first_kwargs", "second_kwargs"),
+    [
+        pytest.param(
+            "household__admin2__name",
+            lambda: {"household__admin2": AreaFactory(name="A District")},
+            lambda: {"household__admin2": AreaFactory(name="B District")},
+            id="admin2_name",
+        ),
+        pytest.param(
+            "financial_service_provider__name",
+            lambda: {"financial_service_provider": FinancialServiceProviderFactory(name="A FSP")},
+            lambda: {"financial_service_provider": FinancialServiceProviderFactory(name="B FSP")},
+            id="fsp_name",
+        ),
+        pytest.param(
+            "entitlement_quantity_usd",
+            lambda: {"entitlement_quantity_usd": 10},
+            lambda: {"entitlement_quantity_usd": 100},
+            id="entitlement_quantity_usd",
+        ),
+        pytest.param(
+            "delivered_quantity",
+            lambda: {"delivered_quantity": 10},
+            lambda: {"delivered_quantity": 100},
+            id="delivered_quantity",
+        ),
+        pytest.param(
+            "fsp_auth_code",
+            lambda: {"fsp_auth_code": "A-CODE"},
+            lambda: {"fsp_auth_code": "B-CODE"},
+            id="fsp_auth_code",
+        ),
+    ],
+)
+def test_payment_search_filter_orders_by_column(ordering: str, first_kwargs, second_kwargs) -> None:
     plan = PaymentPlanFactory()
-    payment_b = PaymentFactory(parent=plan, household__admin2=AreaFactory(name="B District"))
-    payment_a = PaymentFactory(parent=plan, household__admin2=AreaFactory(name="A District"))
+    # Created in reverse so the assertion cannot pass on insertion order alone.
+    second = PaymentFactory(parent=plan, **second_kwargs())
+    first = PaymentFactory(parent=plan, **first_kwargs())
 
-    result = PaymentSearchFilter(data={"ordering": "household__admin2__name"}, queryset=Payment.objects.all()).qs
+    result = PaymentSearchFilter(data={"ordering": ordering}, queryset=Payment.objects.all()).qs
 
-    assert list(result.values_list("pk", flat=True)) == [payment_a.pk, payment_b.pk]
+    assert list(result.values_list("pk", flat=True)) == [first.pk, second.pk]
 
 
-def test_payment_search_filter_orders_by_fsp_name() -> None:
+def test_payment_search_filter_orders_by_reconciliation_rank() -> None:
+    """Statuses outside the reconciled/failed set must sort with their peers, not in a NULL clump."""
     plan = PaymentPlanFactory()
-    payment_b = PaymentFactory(parent=plan, financial_service_provider=FinancialServiceProviderFactory(name="B FSP"))
-    payment_a = PaymentFactory(parent=plan, financial_service_provider=FinancialServiceProviderFactory(name="A FSP"))
-
-    result = PaymentSearchFilter(
-        data={"ordering": "financial_service_provider__name"}, queryset=Payment.objects.all()
-    ).qs
-
-    assert list(result.values_list("pk", flat=True)) == [payment_a.pk, payment_b.pk]
-
-
-def test_payment_search_filter_orders_by_entitlement_quantity_usd() -> None:
-    plan = PaymentPlanFactory()
-    high = PaymentFactory(parent=plan, entitlement_quantity_usd=100)
-    low = PaymentFactory(parent=plan, entitlement_quantity_usd=10)
-
-    result = PaymentSearchFilter(data={"ordering": "entitlement_quantity_usd"}, queryset=Payment.objects.all()).qs
-
-    assert list(result.values_list("pk", flat=True)) == [low.pk, high.pk]
-
-
-def test_payment_search_filter_orders_by_delivered_quantity() -> None:
-    plan = PaymentPlanFactory()
-    high = PaymentFactory(parent=plan, delivered_quantity=100)
-    low = PaymentFactory(parent=plan, delivered_quantity=10)
-
-    result = PaymentSearchFilter(data={"ordering": "delivered_quantity"}, queryset=Payment.objects.all()).qs
-
-    assert list(result.values_list("pk", flat=True)) == [low.pk, high.pk]
-
-
-def test_payment_search_filter_orders_by_fsp_auth_code() -> None:
-    plan = PaymentPlanFactory()
-    payment_b = PaymentFactory(parent=plan, fsp_auth_code="B-CODE")
-    payment_a = PaymentFactory(parent=plan, fsp_auth_code="A-CODE")
-
-    result = PaymentSearchFilter(data={"ordering": "fsp_auth_code"}, queryset=Payment.objects.all()).qs
-
-    assert list(result.values_list("pk", flat=True)) == [payment_a.pk, payment_b.pk]
-
-
-def test_payment_search_filter_orders_by_mark() -> None:
-    plan = PaymentPlanFactory()
-    success = PaymentFactory(parent=plan, status=Payment.STATUS_DISTRIBUTION_SUCCESS)
-    partial = PaymentFactory(parent=plan, status=Payment.STATUS_DISTRIBUTION_PARTIAL)
+    sent_to_fsp = PaymentFactory(parent=plan, status=Payment.STATUS_SENT_TO_FSP)
     not_distributed = PaymentFactory(parent=plan, status=Payment.STATUS_NOT_DISTRIBUTED)
-    pending = PaymentFactory(parent=plan, status=Payment.STATUS_PENDING)
+    transaction_successful = PaymentFactory(parent=plan, status=Payment.STATUS_SUCCESS)
+    partially_distributed = PaymentFactory(parent=plan, status=Payment.STATUS_DISTRIBUTION_PARTIAL)
 
-    result = PaymentSearchFilter(data={"ordering": "mark"}, queryset=Payment.objects.all()).qs
+    result = PaymentSearchFilter(data={"ordering": "reconciliation_rank"}, queryset=Payment.objects.all()).qs
 
     assert list(result.values_list("pk", flat=True)) == [
-        success.pk,
-        partial.pk,
+        transaction_successful.pk,
+        partially_distributed.pk,
         not_distributed.pk,
-        pending.pk,
+        sent_to_fsp.pk,
     ]
+
+
+def test_payment_search_filter_ranks_every_payment_status() -> None:
+    """No status may fall through the Case: NULL sorts arbitrarily, and 99 is the unranked sentinel."""
+    plan = PaymentPlanFactory()
+    for status, _label in Payment.STATUS_CHOICE:
+        payment = PaymentFactory(parent=plan)
+        Payment.objects.filter(pk=payment.pk).update(status=status)
+
+    result = PaymentSearchFilter(data={"ordering": "reconciliation_rank"}, queryset=Payment.objects.all()).qs
+
+    assert result.count() == len(Payment.STATUS_CHOICE)
+    assert not result.filter(reconciliation_rank__isnull=True).exists()
+    assert not result.filter(reconciliation_rank=99).exists()
+
+
+def test_payment_search_filter_breaks_ties_deterministically() -> None:
+    """Ties need a unique tie-breaker, otherwise LIMIT/OFFSET paging can repeat or skip a row."""
+    plan = PaymentPlanFactory()
+    payments = [PaymentFactory(parent=plan, status=Payment.STATUS_PENDING) for _ in range(5)]
+
+    result = PaymentSearchFilter(data={"ordering": "reconciliation_rank"}, queryset=Payment.objects.all()).qs
+
+    assert list(result.values_list("pk", flat=True)) == sorted(payment.pk for payment in payments)
+
+
+def test_payment_search_filter_breaks_ties_deterministically_without_ordering() -> None:
+    plan = PaymentPlanFactory()
+    now = timezone.now()
+    payments = [PaymentFactory(parent=plan) for _ in range(5)]
+    Payment.objects.filter(pk__in=[payment.pk for payment in payments]).update(created_at=now)
+
+    result = PaymentSearchFilter(data={}, queryset=Payment.objects.all()).qs
+
+    assert list(result.values_list("pk", flat=True)) == sorted(payment.pk for payment in payments)
+
+
+def test_payment_search_filter_rejects_collector_id_ordering() -> None:
+    """The Collector column shows a snapshot name, so its UUID is not a meaningful sort key."""
+    filterset = PaymentSearchFilter(data={"ordering": "collector_id"}, queryset=Payment.objects.all())
+
+    assert not filterset.is_valid()
+    assert "ordering" in filterset.errors

--- a/tests/unit/apps/payment/test_payment_list_ordering.py
+++ b/tests/unit/apps/payment/test_payment_list_ordering.py
@@ -58,17 +58,6 @@ def test_payment_search_filter_orders_by_admin2_name() -> None:
     assert list(result.values_list("pk", flat=True)) == [payment_a.pk, payment_b.pk]
 
 
-def test_payment_search_filter_orders_by_collector_id() -> None:
-    plan = PaymentPlanFactory()
-    payment1 = PaymentFactory(parent=plan)
-    payment2 = PaymentFactory(parent=plan)
-    expected = sorted([payment1, payment2], key=lambda p: str(p.collector_id))
-
-    result = PaymentSearchFilter(data={"ordering": "collector_id"}, queryset=Payment.objects.all()).qs
-
-    assert list(result.values_list("pk", flat=True)) == [p.pk for p in expected]
-
-
 def test_payment_search_filter_orders_by_fsp_name() -> None:
     plan = PaymentPlanFactory()
     payment_b = PaymentFactory(parent=plan, financial_service_provider=FinancialServiceProviderFactory(name="B FSP"))


### PR DESCRIPTION
[AB#320656](https://unicef.visualstudio.com/ICTD-HCT-MIS/_workitems/edit/320656)

## Summary
Sorting didn't work for several columns in the Payments table (Administrative Level 2, Collector, FSP, Entitlement, Delivered Quantity, FSP Auth Code, Reconciliation). This fixes it on the backend so those columns can be sorted, except Collector, which is now not sortable since the displayed value can't be sorted properly.