### PR TITLE
Truthful KAB title and tooltip when programme does not collect individual data

### DIFF
--- a/src/frontend/src/containers/tables/population/HouseholdCompositionTable/HouseholdCompositionTable.tsx
+++ b/src/frontend/src/containers/tables/population/HouseholdCompositionTable/HouseholdCompositionTable.tsx
@@ -43,15 +43,18 @@ export function HouseholdCompositionTable({
   const { t } = useTranslation();
   const { selectedProgram } = useProgramContext();
   const beneficiaryGroup = selectedProgram?.beneficiaryGroup;
-  // Deviation from AB#336514: when the programme does not collect individual
-  // data, KAB values can only be a copy of the declared composition (or NULL),
-  // so the ticket's verbatim title/tooltip would be untrue - see _recalculate_kab.
-  const collectsIndividualData =
-    selectedProgram?.dataCollectingType?.collectsIndividualData;
-  const title = collectsIndividualData
+  // Deviation from AB#336514: KAB values can derive from individual records
+  // only when the programme collects individual data or recalculates the
+  // composition from individuals; otherwise they are a copy of the declared
+  // composition (or NULL) and the ticket's verbatim title/tooltip would be
+  // untrue - see _recalculate_kab / recalculate_data.
+  const kabFromIndividuals =
+    selectedProgram?.dataCollectingType?.collectsIndividualData ||
+    selectedProgram?.dataCollectingType?.recalculateComposition;
+  const title = kabFromIndividuals
     ? t('Known Affected Beneficiaries')
     : `${beneficiaryGroup?.groupLabel} Composition`;
-  const tooltip = collectsIndividualData
+  const tooltip = kabFromIndividuals
     ? t(
         'Figures represent known affected beneficiaries counted from individual records, not declared household size.',
       )

--- a/src/frontend/src/containers/tables/population/HouseholdCompositionTable/HouseholdCompositionTable.tsx
+++ b/src/frontend/src/containers/tables/population/HouseholdCompositionTable/HouseholdCompositionTable.tsx
@@ -16,6 +16,7 @@ import {
 import { HouseholdDetail } from '@restgenerated/models/HouseholdDetail';
 import { ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useProgramContext } from 'src/programContext';
 import styled from 'styled-components';
 
 const GreyTableCell = styled(TableCell)`
@@ -40,6 +41,23 @@ export function HouseholdCompositionTable({
   household,
 }: HouseholdCompositionTableProps): ReactElement {
   const { t } = useTranslation();
+  const { selectedProgram } = useProgramContext();
+  const beneficiaryGroup = selectedProgram?.beneficiaryGroup;
+  // Deviation from AB#336514: when the programme does not collect individual
+  // data, KAB values can only be a copy of the declared composition (or NULL),
+  // so the ticket's verbatim title/tooltip would be untrue - see _recalculate_kab.
+  const collectsIndividualData =
+    selectedProgram?.dataCollectingType?.collectsIndividualData;
+  const title = collectsIndividualData
+    ? t('Known Affected Beneficiaries')
+    : `${beneficiaryGroup?.groupLabel} Composition`;
+  const tooltip = collectsIndividualData
+    ? t(
+        'Figures represent known affected beneficiaries counted from individual records, not declared household size.',
+      )
+    : t(
+        'Figures represent the declared composition reported during registration. This programme does not collect individual records.',
+      );
   const rows: {
     ageGroup: string;
     female: Count;
@@ -104,19 +122,9 @@ export function HouseholdCompositionTable({
     <OverviewPaper data-cy="known-affected-beneficiaries">
       <Title>
         <Box sx={{ display: 'flex', alignItems: 'center' }}>
-          <Typography variant="h6">
-            {t('Known Affected Beneficiaries')}
-          </Typography>
-          <Tooltip
-            title={t(
-              'Figures represent known affected beneficiaries counted from individual records, not declared household size.',
-            )}
-          >
-            <IconButton
-              color="primary"
-              aria-label={t('Known Affected Beneficiaries')}
-              data-cy="kab-info"
-            >
+          <Typography variant="h6">{title}</Typography>
+          <Tooltip title={tooltip}>
+            <IconButton color="primary" aria-label={title} data-cy="kab-info">
               <Info />
             </IconButton>
           </Tooltip>

--- a/src/frontend/src/utils/en.json
+++ b/src/frontend/src/utils/en.json
@@ -556,6 +556,7 @@
   "Household Composition": "Household Composition",
   "Known Affected Beneficiaries": "Known Affected Beneficiaries",
   "Figures represent known affected beneficiaries counted from individual records, not declared household size.": "Figures represent known affected beneficiaries counted from individual records, not declared household size.",
+  "Figures represent the declared composition reported during registration. This programme does not collect individual records.": "Figures represent the declared composition reported during registration. This programme does not collect individual records.",
   "Age Group": "Age Group",
   "Females": "Females",
   "with disability": "with disability",

--- a/src/hope/apps/core/api/serializers.py
+++ b/src/hope/apps/core/api/serializers.py
@@ -46,6 +46,7 @@ class DataCollectingTypeSerializer(serializers.ModelSerializer):
             "individual_filters_available",
             "household_filters_available",
             "collects_individual_data",
+            "recalculate_composition",
         )
 
 

--- a/src/hope/apps/core/api/serializers.py
+++ b/src/hope/apps/core/api/serializers.py
@@ -45,6 +45,7 @@ class DataCollectingTypeSerializer(serializers.ModelSerializer):
             "type_display",
             "individual_filters_available",
             "household_filters_available",
+            "collects_individual_data",
         )
 
 

--- a/tests/e2e/programme_population/test_e2e_households.py
+++ b/tests/e2e/programme_population/test_e2e_households.py
@@ -19,7 +19,7 @@ pytestmark = pytest.mark.django_db()
 
 @pytest.fixture
 def create_programs(business_area) -> None:
-    dct = DataCollectingTypeFactory(type=DataCollectingType.Type.STANDARD)
+    dct = DataCollectingTypeFactory(type=DataCollectingType.Type.STANDARD, collects_individual_data=True)
     beneficiary_group = BeneficiaryGroup.objects.filter(name="Main Menu").first()
     return ProgramFactory(
         name="Test Programm",

--- a/tests/unit/api_contract/_api_checker/test_programs/_api_rest_business-areas_business-area-0_programs_/get/dc937b59892604f5a86ac96936cd7ff09e25f18ae6b758e8014a24c7fa039e91.response.json
+++ b/tests/unit/api_contract/_api_checker/test_programs/_api_rest_business-areas_business-area-0_programs_/get/dc937b59892604f5a86ac96936cd7ff09e25f18ae6b758e8014a24c7fa039e91.response.json
@@ -35,7 +35,8 @@
                     "type_display": "Standard",
                     "individual_filters_available": false,
                     "household_filters_available": true,
-                    "collects_individual_data": false
+                    "collects_individual_data": false,
+                    "recalculate_composition": false
                 },
                 "beneficiary_group": {
                     "id": "bf5d7dcc-8cee-400b-9398-330497bc5bec",

--- a/tests/unit/api_contract/_api_checker/test_programs/_api_rest_business-areas_business-area-0_programs_/get/dc937b59892604f5a86ac96936cd7ff09e25f18ae6b758e8014a24c7fa039e91.response.json
+++ b/tests/unit/api_contract/_api_checker/test_programs/_api_rest_business-areas_business-area-0_programs_/get/dc937b59892604f5a86ac96936cd7ff09e25f18ae6b758e8014a24c7fa039e91.response.json
@@ -34,7 +34,8 @@
                     "type": "STANDARD",
                     "type_display": "Standard",
                     "individual_filters_available": false,
-                    "household_filters_available": true
+                    "household_filters_available": true,
+                    "collects_individual_data": false
                 },
                 "beneficiary_group": {
                     "id": "bf5d7dcc-8cee-400b-9398-330497bc5bec",

--- a/tests/unit/api_contract/_api_checker/test_programs/_api_rest_business-areas_business-area-0_programs_yz3c_/get/dc937b59892604f5a86ac96936cd7ff09e25f18ae6b758e8014a24c7fa039e91.response.json
+++ b/tests/unit/api_contract/_api_checker/test_programs/_api_rest_business-areas_business-area-0_programs_yz3c_/get/dc937b59892604f5a86ac96936cd7ff09e25f18ae6b758e8014a24c7fa039e91.response.json
@@ -28,7 +28,8 @@
             "type": "STANDARD",
             "type_display": "Standard",
             "individual_filters_available": false,
-            "household_filters_available": true
+            "household_filters_available": true,
+            "collects_individual_data": false
         },
         "beneficiary_group": {
             "id": "bf5d7dcc-8cee-400b-9398-330497bc5bec",

--- a/tests/unit/api_contract/_api_checker/test_programs/_api_rest_business-areas_business-area-0_programs_yz3c_/get/dc937b59892604f5a86ac96936cd7ff09e25f18ae6b758e8014a24c7fa039e91.response.json
+++ b/tests/unit/api_contract/_api_checker/test_programs/_api_rest_business-areas_business-area-0_programs_yz3c_/get/dc937b59892604f5a86ac96936cd7ff09e25f18ae6b758e8014a24c7fa039e91.response.json
@@ -29,7 +29,8 @@
             "type_display": "Standard",
             "individual_filters_available": false,
             "household_filters_available": true,
-            "collects_individual_data": false
+            "collects_individual_data": false,
+            "recalculate_composition": false
         },
         "beneficiary_group": {
             "id": "bf5d7dcc-8cee-400b-9398-330497bc5bec",

--- a/tests/unit/apps/program/test_views_program_detail.py
+++ b/tests/unit/apps/program/test_views_program_detail.py
@@ -311,6 +311,7 @@ def test_program_detail(
         "type_display": program.data_collecting_type.get_type_display(),
         "household_filters_available": program.data_collecting_type.household_filters_available,
         "individual_filters_available": program.data_collecting_type.individual_filters_available,
+        "collects_individual_data": program.data_collecting_type.collects_individual_data,
     }
     assert response_data["beneficiary_group"] == {
         "id": str(program.beneficiary_group.id),

--- a/tests/unit/apps/program/test_views_program_detail.py
+++ b/tests/unit/apps/program/test_views_program_detail.py
@@ -312,6 +312,7 @@ def test_program_detail(
         "household_filters_available": program.data_collecting_type.household_filters_available,
         "individual_filters_available": program.data_collecting_type.individual_filters_available,
         "collects_individual_data": program.data_collecting_type.collects_individual_data,
+        "recalculate_composition": program.data_collecting_type.recalculate_composition,
     }
     assert response_data["beneficiary_group"] == {
         "id": str(program.beneficiary_group.id),


### PR DESCRIPTION
[AB#336514](https://unicef.visualstudio.com/4e044e8d-bc28-4768-8074-f80ff6e4a0e5/_workitems/edit/336514)

**Intentional deviation from the ticket** — follows the backend logic instead of the ticket's verbatim copy. Stacked on #6319.

The ticket's tooltip says figures are *"counted from individual records"*. Per `recalculate_data`/`_recalculate_kab`, KAB can derive from individual records only when the DCT has `collects_individual_data` on (counted when no declaration) or `recalculate_composition` on (declaration itself overwritten from individuals). With both off, KAB is only ever a copy of the declared composition (or NULL) — the ticket's title and tooltip would be untrue for such programmes.

- `DataCollectingTypeSerializer` now exposes `collects_individual_data` and `recalculate_composition`
- `HouseholdCompositionTable`:
  - either flag on → title **Known Affected Beneficiaries** + ticket's verbatim tooltip (unchanged)
  - both off → title **{Group} Composition** + tooltip *"Figures represent the declared composition reported during registration. This programme does not collect individual records."*
- e2e fixture sets `collects_individual_data=True` so the KAB variant stays covered
