### PR TITLE
Scope a delegation to the import of the url path

### DIFF
--- a/src/hope/api/endpoints/rdi/delegate_people.py
+++ b/src/hope/api/endpoints/rdi/delegate_people.py
@@ -1,13 +1,16 @@
 from typing import TYPE_CHECKING
 from uuid import UUID
 
+from django.db import transaction
+from django.http.response import Http404
+from django.utils.functional import cached_property
 from drf_spectacular.utils import extend_schema
 from rest_framework import serializers, status
 from rest_framework.response import Response
 
 from hope.api.endpoints.base import HOPEAPIBusinessAreaView, HOPEAPIView
 from hope.apps.household.const import ROLE_PRIMARY
-from hope.models import Grant, PendingIndividualRoleInHousehold
+from hope.models import Grant, PendingIndividual, PendingIndividualRoleInHousehold, RegistrationDataImport
 
 if TYPE_CHECKING:
     from rest_framework.request import Request
@@ -21,27 +24,53 @@ class DelegateSerializer(serializers.Serializer):
 class DelegatePeopleSerializer(serializers.Serializer):
     delegates = DelegateSerializer(many=True, required=True, allow_empty=False, allow_null=False)
 
+    def validate_delegates(self, delegates: list[dict]) -> list[dict]:
+        """Reject a delegate from outside this import before any role is reassigned."""
+        rdi = self.context["registration_data_import"]
+        delegate_ids = {delegate["delegate_id"] for delegate in delegates}
+        ids_in_import = set(
+            PendingIndividual.objects.filter(id__in=delegate_ids, registration_data_import=rdi).values_list(
+                "id", flat=True
+            )
+        )
+        for delegate_id in delegate_ids - ids_in_import:
+            raise serializers.ValidationError(f"Delegate {delegate_id} does not belong to this import.")
+        return delegates
+
+    @transaction.atomic
     def create(self, validated_data: dict) -> dict:
+        rdi = self.context["registration_data_import"]
         delegates = validated_data.pop("delegates")
         updated = 0
         for delegate in delegates:
-            delegate_id = delegate["delegate_id"]
-            delegated_for = delegate["delegated_for"]
-            for delegated_for_id in delegated_for:
+            for delegated_for_id in delegate["delegated_for"]:
                 updated += PendingIndividualRoleInHousehold.objects.filter(
+                    household__registration_data_import=rdi,
                     household__individuals__in=[delegated_for_id],
                     individual_id=delegated_for_id,
                     role=ROLE_PRIMARY,
-                ).update(individual_id=delegate_id)
+                ).update(individual_id=delegate["delegate_id"])
         return {"updated": updated}
 
 
 class DelegatePeopleRDIView(HOPEAPIBusinessAreaView, HOPEAPIView):
     permission = Grant.API_RDI_UPLOAD
 
+    @cached_property
+    def selected_rdi(self) -> RegistrationDataImport:
+        try:
+            return RegistrationDataImport.objects.get(
+                id=self.kwargs["rdi"],
+                business_area__slug=self.kwargs["business_area"],
+            )
+        except RegistrationDataImport.DoesNotExist:
+            raise Http404
+
     @extend_schema(request=DelegatePeopleSerializer)
     def post(self, request: "Request", business_area: str, rdi: UUID) -> Response:
-        serializer = DelegatePeopleSerializer(data=request.data)
+        serializer = DelegatePeopleSerializer(
+            data=request.data, context={"registration_data_import": self.selected_rdi}
+        )
         if serializer.is_valid():
             response = serializer.save()
             return Response(response, status=status.HTTP_200_OK)

--- a/tests/unit/api/test_delegate_people.py
+++ b/tests/unit/api/test_delegate_people.py
@@ -5,18 +5,26 @@ from rest_framework import status
 from rest_framework.reverse import reverse
 from rest_framework.test import APIClient
 
+from extras.test_utils.factories import (
+    BusinessAreaFactory,
+    PendingHouseholdFactory,
+    PendingIndividualFactory,
+    RegistrationDataImportFactory,
+)
 from extras.test_utils.factories.core import BeneficiaryGroupFactory, DataCollectingTypeFactory
 from extras.test_utils.factories.program import ProgramFactory
 from hope.apps.core.utils import IDENTIFICATION_TYPE_TO_KEY_MAPPING
 from hope.apps.household.const import (
     IDENTIFICATION_TYPE_BIRTH_CERTIFICATE,
     NON_BENEFICIARY,
+    ROLE_PRIMARY,
 )
 from hope.models import (
     BusinessArea,
     DataCollectingType,
     PendingHousehold,
     PendingIndividual,
+    PendingIndividualRoleInHousehold,
     Program,
     RegistrationDataImport,
 )
@@ -116,3 +124,118 @@ def test_delegate_people_reassigns_primary_collector(
     hh2 = PendingHousehold.objects.get(registration_data_import=rdi_loading, village="village2")
     assert hh1.primary_collector.full_name == "John Doe"
     assert hh2.primary_collector.full_name == "Jack Jones"
+
+
+@pytest.fixture
+def victim_primary_role(afghanistan_country) -> PendingIndividualRoleInHousehold:
+    victim_business_area = BusinessAreaFactory(name="Ukraine", slug="ukraine", code="0070")
+    victim_program = ProgramFactory(status=Program.DRAFT, business_area=victim_business_area)
+    victim_rdi = RegistrationDataImportFactory(
+        business_area=victim_business_area,
+        program=victim_program,
+        status=RegistrationDataImport.LOADING,
+    )
+    household = PendingHouseholdFactory(
+        business_area=victim_business_area,
+        program=victim_program,
+        registration_data_import=victim_rdi,
+        create_role=False,
+    )
+    individual = PendingIndividualFactory(
+        business_area=victim_business_area,
+        program=victim_program,
+        registration_data_import=victim_rdi,
+        household=household,
+    )
+    return PendingIndividualRoleInHousehold.objects.create(
+        household=household, individual=individual, role=ROLE_PRIMARY
+    )
+
+
+def test_delegate_people_of_other_business_area_is_denied(
+    token_api_client: APIClient,
+    business_area: BusinessArea,
+    rdi_loading: RegistrationDataImport,
+    people_ids: list[UUID],
+    victim_primary_role: PendingIndividualRoleInHousehold,
+) -> None:
+    collector_before = victim_primary_role.individual_id
+    url = reverse("api:rdi-delegate-people", args=[business_area.slug, str(rdi_loading.id)])
+    data = {"delegates": [{"delegate_id": people_ids[2], "delegated_for": [str(collector_before)]}]}
+
+    response = token_api_client.post(url, data, format="json")
+
+    assert response.status_code == status.HTTP_200_OK, str(response.json())
+    assert response.json()["updated"] == 0
+    victim_primary_role.refresh_from_db()
+    assert victim_primary_role.individual_id == collector_before
+
+
+def test_delegate_to_individual_of_other_business_area_is_denied(
+    token_api_client: APIClient,
+    business_area: BusinessArea,
+    rdi_loading: RegistrationDataImport,
+    people_ids: list[UUID],
+    victim_primary_role: PendingIndividualRoleInHousehold,
+) -> None:
+    url = reverse("api:rdi-delegate-people", args=[business_area.slug, str(rdi_loading.id)])
+    data = {"delegates": [{"delegate_id": str(victim_primary_role.individual_id), "delegated_for": [people_ids[1]]}]}
+
+    response = token_api_client.post(url, data, format="json")
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST, str(response.json())
+    hh2 = PendingHousehold.objects.get(registration_data_import=rdi_loading, village="village2")
+    assert hh2.primary_collector.full_name == "Mary Doe"
+
+
+def test_delegate_people_rejects_the_whole_batch_when_one_delegate_is_foreign(
+    token_api_client: APIClient,
+    business_area: BusinessArea,
+    rdi_loading: RegistrationDataImport,
+    people_ids: list[UUID],
+    victim_primary_role: PendingIndividualRoleInHousehold,
+) -> None:
+    """A rejected batch must reassign nobody, not even the delegates listed before the bad one."""
+    url = reverse("api:rdi-delegate-people", args=[business_area.slug, str(rdi_loading.id)])
+    data = {
+        "delegates": [
+            {"delegate_id": people_ids[2], "delegated_for": [people_ids[1]]},
+            {"delegate_id": str(victim_primary_role.individual_id), "delegated_for": [people_ids[0]]},
+        ]
+    }
+
+    response = token_api_client.post(url, data, format="json")
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST, str(response.json())
+    hh2 = PendingHousehold.objects.get(registration_data_import=rdi_loading, village="village2")
+    assert hh2.primary_collector.full_name == "Mary Doe"
+
+
+def test_delegate_people_in_import_of_other_business_area_is_denied(
+    token_api_client: APIClient,
+    business_area: BusinessArea,
+    people_ids: list[UUID],
+    victim_primary_role: PendingIndividualRoleInHousehold,
+) -> None:
+    victim_rdi = victim_primary_role.household.registration_data_import
+    url = reverse("api:rdi-delegate-people", args=[business_area.slug, str(victim_rdi.id)])
+    data = {"delegates": [{"delegate_id": people_ids[2], "delegated_for": [str(victim_primary_role.individual_id)]}]}
+
+    response = token_api_client.post(url, data, format="json")
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND, str(response.json())
+    victim_primary_role.refresh_from_db()
+    assert victim_primary_role.individual_id != people_ids[2]
+
+
+def test_delegate_people_without_delegates_is_rejected(
+    token_api_client: APIClient,
+    business_area: BusinessArea,
+    rdi_loading: RegistrationDataImport,
+) -> None:
+    url = reverse("api:rdi-delegate-people", args=[business_area.slug, str(rdi_loading.id)])
+
+    response = token_api_client.post(url, {"delegates": []}, format="json")
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST, str(response.json())
+    assert "delegates" in response.json()


### PR DESCRIPTION
Split out of #6309. Independent — touches no shared code.

## Problem

The delegate-people endpoint took individual ids from the body and reassigned the primary collector role by id alone, so ids belonging to another import — and so to another business area — were reassigned through a url scoped to the caller's.

## Fix

- the RDI of the path is resolved once, and the role queryset is filtered by it
- delegates are validated against that import in `validate_delegates`, before any role is written, which also collapses one `exists()` per delegate into one query for the batch
- the writes run in one transaction

The last two points address @MarekBiczysko's review on #6309: the original check sat inside the write loop, so a bad delegate in the middle of a batch left the earlier ones already reassigned behind a 400.

Part of GHSA-2xf8-jjc2-9pmv.
