### PR TITLE
Scope the program whose field attributes are read, per action

### DIFF
--- a/src/hope/apps/core/api/mixins.py
+++ b/src/hope/apps/core/api/mixins.py
@@ -204,7 +204,7 @@ class BusinessAreaProgramsAccessMixin(BusinessAreaMixin):
 
         program_ids = self.request.user.get_program_ids_for_permissions_in_business_area(
             self.business_area.id,
-            self.PERMISSIONS,
+            self.get_permissions_for_action(),
         )
 
         if self.program_model_field_is_many:

--- a/src/hope/apps/core/api/views.py
+++ b/src/hope/apps/core/api/views.py
@@ -6,6 +6,7 @@ from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework.decorators import action
 from rest_framework.filters import OrderingFilter
+from rest_framework.generics import get_object_or_404
 from rest_framework.mixins import ListModelMixin, RetrieveModelMixin
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
@@ -44,6 +45,7 @@ from hope.models import (
     PaymentVerification,
     PaymentVerificationPlan,
     PaymentVerificationSummary,
+    Program,
     RoleAssignment,
 )
 
@@ -113,6 +115,9 @@ class BusinessAreaViewSet(
     def all_fields_attributes(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         program_id = request.query_params.get("program_id", None)
         business_area_slug = self.kwargs["slug"]
+        if program_id:
+            # checked for scope only, the generator below takes the id
+            get_object_or_404(Program, id=program_id, business_area__slug=business_area_slug)
         result_list = get_fields_attr_generators(business_area_slug=business_area_slug, program_id=program_id)
         return Response(FieldAttributeSerializer(result_list, many=True).data, status=200)
 

--- a/tests/unit/apps/core/test_cross_business_area_access.py
+++ b/tests/unit/apps/core/test_cross_business_area_access.py
@@ -1,0 +1,66 @@
+"""Cross business area scoping of the field attribute lookup (GHSA-2xf8-jjc2-9pmv)."""
+
+from typing import Any, Callable
+
+import pytest
+from rest_framework import status
+from rest_framework.reverse import reverse
+
+from extras.test_utils.factories import BusinessAreaFactory, FlexibleAttributeForPDUFactory, ProgramFactory, UserFactory
+from hope.models import BusinessArea, Program, User
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def attacker_business_area() -> BusinessArea:
+    return BusinessAreaFactory(name="Afghanistan", slug="afghanistan")
+
+
+@pytest.fixture
+def attacker(attacker_business_area: BusinessArea, create_user_role_with_permissions: Callable) -> User:
+    user = UserFactory()
+    create_user_role_with_permissions(user, [], attacker_business_area, whole_business_area_access=True)
+    return user
+
+
+@pytest.fixture
+def authenticated_client(api_client: Callable, attacker: User) -> Any:
+    return api_client(attacker)
+
+
+@pytest.fixture
+def own_program(attacker_business_area: BusinessArea) -> Program:
+    program = ProgramFactory(business_area=attacker_business_area)
+    FlexibleAttributeForPDUFactory(program=program, label="Own round")
+    return program
+
+
+@pytest.fixture
+def victim_program() -> Program:
+    program = ProgramFactory(business_area=BusinessAreaFactory(name="Ukraine", slug="ukraine"))
+    FlexibleAttributeForPDUFactory(program=program, label="Secret round")
+    return program
+
+
+@pytest.fixture
+def url(attacker_business_area: BusinessArea) -> str:
+    return reverse("api:core:business-areas-all-fields-attributes", kwargs={"slug": attacker_business_area.slug})
+
+
+def test_read_field_attributes_of_program_from_other_business_area_is_denied(
+    authenticated_client: Any, url: str, victim_program: Program
+) -> None:
+    response = authenticated_client.get(url, {"program_id": str(victim_program.id)})
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND, response.status_code
+
+
+def test_read_field_attributes_of_program_of_own_business_area_is_allowed(
+    authenticated_client: Any, url: str, own_program: Program
+) -> None:
+    response = authenticated_client.get(url, {"program_id": str(own_program.id)})
+
+    assert response.status_code == status.HTTP_200_OK, response.status_code
+    own_field_name = own_program.pdu_fields.get().name
+    assert any(field["name"] == own_field_name for field in response.json())


### PR DESCRIPTION
Split out of #6309. **Merge this one first** — #6309's accountability and payment splits build on it.

## Problem

Two separate holes in the shared layer.

**Field attributes.** `all_fields_attributes` took a `program_id` from the query string and passed it to the generator without comparing it with the business area of the path, so the field attributes of any program could be read.

**Wrong permission set.** `BusinessAreaProgramsAccessMixin` narrowed the queryset to the programs the user holds `self.PERMISSIONS` in — that is the *list* permission. A detail or write action requires a different one, so the narrowing was done against the wrong set. It now uses the permissions of the action actually being served.

## Fix

- the program named in the query string is checked against the business area of the path before it is used
- the mixin narrows by `get_permissions_for_action()` instead of the class-level list

The second change is not cosmetic: the feedback update endpoint answers 404 for a legitimate request without it. Used by `payment`, `accountability` and `activity_log`.

Part of GHSA-2xf8-jjc2-9pmv.
