### PR TITLE
Bind a grievance document and a bulk action to the ticket of the url path

### DIFF
--- a/src/hope/apps/grievance/api/mixins.py
+++ b/src/hope/apps/grievance/api/mixins.py
@@ -529,7 +529,7 @@ class GrievanceMutationMixin:
             delete_grievance_documents(ticket.id, ids_to_delete)
         if documents_to_update := input_data.pop("documentation_to_update", None):
             validate_grievance_documents_size(ticket.id, documents_to_update, is_updated=True)
-            update_grievance_documents(documents_to_update)
+            update_grievance_documents(ticket.id, documents_to_update)
         if documents := input_data.pop("documentation", None):
             validate_grievance_documents_size(ticket.id, documents)
             create_grievance_documents(approver, ticket, documents)

--- a/src/hope/apps/grievance/services/bulk_action_service.py
+++ b/src/hope/apps/grievance/services/bulk_action_service.py
@@ -43,6 +43,13 @@ _ACTIVITY_LOG_SELECT_RELATED = (
 
 
 class BulkActionService:
+    def _open_tickets(self, tickets_ids: Sequence[str], business_area_slug: str) -> QuerySet[GrievanceTicket]:
+        return GrievanceTicket.objects.filter(
+            ~Q(status=GrievanceTicket.STATUS_CLOSED),
+            id__in=tickets_ids,
+            business_area__slug=business_area_slug,
+        )
+
     def _clear_cache(self, business_area_slug: str) -> None:
         cache_key = f"count_{business_area_slug}_GrievanceTicketNodeConnection_"
         clear_cache_for_key(cache_key)
@@ -56,7 +63,7 @@ class BulkActionService:
         action_user: User | None = None,
     ) -> QuerySet[GrievanceTicket]:
         user = get_object_or_404(User, id=assigned_to_id)
-        queryset = GrievanceTicket.objects.filter(~Q(status=GrievanceTicket.STATUS_CLOSED), id__in=tickets_ids)
+        queryset = self._open_tickets(tickets_ids, business_area_slug)
 
         new_tickets = queryset.filter(status=GrievanceTicket.STATUS_NEW)
         # Capture which tickets actually change assignee before the update; only those count as assigned.
@@ -83,7 +90,7 @@ class BulkActionService:
     ) -> QuerySet[GrievanceTicket]:
         if priority not in [x for x, y in PRIORITY_CHOICES]:
             raise ValidationError("Invalid priority")
-        queryset = GrievanceTicket.objects.filter(~Q(status=GrievanceTicket.STATUS_CLOSED), id__in=tickets_ids)
+        queryset = self._open_tickets(tickets_ids, business_area_slug)
         updated_count = queryset.update(priority=priority)
         if updated_count != len(tickets_ids):
             raise ValidationError("Some tickets do not exist or are closed")
@@ -97,7 +104,7 @@ class BulkActionService:
     ) -> QuerySet[GrievanceTicket]:
         if urgency not in [x for x, y in URGENCY_CHOICES]:
             raise ValidationError("Invalid priority")
-        queryset = GrievanceTicket.objects.filter(~Q(status=GrievanceTicket.STATUS_CLOSED), id__in=tickets_ids)
+        queryset = self._open_tickets(tickets_ids, business_area_slug)
         updated_count = queryset.update(urgency=urgency)
         if updated_count != len(tickets_ids):
             raise ValidationError("Some tickets do not exist or are closed")
@@ -266,7 +273,7 @@ class BulkActionService:
         comment: str,
         business_area_slug: str,
     ) -> QuerySet[GrievanceTicket]:
-        tickets = GrievanceTicket.objects.filter(~Q(status=GrievanceTicket.STATUS_CLOSED), id__in=tickets_ids)
+        tickets = self._open_tickets(tickets_ids, business_area_slug)
         if len(tickets) != len(tickets_ids):
             raise ValidationError("Some tickets do not exist, or are closed")
         for ticket in tickets:

--- a/src/hope/apps/grievance/utils.py
+++ b/src/hope/apps/grievance/utils.py
@@ -101,9 +101,9 @@ def create_grievance_documents(user: AbstractUser, grievance_ticket: GrievanceTi
     GrievanceDocument.objects.bulk_create(grievance_documents)
 
 
-def update_grievance_documents(documents: list[dict]) -> None:
+def update_grievance_documents(ticket_id: str, documents: list[dict]) -> None:
     for document in documents:
-        current_document = GrievanceDocument.objects.filter(id=document["id"]).first()
+        current_document = GrievanceDocument.objects.filter(id=document["id"], grievance_ticket_id=ticket_id).first()
         if current_document:
             os.remove(current_document.file.path)
 

--- a/tests/unit/apps/grievance/test_bulk_action_cross_business_area_access.py
+++ b/tests/unit/apps/grievance/test_bulk_action_cross_business_area_access.py
@@ -1,0 +1,92 @@
+from typing import Any, Callable
+
+from django.urls import reverse
+import pytest
+from rest_framework import status
+
+from extras.test_utils.factories import (
+    BusinessAreaFactory,
+    GrievanceTicketFactory,
+    ProgramFactory,
+    UserFactory,
+)
+from hope.apps.account.permissions import Permissions
+from hope.apps.grievance.constants import PRIORITY_HIGH, PRIORITY_LOW
+from hope.apps.grievance.models import GrievanceTicket
+from hope.models import BusinessArea, Program, User
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def attacker_business_area() -> BusinessArea:
+    return BusinessAreaFactory(name="Afghanistan", slug="afghanistan", code="0060")
+
+
+@pytest.fixture
+def attacker_program(attacker_business_area: BusinessArea) -> Program:
+    return ProgramFactory(status=Program.ACTIVE, business_area=attacker_business_area)
+
+
+@pytest.fixture
+def attacker(
+    attacker_business_area: BusinessArea,
+    attacker_program: Program,
+    create_user_role_with_permissions: Callable,
+) -> User:
+    user = UserFactory()
+    create_user_role_with_permissions(
+        user,
+        [Permissions.GRIEVANCES_CREATE, Permissions.GRIEVANCES_UPDATE],
+        attacker_business_area,
+        attacker_program,
+    )
+    return user
+
+
+@pytest.fixture
+def authenticated_client(api_client: Callable, attacker: User) -> Any:
+    return api_client(attacker)
+
+
+@pytest.fixture
+def victim_program() -> Program:
+    return ProgramFactory(
+        status=Program.ACTIVE,
+        business_area=BusinessAreaFactory(name="Ukraine", slug="ukraine", code="0070"),
+    )
+
+
+@pytest.fixture
+def victim_ticket(victim_program: Program) -> GrievanceTicket:
+    ticket = GrievanceTicketFactory(
+        business_area=victim_program.business_area,
+        status=GrievanceTicket.STATUS_NEW,
+        priority=PRIORITY_LOW,
+    )
+    ticket.programs.add(victim_program)
+    return ticket
+
+
+@pytest.fixture
+def bulk_priority_url(attacker_business_area: BusinessArea) -> str:
+    return reverse(
+        "api:grievance-tickets:grievance-tickets-global-bulk-update-priority",
+        kwargs={"business_area_slug": attacker_business_area.slug},
+    )
+
+
+def test_bulk_update_priority_of_ticket_from_other_business_area_is_denied(
+    authenticated_client: Any,
+    bulk_priority_url: str,
+    victim_ticket: GrievanceTicket,
+) -> None:
+    response = authenticated_client.post(
+        bulk_priority_url,
+        {"grievance_ticket_ids": [str(victim_ticket.id)], "priority": PRIORITY_HIGH},
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST, response.status_code
+    victim_ticket.refresh_from_db()
+    assert victim_ticket.priority == PRIORITY_LOW

--- a/tests/unit/apps/grievance/test_grievance_ticket_update.py
+++ b/tests/unit/apps/grievance/test_grievance_ticket_update.py
@@ -12,6 +12,7 @@ from extras.test_utils.factories import (
     BusinessAreaFactory,
     CurrencyFactory,
     DocumentFactory,
+    GrievanceDocumentFactory,
     GrievanceTicketFactory,
     HouseholdFactory,
     IndividualFactory,
@@ -1681,3 +1682,81 @@ def test_status_change_back_to_in_progress_does_not_notify_the_owner_who_sent_it
         for recipient in notification.user_recipients
     ]
     assert send_back_recipients == []
+
+
+@pytest.fixture
+def complaint_ticket_document(complaint_ticket: GrievanceTicket) -> Any:
+    return GrievanceDocumentFactory(
+        grievance_ticket=complaint_ticket,
+        name="old name",
+        file=SimpleUploadedFile("old.jpg", b"old-bytes", content_type="image/jpeg"),
+        file_size=9,
+    )
+
+
+@pytest.fixture
+def other_ticket_document(afghanistan: BusinessArea) -> Any:
+    return GrievanceDocumentFactory(
+        grievance_ticket=GrievanceTicketFactory(business_area=afghanistan),
+        name="old name",
+        file=SimpleUploadedFile("old.jpg", b"old-bytes", content_type="image/jpeg"),
+        file_size=9,
+    )
+
+
+@pytest.mark.usefixtures("mock_elasticsearch")
+def test_update_grievance_ticket_documentation(
+    api_client: Any,
+    user: User,
+    afghanistan: BusinessArea,
+    program: Program,
+    complaint_ticket_detail_url: str,
+    complaint_ticket_document: Any,
+    create_user_role_with_permissions: Callable,
+) -> None:
+    create_user_role_with_permissions(user, [Permissions.GRIEVANCES_UPDATE], afghanistan, program)
+
+    client = api_client(user)
+    response = client.patch(
+        complaint_ticket_detail_url,
+        {
+            "documentation_to_update[0].id": str(complaint_ticket_document.id),
+            "documentation_to_update[0].name": "new name",
+            "documentation_to_update[0].file": SimpleUploadedFile("new.jpg", b"new-bytes!", content_type="image/jpeg"),
+        },
+        format="multipart",
+    )
+
+    assert response.status_code == status.HTTP_200_OK, response.json()
+    complaint_ticket_document.refresh_from_db()
+    assert complaint_ticket_document.name == "new name"
+    assert complaint_ticket_document.file_size == 10
+
+
+@pytest.mark.usefixtures("mock_elasticsearch")
+def test_update_grievance_ticket_documentation_of_other_ticket_is_denied(
+    api_client: Any,
+    user: User,
+    afghanistan: BusinessArea,
+    program: Program,
+    complaint_ticket_detail_url: str,
+    other_ticket_document: Any,
+    create_user_role_with_permissions: Callable,
+) -> None:
+    create_user_role_with_permissions(user, [Permissions.GRIEVANCES_UPDATE], afghanistan, program)
+
+    client = api_client(user)
+    response = client.patch(
+        complaint_ticket_detail_url,
+        {
+            "documentation_to_update[0].id": str(other_ticket_document.id),
+            "documentation_to_update[0].name": "new name",
+            "documentation_to_update[0].file": SimpleUploadedFile("new.jpg", b"new-bytes!", content_type="image/jpeg"),
+        },
+        format="multipart",
+    )
+
+    assert response.status_code == status.HTTP_200_OK, response.json()
+    other_ticket_document.refresh_from_db()
+    assert other_ticket_document.name == "old name"
+    assert other_ticket_document.file_size == 9

--- a/tests/unit/apps/grievance/test_grievance_utils.py
+++ b/tests/unit/apps/grievance/test_grievance_utils.py
@@ -189,7 +189,10 @@ def test_update_grievance_documents_replaces_file_and_metadata(grievance_documen
     assert "old" in grievance_document.file.name
     new_file = SimpleUploadedFile("new.jpg", b"new-bytes!", content_type="image/jpeg")
 
-    update_grievance_documents([{"id": grievance_document.id, "name": "updated name", "file": new_file}])
+    update_grievance_documents(
+        grievance_document.grievance_ticket_id,
+        [{"id": grievance_document.id, "name": "updated name", "file": new_file}],
+    )
 
     grievance_document.refresh_from_db()
     assert grievance_document.name == "updated name"
@@ -201,7 +204,22 @@ def test_update_grievance_documents_replaces_file_and_metadata(grievance_documen
 def test_update_grievance_documents_skips_missing_document(grievance_document: Any) -> None:
     new_file = SimpleUploadedFile("new.jpg", b"new-bytes!", content_type="image/jpeg")
 
-    update_grievance_documents([{"id": uuid4(), "name": "updated name", "file": new_file}])
+    update_grievance_documents(
+        grievance_document.grievance_ticket_id, [{"id": uuid4(), "name": "updated name", "file": new_file}]
+    )
 
     grievance_document.refresh_from_db()
     assert grievance_document.name != "updated name"
+
+
+def test_update_grievance_documents_skips_document_of_another_ticket(grievance_document: Any) -> None:
+    other_ticket = GrievanceTicketFactory()
+    new_file = SimpleUploadedFile("new.jpg", b"new-bytes!", content_type="image/jpeg")
+
+    update_grievance_documents(
+        other_ticket.id, [{"id": grievance_document.id, "name": "updated name", "file": new_file}]
+    )
+
+    grievance_document.refresh_from_db()
+    assert grievance_document.name != "updated name"
+    assert "old" in grievance_document.file.name


### PR DESCRIPTION
Split out of #6309. Independent — touches no shared code.

## Problem

**Documents.** `update_grievance_documents` took a document id straight from the body and looked it up globally. An edit on your own ticket could point at a document of someone else's ticket — the file on disk was removed and replaced.

**Bulk actions.** Assign, priority, urgency and add-note filtered tickets by `id__in` alone. Ids of another business area, posted to an endpoint scoped to the caller's, were updated.

## Fix

- `update_grievance_documents` takes the ticket id and filters on it
- the four bulk actions share one `_open_tickets()` helper that filters by `business_area__slug` of the path

Part of GHSA-2xf8-jjc2-9pmv.
