### PR TITLE
Scope the beneficiaries and the program a feedback points at

### DIFF
--- a/src/hope/apps/accountability/api/views.py
+++ b/src/hope/apps/accountability/api/views.py
@@ -116,7 +116,7 @@ class FeedbackViewSet(
     program_model_field = "program"
 
     def get_object(self) -> Feedback:
-        return get_object_or_404(Feedback, id=self.kwargs.get("pk"))
+        return get_object_or_404(self.get_queryset(), id=self.kwargs.get("pk"))
 
     def get_queryset(self) -> QuerySet[Feedback]:
         queryset = super().get_queryset()
@@ -138,10 +138,10 @@ class FeedbackViewSet(
         program_code = self.kwargs.get("program_code")
         program = None
         if program_code:
-            program = Program.objects.get(code=program_code)
+            program = get_object_or_404(Program, code=program_code, business_area=business_area)
 
         if program_id := serializer.validated_data.get("program_id"):
-            program = Program.objects.get(id=program_id)
+            program = get_object_or_404(Program, id=program_id, business_area=business_area)
 
         if program and program.status == Program.FINISHED:
             raise ValidationError("It is not possible to create Feedback for a Finished Program.")
@@ -195,7 +195,7 @@ class FeedbackViewSet(
         program = feedback.program
 
         if program_id := serializer.validated_data.get("program_id"):
-            program = Program.objects.get(id=program_id)
+            program = get_object_or_404(Program, id=program_id, business_area=business_area)
 
         if program and program.status == Program.FINISHED:
             raise ValidationError("It is not possible to update Feedback for a Finished Program.")
@@ -305,8 +305,8 @@ class MessageViewSet(
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
-        business_area = BusinessArea.objects.get(slug=self.kwargs.get("business_area_slug"))
-        program = Program.objects.get(code=self.program_code)
+        business_area = self.business_area
+        program = self.program
 
         input_data = serializer.validated_data
         input_data["program"] = str(program.pk)
@@ -405,8 +405,8 @@ class SurveyViewSet(
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
-        business_area = BusinessArea.objects.get(slug=self.business_area_slug)
-        program = Program.objects.get(code=self.program_code)
+        business_area = self.business_area
+        program = self.program
 
         input_data = serializer.validated_data
         input_data["business_area"] = business_area

--- a/src/hope/apps/accountability/services/feedback_crud_services.py
+++ b/src/hope/apps/accountability/services/feedback_crud_services.py
@@ -7,10 +7,9 @@ from django.shortcuts import get_object_or_404
 from hope.models import Area, BusinessArea, Feedback, Household, Individual, Program, User
 
 _SIMPLE_FIELDS = ("comments", "area", "language", "consent")
-_FK_FIELDS = {
+_SCOPED_FK_FIELDS = {
     "household_lookup": Household,
     "individual_lookup": Individual,
-    "admin2": Area,
 }
 
 
@@ -20,13 +19,16 @@ class FeedbackCrudServices:
         return key in input_data and input_data[key] is not None and input_data[key] != ""
 
     @classmethod
-    def _apply_fields(cls, obj: Feedback, input_data: dict) -> None:
+    def _apply_fields(cls, obj: Feedback, input_data: dict, business_area: BusinessArea) -> None:
         for field in _SIMPLE_FIELDS:
             if cls._has_value(input_data, field):
                 setattr(obj, field, input_data[field])
-        for field, model in _FK_FIELDS.items():
+        for field, model in _SCOPED_FK_FIELDS.items():
             if cls._has_value(input_data, field):
-                setattr(obj, field, get_object_or_404(model, id=input_data[field]))
+                setattr(obj, field, get_object_or_404(model, id=input_data[field], business_area=business_area))
+        if cls._has_value(input_data, "admin2"):
+            # admin areas are shared reference data, not owned by a business area
+            obj.admin2 = get_object_or_404(Area, id=input_data["admin2"])
 
     @classmethod
     def validate_lookup(cls, feedback: Feedback) -> None:
@@ -49,7 +51,7 @@ class FeedbackCrudServices:
             issue_type=input_data["issue_type"],
             description=input_data["description"],
         )
-        cls._apply_fields(obj, input_data)
+        cls._apply_fields(obj, input_data, business_area)
 
         if obj.household_lookup:
             obj.program = obj.household_lookup.program or obj.household_lookup.programs.first()
@@ -66,7 +68,7 @@ class FeedbackCrudServices:
         for field in ("issue_type", "description"):
             if cls._has_value(input_data, field):
                 setattr(feedback, field, input_data[field])
-        cls._apply_fields(feedback, input_data)
+        cls._apply_fields(feedback, input_data, feedback.business_area)
         if cls._has_value(input_data, "program"):
             feedback.program = get_object_or_404(Program, id=input_data["program"])
         cls.validate_lookup(feedback)

--- a/tests/unit/apps/accountability/test_feedback_cross_business_area_access.py
+++ b/tests/unit/apps/accountability/test_feedback_cross_business_area_access.py
@@ -1,0 +1,210 @@
+from typing import Any
+
+from django.urls import reverse
+import pytest
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from extras.test_utils.factories import (
+    BusinessAreaFactory,
+    FeedbackFactory,
+    HouseholdFactory,
+    IndividualFactory,
+    ProgramFactory,
+    UserFactory,
+)
+from hope.apps.account.permissions import Permissions
+from hope.models import BusinessArea, Feedback, Household, Individual, Program, User
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def attacker_business_area() -> BusinessArea:
+    return BusinessAreaFactory(slug="afghanistan")
+
+
+@pytest.fixture
+def attacker_program(attacker_business_area: BusinessArea) -> Program:
+    return ProgramFactory(business_area=attacker_business_area)
+
+
+@pytest.fixture
+def victim_feedback() -> Feedback:
+    business_area = BusinessAreaFactory(slug="ukraine")
+    return FeedbackFactory(
+        business_area=business_area,
+        program=ProgramFactory(business_area=business_area),
+        created_by=UserFactory(),
+    )
+
+
+@pytest.fixture
+def attacker(
+    attacker_business_area: BusinessArea,
+    attacker_program: Program,
+    create_user_role_with_permissions: Any,
+) -> User:
+    user = UserFactory()
+    create_user_role_with_permissions(
+        user,
+        [
+            Permissions.GRIEVANCES_FEEDBACK_VIEW_LIST,
+            Permissions.GRIEVANCES_FEEDBACK_VIEW_DETAILS,
+            Permissions.GRIEVANCES_FEEDBACK_VIEW_UPDATE,
+            Permissions.GRIEVANCES_FEEDBACK_VIEW_CREATE,
+        ],
+        attacker_business_area,
+        program=attacker_program,
+    )
+    return user
+
+
+@pytest.fixture
+def api_client(attacker: User) -> APIClient:
+    client = APIClient()
+    client.force_authenticate(user=attacker)
+    return client
+
+
+@pytest.fixture
+def cross_ba_detail_url(attacker_business_area: BusinessArea, victim_feedback: Feedback) -> str:
+    return reverse(
+        "api:accountability:feedbacks-detail",
+        kwargs={"business_area_slug": attacker_business_area.slug, "pk": str(victim_feedback.id)},
+    )
+
+
+def test_retrieve_feedback_from_other_business_area_is_denied(api_client: APIClient, cross_ba_detail_url: str) -> None:
+    response = api_client.get(cross_ba_detail_url)
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND, response.status_code
+
+
+def test_update_feedback_from_other_business_area_is_denied(
+    api_client: APIClient, cross_ba_detail_url: str, victim_feedback: Feedback
+) -> None:
+    response = api_client.patch(cross_ba_detail_url, {"description": "hijacked"}, format="json")
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND, response.status_code
+    victim_feedback.refresh_from_db()
+    assert victim_feedback.description != "hijacked"
+
+
+@pytest.fixture
+def feedback_in_program_without_role(attacker_business_area: BusinessArea) -> Feedback:
+    return FeedbackFactory(
+        business_area=attacker_business_area,
+        program=ProgramFactory(business_area=attacker_business_area),
+        created_by=UserFactory(),
+    )
+
+
+def test_retrieve_feedback_from_program_without_role_is_denied(
+    api_client: APIClient, attacker_business_area: BusinessArea, feedback_in_program_without_role: Feedback
+) -> None:
+    url = reverse(
+        "api:accountability:feedbacks-detail",
+        kwargs={
+            "business_area_slug": attacker_business_area.slug,
+            "pk": str(feedback_in_program_without_role.id),
+        },
+    )
+
+    response = api_client.get(url)
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND, response.status_code
+
+
+@pytest.fixture
+def attacker_feedback(attacker_business_area: BusinessArea, attacker_program: Program) -> Feedback:
+    return FeedbackFactory(
+        business_area=attacker_business_area,
+        program=attacker_program,
+        created_by=UserFactory(),
+    )
+
+
+def test_move_feedback_to_program_in_other_business_area_is_denied(
+    api_client: APIClient,
+    attacker_business_area: BusinessArea,
+    attacker_feedback: Feedback,
+    victim_feedback: Feedback,
+) -> None:
+    url = reverse(
+        "api:accountability:feedbacks-detail",
+        kwargs={"business_area_slug": attacker_business_area.slug, "pk": str(attacker_feedback.id)},
+    )
+
+    response = api_client.patch(
+        url,
+        {
+            "issue_type": attacker_feedback.issue_type,
+            "description": attacker_feedback.description,
+            "program_id": str(victim_feedback.program_id),
+        },
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND, response.status_code
+    attacker_feedback.refresh_from_db()
+    assert attacker_feedback.program_id != victim_feedback.program_id
+
+
+@pytest.fixture
+def victim_household() -> Household:
+    program = ProgramFactory(business_area=BusinessAreaFactory(slug="ukraine"))
+    return HouseholdFactory(business_area=program.business_area, program=program, create_role=False)
+
+
+@pytest.fixture
+def victim_individual(victim_household: Household) -> Individual:
+    return IndividualFactory(
+        household=victim_household,
+        business_area=victim_household.business_area,
+        program=victim_household.program,
+        registration_data_import=victim_household.registration_data_import,
+    )
+
+
+@pytest.fixture
+def create_url(attacker_business_area: BusinessArea) -> str:
+    return reverse("api:accountability:feedbacks-list", kwargs={"business_area_slug": attacker_business_area.slug})
+
+
+def test_create_feedback_for_household_from_other_business_area_is_denied(
+    api_client: APIClient,
+    create_url: str,
+    victim_household: Household,
+) -> None:
+    response = api_client.post(
+        create_url,
+        {
+            "issue_type": Feedback.POSITIVE_FEEDBACK,
+            "description": "cross business area feedback",
+            "household_lookup": str(victim_household.id),
+        },
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND, response.status_code
+    assert not Feedback.objects.filter(household_lookup=victim_household).exists()
+
+
+def test_create_feedback_for_individual_from_other_business_area_is_denied(
+    api_client: APIClient,
+    create_url: str,
+    victim_individual: Individual,
+) -> None:
+    response = api_client.post(
+        create_url,
+        {
+            "issue_type": Feedback.POSITIVE_FEEDBACK,
+            "description": "cross business area feedback",
+            "individual_lookup": str(victim_individual.id),
+        },
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND, response.status_code
+    assert not Feedback.objects.filter(individual_lookup=victim_individual).exists()

--- a/tests/unit/apps/accountability/test_feedback_viewset.py
+++ b/tests/unit/apps/accountability/test_feedback_viewset.py
@@ -896,7 +896,8 @@ def test_update_feedback_with_program_without_permission_in_program(
         },
         format="json",
     )
-    assert response.status_code == status.HTTP_403_FORBIDDEN
+    # not visible in that program, so not found rather than forbidden
+    assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
 def test_update_feedback_hh_lookup_returns_data_with_permission(
@@ -1400,7 +1401,8 @@ def test_create_feedback_message_with_program_without_permission_in_program(
         {"description": "Message for Feedback #1"},
         format="json",
     )
-    assert response.status_code == status.HTTP_403_FORBIDDEN
+    # not visible in that program, so not found rather than forbidden
+    assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
 def test_create_feedback_message_per_program_returns_created_with_permission(


### PR DESCRIPTION
Split out of #6309. **Based on `feature/fix-cross-ba-idor-core`** — the base retargets to develop once that merges.

## Problem

`FeedbackCrudServices._apply_fields` resolved `household_lookup` and `individual_lookup` with a global `get_object_or_404`. A feedback created in one business area attached beneficiaries of another and was then dragged into their program — this is the PoC @Jeeziorny posted on #6309.

The program was resolved the same unscoped way, from both the `program_id` of the body and the `program_code` of the path, and `get_object` bypassed the queryset that scopes the list.

## Fix

- `household_lookup` and `individual_lookup` are scoped to the feedback's business area
- `admin2` stays global on purpose — admin areas are shared reference data, not owned by a business area
- both program lookups are scoped to the business area of the path
- `get_object` goes through `get_queryset()`
- the message and survey actions read `self.business_area` / `self.program` instead of re-fetching them unscoped

Part of GHSA-2xf8-jjc2-9pmv.
