### PR TITLE
Scope the program and the import file a registration import starts from

### DIFF
--- a/src/hope/apps/registration_data/api/serializers.py
+++ b/src/hope/apps/registration_data/api/serializers.py
@@ -4,12 +4,13 @@ from typing import Any
 
 from django.db.models import Count, Q
 from rest_framework import serializers
+from rest_framework.generics import get_object_or_404
 from rest_framework.validators import UniqueValidator
 
 from hope.apps.core.api.mixins import AdminUrlSerializerMixin
 from hope.apps.core.utils import get_count_and_percentage
 from hope.apps.registration_data.utils import get_rdi_program_population
-from hope.models import ImportData, KoboImportData, RegistrationDataImport
+from hope.models import ImportData, KoboImportData, Program, RegistrationDataImport
 
 
 class RegistrationDataImportListSerializer(serializers.ModelSerializer):
@@ -152,6 +153,8 @@ class RefuseRdiSerializer(serializers.Serializer):
 
 
 class RegistrationDataImportCreateSerializer(serializers.Serializer):
+    import_from_program: Program  # set by validate_import_from_program_id, not a field
+
     import_from_program_id = serializers.CharField(required=True)
     import_from_ids = serializers.CharField(
         required=True,
@@ -163,6 +166,12 @@ class RegistrationDataImportCreateSerializer(serializers.Serializer):
     )
     screen_beneficiary = serializers.BooleanField(required=True)
     exclude_external_collectors = serializers.BooleanField(required=False, default=False)
+
+    def validate_import_from_program_id(self, import_from_program_id: str) -> str:
+        self.import_from_program = get_object_or_404(
+            Program, id=import_from_program_id, business_area=self.context["business_area"]
+        )
+        return import_from_program_id
 
     def get_object(self, validated_data: dict) -> RegistrationDataImport:
         request = self.context["request"]

--- a/src/hope/apps/registration_data/api/views.py
+++ b/src/hope/apps/registration_data/api/views.py
@@ -340,7 +340,7 @@ class RegistrationDataImportViewSet(
         serializer.is_valid(raise_exception=True)
         registration_data_import = serializer.get_object(serializer.validated_data)
         import_from_program_id = serializer.validated_data["import_from_program_id"]
-        import_from_program = Program.objects.get(id=import_from_program_id)
+        import_from_program = serializer.import_from_program  # already scoped to the business area of the url path
         if self.program.status == Program.FINISHED:
             raise ValidationError("In order to perform this action, program status must not be finished.")
 
@@ -419,7 +419,7 @@ class RegistrationDataImportViewSet(
 
         # Validate import data exists and is finished
         import_data_id = validated_data["import_data_id"]
-        import_data = ImportData.objects.filter(id=import_data_id).first()
+        import_data = ImportData.objects.filter(id=import_data_id, business_area_slug=self.business_area.slug).first()
         if not import_data:
             raise ValidationError("Import data not found")
         if import_data.status != ImportData.STATUS_FINISHED:
@@ -428,8 +428,8 @@ class RegistrationDataImportViewSet(
         # Create RDI objects inline instead of using GraphQL mutation helpers
         from hope.models import BusinessArea
 
-        import_data_id = validated_data.pop("import_data_id")
-        import_data_obj = ImportData.objects.get(id=import_data_id)
+        validated_data.pop("import_data_id")
+        import_data_obj = import_data
         business_area = BusinessArea.objects.get(slug=validated_data.pop("business_area_slug"))
 
         registration_data_import = RegistrationDataImport(
@@ -500,7 +500,9 @@ class RegistrationDataImportViewSet(
 
         # Validate import data exists and is finished
         import_data_id = validated_data["import_data_id"]
-        import_data = KoboImportData.objects.filter(id=import_data_id).first()
+        import_data = KoboImportData.objects.filter(
+            id=import_data_id, business_area_slug=self.business_area.slug
+        ).first()
         if not import_data:
             raise ValidationError("Kobo import data not found")
         if import_data.status != ImportData.STATUS_FINISHED:
@@ -509,8 +511,8 @@ class RegistrationDataImportViewSet(
         # Create RDI objects inline instead of using GraphQL mutation helpers
         from hope.models import BusinessArea
 
-        import_data_id = validated_data.pop("import_data_id")
-        import_data_obj = KoboImportData.objects.get(id=import_data_id)
+        validated_data.pop("import_data_id")
+        import_data_obj = import_data
         business_area = BusinessArea.objects.get(slug=validated_data.pop("business_area_slug"))
 
         registration_data_import = RegistrationDataImport(

--- a/tests/unit/apps/registration_data/test_cross_business_area_access.py
+++ b/tests/unit/apps/registration_data/test_cross_business_area_access.py
@@ -1,0 +1,126 @@
+"""Cross business area scoping of the registration data import actions (GHSA-2xf8-jjc2-9pmv)."""
+
+from typing import Any, Callable
+
+import pytest
+from rest_framework import status
+from rest_framework.reverse import reverse
+
+from extras.test_utils.factories import (
+    BusinessAreaFactory,
+    ProgramFactory,
+    UserFactory,
+)
+from hope.apps.account.permissions import Permissions
+from hope.models import BusinessArea, ImportData, KoboImportData, Program, RegistrationDataImport, User
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def attacker_business_area() -> BusinessArea:
+    return BusinessAreaFactory(name="Afghanistan", slug="afghanistan")
+
+
+@pytest.fixture
+def attacker_program(attacker_business_area: BusinessArea) -> Program:
+    return ProgramFactory(business_area=attacker_business_area, status=Program.ACTIVE)
+
+
+@pytest.fixture
+def attacker(
+    attacker_business_area: BusinessArea,
+    attacker_program: Program,
+    create_user_role_with_permissions: Callable,
+) -> User:
+    user = UserFactory()
+    create_user_role_with_permissions(
+        user,
+        [Permissions.RDI_IMPORT_DATA],
+        attacker_business_area,
+        attacker_program,
+    )
+    return user
+
+
+@pytest.fixture
+def api_client(api_client: Callable, attacker: User) -> Any:
+    return api_client(attacker)
+
+
+@pytest.fixture
+def victim_business_area() -> BusinessArea:
+    return BusinessAreaFactory(name="Ukraine", slug="ukraine")
+
+
+@pytest.fixture
+def victim_import_data(victim_business_area: BusinessArea) -> ImportData:
+    return ImportData.objects.create(
+        status=ImportData.STATUS_FINISHED,
+        business_area_slug=victim_business_area.slug,
+        data_type=ImportData.XLSX,
+        number_of_households=1,
+        number_of_individuals=1,
+    )
+
+
+@pytest.fixture
+def victim_kobo_import_data(victim_business_area: BusinessArea) -> KoboImportData:
+    return KoboImportData.objects.create(
+        status=ImportData.STATUS_FINISHED,
+        business_area_slug=victim_business_area.slug,
+        data_type=ImportData.JSON,
+        number_of_households=1,
+        number_of_individuals=1,
+    )
+
+
+def test_xlsx_import_from_file_of_other_business_area_is_denied(
+    api_client: Any,
+    attacker_business_area: BusinessArea,
+    attacker_program: Program,
+    victim_import_data: ImportData,
+) -> None:
+    url = reverse(
+        "api:registration-data:registration-data-imports-registration-xlsx-import",
+        kwargs={"business_area_slug": attacker_business_area.slug, "program_code": attacker_program.code},
+    )
+
+    response = api_client.post(
+        url,
+        {
+            "import_data_id": str(victim_import_data.id),
+            "name": "cross business area xlsx import",
+            "screen_beneficiary": False,
+        },
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST, response.status_code
+    assert not RegistrationDataImport.objects.exists()
+
+
+def test_kobo_import_from_file_of_other_business_area_is_denied(
+    api_client: Any,
+    attacker_business_area: BusinessArea,
+    attacker_program: Program,
+    victim_kobo_import_data: KoboImportData,
+) -> None:
+    url = reverse(
+        "api:registration-data:registration-data-imports-registration-kobo-import",
+        kwargs={"business_area_slug": attacker_business_area.slug, "program_code": attacker_program.code},
+    )
+
+    response = api_client.post(
+        url,
+        {
+            "import_data_id": str(victim_kobo_import_data.id),
+            "name": "cross business area kobo import",
+            "pull_pictures": False,
+            "screen_beneficiary": False,
+        },
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST, response.status_code
+    assert not RegistrationDataImport.objects.exists()

--- a/tests/unit/apps/registration_data/test_program_population_import_cross_business_area.py
+++ b/tests/unit/apps/registration_data/test_program_population_import_cross_business_area.py
@@ -1,0 +1,112 @@
+from typing import Any
+from unittest.mock import Mock, patch
+
+from django.urls import reverse
+import pytest
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from extras.test_utils.factories import (
+    BusinessAreaFactory,
+    HouseholdFactory,
+    IndividualFactory,
+    ProgramFactory,
+    UserFactory,
+)
+from hope.apps.account.permissions import Permissions
+from hope.models import BusinessArea, Household, Program, RegistrationDataImport, User
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def attacker_business_area() -> BusinessArea:
+    return BusinessAreaFactory(slug="afghanistan")
+
+
+@pytest.fixture
+def victim_business_area() -> BusinessArea:
+    return BusinessAreaFactory(slug="ukraine")
+
+
+@pytest.fixture
+def victim_program(victim_business_area: BusinessArea) -> Program:
+    return ProgramFactory(business_area=victim_business_area, status=Program.ACTIVE)
+
+
+@pytest.fixture
+def attacker_program(attacker_business_area: BusinessArea, victim_program: Program) -> Program:
+    return ProgramFactory(
+        business_area=attacker_business_area,
+        status=Program.ACTIVE,
+        beneficiary_group=victim_program.beneficiary_group,
+        data_collecting_type=victim_program.data_collecting_type,
+    )
+
+
+@pytest.fixture
+def victim_household(victim_program: Program) -> Household:
+    head_of_household = IndividualFactory(
+        household=None,
+        program=victim_program,
+        business_area=victim_program.business_area,
+    )
+    household = HouseholdFactory(
+        program=victim_program,
+        business_area=victim_program.business_area,
+        head_of_household=head_of_household,
+    )
+    head_of_household.household = household
+    head_of_household.save()
+    return household
+
+
+@pytest.fixture
+def attacker(
+    attacker_business_area: BusinessArea,
+    attacker_program: Program,
+    create_user_role_with_permissions: Any,
+) -> User:
+    user = UserFactory()
+    create_user_role_with_permissions(
+        user,
+        [Permissions.RDI_IMPORT_DATA],
+        attacker_business_area,
+        program=attacker_program,
+    )
+    return user
+
+
+@pytest.fixture
+def api_client(attacker: User) -> APIClient:
+    client = APIClient()
+    client.force_authenticate(user=attacker)
+    return client
+
+
+@patch("hope.apps.registration_data.api.views.registration_program_population_import_async_task", new=Mock())
+def test_import_population_from_program_in_other_business_area_is_denied(
+    api_client: APIClient,
+    attacker_business_area: BusinessArea,
+    attacker_program: Program,
+    victim_program: Program,
+    victim_household: Household,
+) -> None:
+    url = reverse(
+        "api:registration-data:registration-data-imports-list",
+        kwargs={"business_area_slug": attacker_business_area.slug, "program_code": attacker_program.code},
+    )
+
+    response = api_client.post(
+        url,
+        {
+            "import_from_program_id": str(victim_program.id),
+            "import_from_ids": victim_household.unicef_id,
+            "name": "cross business area import",
+            "screen_beneficiary": False,
+        },
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND, response.status_code
+    assert not RegistrationDataImport.objects.filter(name="cross business area import").exists()

--- a/tests/unit/apps/registration_data/test_views_registration_data_import_actions.py
+++ b/tests/unit/apps/registration_data/test_views_registration_data_import_actions.py
@@ -1118,6 +1118,7 @@ def test_create_rdi_social_worker_program_with_household_ids(
     import_from_program = ProgramFactory(
         name="Source Social Worker Program",
         status=Program.ACTIVE,
+        business_area=business_area,
         biometric_deduplication_enabled=True,
         beneficiary_group=beneficiary_group,
         data_collecting_type=social_dct,
@@ -1201,6 +1202,7 @@ def test_create_rdi_social_worker_program_with_individual_ids(
     import_from_program = ProgramFactory(
         name="Source Social Worker Program",
         status=Program.ACTIVE,
+        business_area=business_area,
         biometric_deduplication_enabled=True,
         beneficiary_group=beneficiary_group,
         data_collecting_type=social_dct,


### PR DESCRIPTION
Split out of #6309. Independent — touches no shared code.

## Problem

Three lookups took a caller-supplied id and never compared it with the business area in the url path.

| Action | Id from the body | What it reached |
|---|---|---|
| `create-program-population-import` | `import_from_program_id` | a program of another business area, whose population was then pulled in |
| `create` (xlsx) | `import_data_id` | an `ImportData` uploaded by another business area |
| `create-kobo` | `import_data_id` | a `KoboImportData` uploaded by another business area |

## Fix

- the source program is resolved in `validate_import_from_program_id`, where the business area is already in the serializer context, and the view reads the resolved object instead of looking it up again
- both import-data lookups are filtered by the `business_area_slug` of the path
- the second `.get()` of the same import data in each action is dropped — the row was already fetched, and fetching it again unfiltered would have undone the scoping

Part of GHSA-2xf8-jjc2-9pmv.
