### PR TITLE
Scope payment plans, verifications and their documents to the url path

### DIFF
--- a/src/hope/apps/payment/api/serializers.py
+++ b/src/hope/apps/payment/api/serializers.py
@@ -89,8 +89,7 @@ class PaymentPlanSupportingDocumentSerializer(serializers.ModelSerializer):
         return file
 
     def validate(self, data: dict) -> dict:
-        payment_plan_id = self.context["request"].parser_context["kwargs"]["payment_plan_pk"]
-        payment_plan = get_object_or_404(PaymentPlan, id=payment_plan_id)
+        payment_plan = self.context["payment_plan"]
         data["payment_plan"] = payment_plan
         data["created_by"] = self.context["request"].user
 
@@ -1774,11 +1773,8 @@ class TargetPopulationCreateSerializer(serializers.ModelSerializer):
         program = self.get_program()
         data["program"] = program
         data["created_by"] = request.user
-        business_area = program.business_area
 
-        payment_plan = PaymentPlanService.create(
-            input_data=data, user=request.user, business_area_slug=business_area.slug
-        )
+        payment_plan = PaymentPlanService.create(input_data=data, user=request.user, program=program)
         log_create(
             mapping=PaymentPlan.ACTIVITY_LOG_MAPPING,
             business_area_field="business_area",
@@ -1788,6 +1784,7 @@ class TargetPopulationCreateSerializer(serializers.ModelSerializer):
         )
         return payment_plan
 
+    @transaction.atomic
     def update(self, payment_plan: PaymentPlan, validated_data: dict) -> PaymentPlan:
         request = self.context["request"]
         check_concurrency_version_in_mutation(validated_data.get("version"), payment_plan)

--- a/src/hope/apps/payment/api/views.py
+++ b/src/hope/apps/payment/api/views.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from decimal import Decimal
+from functools import cached_property
 from io import BytesIO
 import logging
 import mimetypes
@@ -194,6 +195,17 @@ logger = logging.getLogger(__name__)
 XLSX_CONTENT_TYPE = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
 
 
+class ScopedPaymentPlanMixin:
+    payment_plan_url_kwarg = "payment_plan_pk"
+
+    def scoped_payment_plan(self, pk: Any) -> PaymentPlan:
+        return get_object_or_404(PaymentPlan, pk=pk, program_cycle__program=self.program)
+
+    @cached_property
+    def payment_plan(self) -> PaymentPlan:
+        return self.scoped_payment_plan(self.kwargs.get(self.payment_plan_url_kwarg))
+
+
 class PaymentPlanMixin:
     serializer_class = PaymentPlanSerializer
     filter_backends = (
@@ -214,11 +226,13 @@ class PaymentVerificationViewSet(
     ProgramMixin,
     SerializerActionMixin,
     PaymentPlanMixin,
+    ScopedPaymentPlanMixin,
     mixins.RetrieveModelMixin,
     mixins.ListModelMixin,
     BaseViewSet,
 ):
     program_model_field = "program_cycle__program"
+    payment_plan_url_kwarg = "pk"
     queryset = (
         PaymentPlan.objects.filter(status__in=(PaymentPlan.Status.ACCEPTED, PaymentPlan.Status.FINISHED))
         .select_related("currency")
@@ -255,10 +269,14 @@ class PaymentVerificationViewSet(
     }
 
     def get_object(self) -> PaymentPlan:
-        return get_object_or_404(PaymentPlan, id=self.kwargs.get("pk"))
+        return self.payment_plan
 
     def get_verification_plan_object(self) -> PaymentVerificationPlan:
-        return get_object_or_404(PaymentVerificationPlan, id=self.kwargs.get("verification_plan_id"))
+        return get_object_or_404(
+            PaymentVerificationPlan,
+            id=self.kwargs.get("verification_plan_id"),
+            payment_plan=self.payment_plan,
+        )
 
     # @etag_decorator(PaymentVerificationListKeyConstructor)
     # @cache_response(timeout=config.REST_API_TTL, key_func=PaymentVerificationListKeyConstructor())
@@ -375,7 +393,7 @@ class PaymentVerificationViewSet(
         payment_plan = self.get_object()
         try:
             payment_verification_plan = PaymentVerificationPlan.objects.select_for_update(nowait=True).get(
-                pk=verification_plan_id
+                pk=verification_plan_id, payment_plan=payment_plan
             )
         except PaymentVerificationPlan.DoesNotExist:
             raise Http404
@@ -650,9 +668,12 @@ def _with_payment_related_data(queryset: QuerySet[Payment]) -> QuerySet[Payment]
     )
 
 
-class PaymentVerificationRecordViewSet(CountActionMixin, ProgramMixin, SerializerActionMixin, BaseViewSet):
+class PaymentVerificationRecordViewSet(
+    CountActionMixin, ProgramMixin, SerializerActionMixin, ScopedPaymentPlanMixin, BaseViewSet
+):
     queryset = Payment.objects.all()
     program_model_field = "program_cycle__program"
+    payment_plan_url_kwarg = "payment_verification_pk"
     PERMISSIONS = [Permissions.PAYMENT_VERIFICATION_VIEW_LIST]
     serializer_classes_by_action = {
         "list": PaymentListSerializer,
@@ -668,14 +689,17 @@ class PaymentVerificationRecordViewSet(CountActionMixin, ProgramMixin, Serialize
     filterset_class = PaymentVerificationRecordFilter
 
     def get_object(self) -> PaymentPlan:
-        return get_object_or_404(PaymentPlan, id=self.kwargs.get("payment_verification_pk"))
+        return self.payment_plan
 
     def get_verification_record(self) -> Payment:
-        return get_object_or_404(Payment, id=self.kwargs.get("pk"))
+        return get_object_or_404(
+            _with_payment_related_data(Payment.objects.all()),
+            id=self.kwargs.get("pk"),
+            parent=self.payment_plan,
+        )
 
     def get_queryset(self) -> QuerySet:
-        payment_plan = get_object_or_404(PaymentPlan, id=self.kwargs.get("payment_verification_pk"))
-        return payment_plan.eligible_payments.exclude(
+        return self.payment_plan.eligible_payments.exclude(
             payment_verifications__payment_verification_plan__isnull=True
         ).select_related("currency")
 
@@ -696,10 +720,7 @@ class PaymentVerificationRecordViewSet(CountActionMixin, ProgramMixin, Serialize
         return Response(serializer.data)
 
     def retrieve(self, request: Request, *args: Any, **kwargs: Any) -> Response:
-        payment = get_object_or_404(
-            _with_payment_related_data(Payment.objects.all()),
-            id=self.kwargs.get("pk"),
-        )
+        payment = self.get_verification_record()
         serializer = self.get_serializer(payment)
         return Response(serializer.data, status=status.HTTP_200_OK)
 
@@ -769,6 +790,7 @@ class PaymentPlanViewSet(
     ProgramMixin,
     SerializerActionMixin,
     PaymentPlanMixin,
+    ScopedPaymentPlanMixin,
     mixins.RetrieveModelMixin,
     mixins.CreateModelMixin,
     mixins.ListModelMixin,
@@ -877,7 +899,7 @@ class PaymentPlanViewSet(
     }
 
     def get_object(self) -> PaymentPlan:
-        payment_plan = get_object_or_404(PaymentPlan, id=self.kwargs.get("pk"))
+        payment_plan = self.scoped_payment_plan(self.kwargs.get("pk"))
         if payment_plan.is_instruction_managed and self.action in self.BLOCKED_ACTIONS_FOR_INSTRUCTION_MANAGED:
             raise ValidationError("This Payment Plan is managed by a Follow Up Instruction.")
         return payment_plan
@@ -891,7 +913,7 @@ class PaymentPlanViewSet(
     def create(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         if "target_population_id" not in request.data:
             raise ValidationError("target_population_id is required")
-        payment_plan = get_object_or_404(PaymentPlan, id=request.data["target_population_id"])
+        payment_plan = self.scoped_payment_plan(request.data["target_population_id"])
         serializer = self.get_serializer(data=request.data, context={"payment_plan": payment_plan})
         serializer.is_valid(raise_exception=True)
         old_payment_plan = copy_model_object(payment_plan)
@@ -1149,7 +1171,7 @@ class PaymentPlanViewSet(
             engine_formula_rule_id = serializer.validated_data["engine_formula_rule_id"]
             if version := serializer.validated_data.get("version"):
                 check_concurrency_version_in_mutation(version, payment_plan)
-            engine_rule = get_object_or_404(Rule, id=engine_formula_rule_id)
+            engine_rule = get_object_or_404(Rule, id=engine_formula_rule_id, allowed_business_areas=self.business_area)
             if payment_plan.status not in PaymentPlan.CAN_RUN_ENGINE_FORMULA_FOR_ENTITLEMENT:
                 raise ValidationError(f"Not allowed to run engine formula within status {payment_plan.status}.")
             if not engine_rule.enabled or engine_rule.deprecated:
@@ -2072,6 +2094,7 @@ class TargetPopulationViewSet(
     ProgramMixin,
     SerializerActionMixin,
     PaymentPlanMixin,
+    ScopedPaymentPlanMixin,
     mixins.RetrieveModelMixin,
     mixins.ListModelMixin,
     mixins.CreateModelMixin,
@@ -2111,7 +2134,7 @@ class TargetPopulationViewSet(
     filterset_class = TargetPopulationFilter
 
     def get_object(self) -> PaymentPlan:
-        return get_object_or_404(PaymentPlan, id=self.kwargs.get("pk"))
+        return self.scoped_payment_plan(self.kwargs.get("pk"))
 
     @etag_decorator(TargetPopulationListKeyConstructor)
     @cached_response(key_func=TargetPopulationListKeyConstructor())
@@ -2276,8 +2299,8 @@ class TargetPopulationViewSet(
             program_cycle_id = serializer.validated_data["program_cycle_id"]
             payment_plan_group_id = serializer.validated_data["payment_plan_group_id"]
             purposes = serializer.validated_data["payment_plan_purposes"]
-            payment_plan = get_object_or_404(PaymentPlan, pk=payment_plan_id)
-            program_cycle = get_object_or_404(ProgramCycle, pk=program_cycle_id)
+            payment_plan = self.scoped_payment_plan(payment_plan_id)
+            program_cycle = get_object_or_404(ProgramCycle, pk=program_cycle_id, program=self.program)
             program = program_cycle.program
 
             if program_cycle.status == ProgramCycle.FINISHED:
@@ -2348,7 +2371,7 @@ class TargetPopulationViewSet(
         engine_formula_rule_id = serializer.validated_data["engine_formula_rule_id"]
         if version := serializer.validated_data.get("version"):
             check_concurrency_version_in_mutation(version, tp)
-        engine_rule = get_object_or_404(Rule, id=engine_formula_rule_id)
+        engine_rule = get_object_or_404(Rule, id=engine_formula_rule_id, allowed_business_areas=self.business_area)
         # tp vulnerability_score
         if tp.status not in PaymentPlan.CAN_RUN_ENGINE_FORMULA_FOR_VULNERABILITY_SCORE:
             raise ValidationError(f"Not allowed to run engine formula within status {tp.status}.")
@@ -2486,7 +2509,9 @@ class PaymentPlanManagerialViewSet(
         return action_to_permissions_map.get(action_name)
 
 
-class PaymentPlanSupportingDocumentViewSet(mixins.CreateModelMixin, mixins.DestroyModelMixin, BaseViewSet):
+class PaymentPlanSupportingDocumentViewSet(
+    ProgramMixin, ScopedPaymentPlanMixin, mixins.CreateModelMixin, mixins.DestroyModelMixin, BaseViewSet
+):
     serializer_class = PaymentPlanSupportingDocumentSerializer
     lookup_field = "file_id"
 
@@ -2498,16 +2523,15 @@ class PaymentPlanSupportingDocumentViewSet(mixins.CreateModelMixin, mixins.Destr
     }
 
     def get_queryset(self) -> QuerySet:
-        payment_plan_id = self.kwargs.get("payment_plan_pk")
-        return PaymentPlanSupportingDocument.objects.filter(payment_plan_id=payment_plan_id)
+        return PaymentPlanSupportingDocument.objects.filter(payment_plan=self.payment_plan)
 
     def get_object(self) -> PaymentPlanSupportingDocument:
-        payment_plan = get_object_or_404(PaymentPlan, id=self.kwargs.get("payment_plan_pk"))
-        return get_object_or_404(
-            PaymentPlanSupportingDocument,
-            id=self.kwargs.get("file_id"),
-            payment_plan=payment_plan,
-        )
+        return get_object_or_404(self.get_queryset(), id=self.kwargs.get("file_id"))
+
+    def get_serializer_context(self) -> dict:
+        context = super().get_serializer_context()
+        context["payment_plan"] = self.payment_plan
+        return context
 
     @transaction.atomic
     def perform_create(self, serializer: Any) -> None:
@@ -2540,7 +2564,9 @@ class PaymentPlanSupportingDocumentViewSet(mixins.CreateModelMixin, mixins.Destr
 
 class PaymentViewSet(
     CountActionMixin,
+    ProgramMixin,
     SerializerActionMixin,
+    ScopedPaymentPlanMixin,
     mixins.RetrieveModelMixin,
     mixins.ListModelMixin,
     BaseViewSet,
@@ -2568,11 +2594,15 @@ class PaymentViewSet(
     filterset_class = PaymentSearchFilter
 
     def get_object(self) -> Payment:
-        payment_id = self.kwargs["payment_id"]
-        return get_object_or_404(_with_payment_related_data(Payment.objects.all()), id=payment_id)
+        # the details page is reached by a plain link with no plan id, so scope to the program instead
+        return get_object_or_404(
+            _with_payment_related_data(Payment.objects.all()),
+            id=self.kwargs["payment_id"],
+            parent__program_cycle__program=self.program,
+        )
 
     def get_queryset(self) -> QuerySet:
-        parent = PaymentPlan.objects.get(pk=self.kwargs["payment_plan_pk"])
+        parent = self.payment_plan
         if parent.status == PaymentPlan.Status.OPEN:
             queryset = parent.eligible_payments_with_conflicts
         else:

--- a/src/hope/apps/payment/filters.py
+++ b/src/hope/apps/payment/filters.py
@@ -1,6 +1,5 @@
 from base64 import b64decode
 from typing import Any
-from uuid import UUID
 
 from django.db.models import Case, Count, IntegerField, Q, QuerySet, Value, When
 from django.db.models.functions import Lower
@@ -15,10 +14,8 @@ from django_filters import (
     MultipleChoiceFilter,
     NumberFilter,
     OrderingFilter,
-    UUIDFilter,
 )
 
-from hope.apps.activity_log.filters import LogEntryFilter
 from hope.apps.core.filters import IntegerFilter
 from hope.apps.core.utils import CustomOrderingFilter
 from hope.models import (
@@ -112,15 +109,6 @@ class PaymentVerificationSummaryFilter(FilterSet):
     class Meta:
         fields = ()
         model = PaymentVerificationSummary
-
-
-class PaymentVerificationLogEntryFilter(LogEntryFilter):
-    object_id = UUIDFilter(method="object_id_filter")
-
-    def object_id_filter(self, qs: QuerySet, name: str, value: UUID) -> QuerySet:
-        payment_plan = PaymentPlan.objects.get(pk=value)
-        verifications_ids = payment_plan.payment_verification_plans.all().values_list("pk", flat=True)
-        return qs.filter(object_id__in=verifications_ids)
 
 
 class FinancialServiceProviderXlsxTemplateFilter(FilterSet):

--- a/src/hope/apps/payment/services/payment_plan_services.py
+++ b/src/hope/apps/payment/services/payment_plan_services.py
@@ -52,7 +52,6 @@ from hope.apps.utils.recipients import users_with_permissions
 from hope.models import (
     Approval,
     ApprovalProcess,
-    BusinessArea,
     Currency,
     DeliveryMechanism,
     FinancialServiceProvider,
@@ -599,10 +598,9 @@ class PaymentPlanService:
         from_input_to_targeting_criteria(targeting_criteria_input, program, self.payment_plan)
 
     @staticmethod
-    def create(input_data: dict, user: "User", business_area_slug: str) -> PaymentPlan:
-        business_area = BusinessArea.objects.get(slug=business_area_slug)
-        program_cycle = get_object_or_404(ProgramCycle, pk=input_data["program_cycle_id"])
-        program = program_cycle.program
+    def create(input_data: dict, user: "User", program: Program) -> PaymentPlan:
+        business_area = program.business_area
+        program_cycle = get_object_or_404(ProgramCycle, pk=input_data["program_cycle_id"], program=program)
         if program_cycle.status == ProgramCycle.FINISHED:
             raise ValidationError("Impossible to create Target Population for Programme Cycle within Finished status")
 
@@ -643,7 +641,7 @@ class PaymentPlanService:
             delivery_mechanism_code = input_data.get("delivery_mechanism_code")
 
             if fsp_id and delivery_mechanism_code:
-                fsp = get_object_or_404(FinancialServiceProvider, pk=fsp_id)
+                fsp = get_object_or_404(FinancialServiceProvider, pk=fsp_id, allowed_business_areas=business_area)
                 PaymentPlanService._check_group_fsp_consistency(payment_plan_group, fsp)
                 delivery_mechanism = get_object_or_404(DeliveryMechanism, code=delivery_mechanism_code)
                 payment_plan.financial_service_provider = fsp
@@ -694,7 +692,11 @@ class PaymentPlanService:
             self.payment_plan.delivery_mechanism = None
             return True
         if fsp_id and delivery_mechanism_code:
-            fsp = get_object_or_404(FinancialServiceProvider, pk=fsp_id)
+            fsp = get_object_or_404(
+                FinancialServiceProvider,
+                pk=fsp_id,
+                allowed_business_areas=self.payment_plan.business_area,
+            )
             delivery_mechanism = get_object_or_404(DeliveryMechanism, code=delivery_mechanism_code)
             if current_fsp != fsp or current_dm != delivery_mechanism:
                 self.payment_plan.financial_service_provider = fsp
@@ -796,7 +798,9 @@ class PaymentPlanService:
 
     def _set_program_cycle(self, input_data: dict) -> None:
         if program_cycle_id := input_data.get("program_cycle_id"):
-            program_cycle = get_object_or_404(ProgramCycle, pk=program_cycle_id)
+            program_cycle = get_object_or_404(
+                ProgramCycle, pk=program_cycle_id, program=self.payment_plan.program_cycle.program
+            )
             if program_cycle == self.payment_plan.program_cycle:
                 return
             self._validate_pp_cycle(program_cycle)

--- a/tests/unit/apps/payment/test_cross_business_area_access.py
+++ b/tests/unit/apps/payment/test_cross_business_area_access.py
@@ -1,0 +1,757 @@
+from typing import Any
+
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.urls import reverse
+import pytest
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from extras.test_utils.factories import (
+    BusinessAreaFactory,
+    CurrencyFactory,
+    DeliveryMechanismFactory,
+    FinancialServiceProviderFactory,
+    HouseholdFactory,
+    PaymentFactory,
+    PaymentPlanFactory,
+    PaymentPlanGroupFactory,
+    PaymentPlanPurposeFactory,
+    PaymentPlanSupportingDocumentFactory,
+    PaymentVerificationPlanFactory,
+    PaymentVerificationSummaryFactory,
+    ProgramFactory,
+    RuleCommitFactory,
+    TargetingCriteriaRuleFactory,
+    UserFactory,
+)
+from hope.apps.account.permissions import Permissions
+from hope.models import (
+    BusinessArea,
+    Payment,
+    PaymentPlan,
+    PaymentPlanPurpose,
+    PaymentPlanSupportingDocument,
+    PaymentVerificationPlan,
+    Rule,
+    User,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def attacker_business_area() -> BusinessArea:
+    return BusinessAreaFactory(slug="afghanistan")
+
+
+@pytest.fixture
+def victim_business_area() -> BusinessArea:
+    return BusinessAreaFactory(slug="ukraine")
+
+
+@pytest.fixture
+def attacker_payment_plan(attacker_business_area: BusinessArea) -> PaymentPlan:
+    return PaymentPlanFactory(
+        status=PaymentPlan.Status.OPEN,
+        program_cycle__program=ProgramFactory(business_area=attacker_business_area),
+    )
+
+
+@pytest.fixture
+def victim_payment_plan(victim_business_area: BusinessArea) -> PaymentPlan:
+    return PaymentPlanFactory(
+        status=PaymentPlan.Status.ACCEPTED,
+        program_cycle__program=ProgramFactory(business_area=victim_business_area),
+    )
+
+
+@pytest.fixture
+def victim_target_population(victim_business_area: BusinessArea) -> PaymentPlan:
+    return PaymentPlanFactory(
+        status=PaymentPlan.Status.DRAFT,
+        program_cycle__program=ProgramFactory(business_area=victim_business_area),
+        currency=CurrencyFactory(),
+    )
+
+
+@pytest.fixture
+def attacker_purpose(attacker_payment_plan: PaymentPlan) -> PaymentPlanPurpose:
+    purpose = PaymentPlanPurposeFactory()
+    attacker_payment_plan.program.payment_plan_purposes.add(purpose)
+    return purpose
+
+
+@pytest.fixture
+def victim_document(victim_payment_plan: PaymentPlan) -> PaymentPlanSupportingDocument:
+    return PaymentPlanSupportingDocumentFactory(payment_plan=victim_payment_plan)
+
+
+@pytest.fixture
+def victim_payment(victim_payment_plan: PaymentPlan) -> Payment:
+    return PaymentFactory(parent=victim_payment_plan)
+
+
+@pytest.fixture
+def victim_verification_plan(victim_payment_plan: PaymentPlan) -> PaymentVerificationPlan:
+    PaymentVerificationSummaryFactory(payment_plan=victim_payment_plan)
+    return PaymentVerificationPlanFactory(payment_plan=victim_payment_plan)
+
+
+@pytest.fixture
+def attacker(
+    attacker_business_area: BusinessArea,
+    attacker_payment_plan: PaymentPlan,
+    create_user_role_with_permissions: Any,
+) -> User:
+    user = UserFactory()
+    create_user_role_with_permissions(
+        user,
+        [
+            Permissions.PM_VIEW_LIST,
+            Permissions.PM_VIEW_DETAILS,
+            Permissions.PM_CREATE,
+            Permissions.PM_UPLOAD_SUPPORTING_DOCUMENT,
+            Permissions.PM_DOWNLOAD_SUPPORTING_DOCUMENT,
+            Permissions.PM_DELETE_SUPPORTING_DOCUMENT,
+            Permissions.TARGETING_VIEW_LIST,
+            Permissions.TARGETING_VIEW_DETAILS,
+            Permissions.TARGETING_REMOVE,
+            Permissions.TARGETING_DUPLICATE,
+            Permissions.PAYMENT_VERIFICATION_VIEW_LIST,
+            Permissions.PAYMENT_VERIFICATION_VIEW_DETAILS,
+            Permissions.PAYMENT_VERIFICATION_DELETE,
+            Permissions.PAYMENT_VERIFICATION_ACTIVATE,
+            Permissions.PM_PAYMENT_PLAN_GROUP_CREATE,
+            Permissions.TARGETING_CREATE,
+            Permissions.TARGETING_UPDATE,
+            Permissions.PM_APPLY_RULE_ENGINE_FORMULA_WITH_ENTITLEMENTS,
+        ],
+        attacker_business_area,
+        program=attacker_payment_plan.program,
+    )
+    return user
+
+
+@pytest.fixture
+def api_client(attacker: User) -> APIClient:
+    client = APIClient()
+    client.force_authenticate(user=attacker)
+    return client
+
+
+@pytest.fixture
+def upload_file() -> SimpleUploadedFile:
+    return SimpleUploadedFile("test.pdf", b"123", content_type="application/pdf")
+
+
+@pytest.fixture
+def api_client_without_role() -> APIClient:
+    client = APIClient()
+    client.force_authenticate(user=UserFactory())
+    return client
+
+
+@pytest.fixture
+def cross_ba_kwargs(attacker_business_area: BusinessArea, attacker_payment_plan: PaymentPlan) -> dict[str, str]:
+    """Path segments the attacker is authorized for - the object ids appended to them are not."""
+    return {
+        "business_area_slug": attacker_business_area.slug,
+        "program_code": attacker_payment_plan.program.code,
+    }
+
+
+def test_download_supporting_document_without_permission_is_denied(
+    api_client_without_role: APIClient,
+    cross_ba_kwargs: dict[str, str],
+    victim_document: PaymentPlanSupportingDocument,
+) -> None:
+    url = reverse(
+        "api:payments:supporting-documents-download",
+        kwargs={
+            **cross_ba_kwargs,
+            "payment_plan_pk": str(victim_document.payment_plan.id),
+            "file_id": str(victim_document.id),
+        },
+    )
+
+    response = api_client_without_role.get(url)
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN, response.status_code
+
+
+def test_download_supporting_document_from_other_business_area_is_denied(
+    api_client: APIClient,
+    cross_ba_kwargs: dict[str, str],
+    victim_document: PaymentPlanSupportingDocument,
+) -> None:
+    url = reverse(
+        "api:payments:supporting-documents-download",
+        kwargs={
+            **cross_ba_kwargs,
+            "payment_plan_pk": str(victim_document.payment_plan.id),
+            "file_id": str(victim_document.id),
+        },
+    )
+
+    response = api_client.get(url)
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND, response.status_code
+
+
+def test_delete_supporting_document_from_other_business_area_is_denied(
+    api_client: APIClient,
+    cross_ba_kwargs: dict[str, str],
+    victim_document: PaymentPlanSupportingDocument,
+) -> None:
+    url = reverse(
+        "api:payments:supporting-documents-detail",
+        kwargs={
+            **cross_ba_kwargs,
+            "payment_plan_pk": str(victim_document.payment_plan.id),
+            "file_id": str(victim_document.id),
+        },
+    )
+
+    response = api_client.delete(url)
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND, response.status_code
+    assert PaymentPlanSupportingDocument.objects.filter(id=victim_document.id).exists()
+
+
+def test_upload_supporting_document_to_other_business_area_is_denied(
+    api_client: APIClient,
+    cross_ba_kwargs: dict[str, str],
+    victim_payment_plan: PaymentPlan,
+    upload_file: SimpleUploadedFile,
+) -> None:
+    url = reverse(
+        "api:payments:supporting-documents-list",
+        kwargs={**cross_ba_kwargs, "payment_plan_pk": str(victim_payment_plan.id)},
+    )
+
+    response = api_client.post(url, {"title": "cross ba", "file": upload_file}, format="multipart")
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND, response.status_code
+    assert not victim_payment_plan.documents.exists()
+
+
+def test_retrieve_payment_plan_from_other_business_area_is_denied(
+    api_client: APIClient, cross_ba_kwargs: dict[str, str], victim_payment_plan: PaymentPlan
+) -> None:
+    url = reverse("api:payments:payment-plans-detail", kwargs={**cross_ba_kwargs, "pk": str(victim_payment_plan.id)})
+
+    response = api_client.get(url)
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND, response.status_code
+
+
+def test_retrieve_target_population_from_other_business_area_is_denied(
+    api_client: APIClient, cross_ba_kwargs: dict[str, str], victim_payment_plan: PaymentPlan
+) -> None:
+    url = reverse(
+        "api:payments:target-populations-detail", kwargs={**cross_ba_kwargs, "pk": str(victim_payment_plan.id)}
+    )
+
+    response = api_client.get(url)
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND, response.status_code
+
+
+def test_retrieve_payment_verification_from_other_business_area_is_denied(
+    api_client: APIClient, cross_ba_kwargs: dict[str, str], victim_payment_plan: PaymentPlan
+) -> None:
+    url = reverse(
+        "api:payments:payment-verifications-detail", kwargs={**cross_ba_kwargs, "pk": str(victim_payment_plan.id)}
+    )
+
+    response = api_client.get(url)
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND, response.status_code
+
+
+def test_delete_payment_verification_plan_from_other_business_area_is_denied(
+    api_client: APIClient,
+    cross_ba_kwargs: dict[str, str],
+    victim_verification_plan: PaymentVerificationPlan,
+) -> None:
+    url = reverse(
+        "api:payments:payment-verifications-delete-payment-verification-plan",
+        kwargs={
+            **cross_ba_kwargs,
+            "pk": str(victim_verification_plan.payment_plan.id),
+            "verification_plan_id": str(victim_verification_plan.id),
+        },
+    )
+
+    response = api_client.post(url, {}, format="json")
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND, response.status_code
+    assert PaymentVerificationPlan.objects.filter(id=victim_verification_plan.id).exists()
+
+
+def test_activate_verification_plan_from_other_business_area_under_own_plan_is_denied(
+    api_client: APIClient,
+    cross_ba_kwargs: dict[str, str],
+    attacker_payment_plan: PaymentPlan,
+    victim_verification_plan: PaymentVerificationPlan,
+) -> None:
+    url = reverse(
+        "api:payments:payment-verifications-activate-payment-verification-plan",
+        kwargs={
+            **cross_ba_kwargs,
+            "pk": str(attacker_payment_plan.id),
+            "verification_plan_id": str(victim_verification_plan.id),
+        },
+    )
+
+    response = api_client.post(url, {}, format="json")
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND, response.status_code
+    victim_verification_plan.refresh_from_db()
+    assert victim_verification_plan.status == PaymentVerificationPlan.STATUS_PENDING
+
+
+def test_list_verification_records_from_other_business_area_is_denied(
+    api_client: APIClient, cross_ba_kwargs: dict[str, str], victim_payment_plan: PaymentPlan
+) -> None:
+    url = reverse(
+        "api:payments:verification-records-list",
+        kwargs={**cross_ba_kwargs, "payment_verification_pk": str(victim_payment_plan.id)},
+    )
+
+    response = api_client.get(url)
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND, response.status_code
+
+
+def test_create_payment_plan_from_other_business_area_target_population_is_denied(
+    api_client: APIClient, cross_ba_kwargs: dict[str, str], victim_target_population: PaymentPlan
+) -> None:
+    url = reverse("api:payments:payment-plans-list", kwargs=cross_ba_kwargs)
+
+    response = api_client.post(
+        url,
+        {
+            "target_population_id": str(victim_target_population.id),
+            "dispersion_start_date": "2050-01-01",
+            "dispersion_end_date": "2050-02-01",
+            "currency": "PLN",
+        },
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND, response.status_code
+
+
+def test_copy_target_population_into_other_business_area_cycle_is_denied(
+    api_client: APIClient,
+    cross_ba_kwargs: dict[str, str],
+    attacker_payment_plan: PaymentPlan,
+    victim_payment_plan: PaymentPlan,
+    attacker_purpose: PaymentPlanPurpose,
+) -> None:
+    url = reverse(
+        "api:payments:target-populations-copy", kwargs={**cross_ba_kwargs, "pk": str(attacker_payment_plan.id)}
+    )
+
+    response = api_client.post(
+        url,
+        {
+            "name": "copied across business areas",
+            "program_cycle_id": str(victim_payment_plan.program_cycle_id),
+            "payment_plan_group_id": str(victim_payment_plan.payment_plan_group_id),
+            "payment_plan_purposes": [str(attacker_purpose.id)],
+        },
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND, response.status_code
+    assert not PaymentPlan.objects.filter(name="copied across business areas").exists()
+
+
+def test_retrieve_payment_from_other_business_area_is_denied(
+    api_client: APIClient, cross_ba_kwargs: dict[str, str], victim_payment: Payment
+) -> None:
+    url = reverse(
+        "api:payments:payments-detail",
+        kwargs={
+            **cross_ba_kwargs,
+            "payment_plan_pk": str(victim_payment.parent_id),
+            "payment_id": str(victim_payment.id),
+        },
+    )
+
+    response = api_client.get(url)
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND, response.status_code
+
+
+@pytest.fixture
+def attacker_second_payment_plan(attacker_payment_plan: PaymentPlan) -> PaymentPlan:
+    return PaymentPlanFactory(
+        status=PaymentPlan.Status.ACCEPTED,
+        program_cycle__program=attacker_payment_plan.program,
+    )
+
+
+@pytest.fixture
+def attacker_second_plan_payment(attacker_second_payment_plan: PaymentPlan) -> Payment:
+    return PaymentFactory(parent=attacker_second_payment_plan)
+
+
+@pytest.fixture
+def attacker_second_plan_verification_plan(attacker_second_payment_plan: PaymentPlan) -> PaymentVerificationPlan:
+    PaymentVerificationSummaryFactory(payment_plan=attacker_second_payment_plan)
+    return PaymentVerificationPlanFactory(payment_plan=attacker_second_payment_plan)
+
+
+def test_retrieve_payment_of_other_business_area_under_own_payment_plan_is_denied(
+    api_client: APIClient,
+    cross_ba_kwargs: dict[str, str],
+    attacker_payment_plan: PaymentPlan,
+    victim_payment: Payment,
+) -> None:
+    url = reverse(
+        "api:payments:payments-detail",
+        kwargs={
+            **cross_ba_kwargs,
+            "payment_plan_pk": str(attacker_payment_plan.id),
+            "payment_id": str(victim_payment.id),
+        },
+    )
+
+    response = api_client.get(url)
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND, response.status_code
+
+
+def test_retrieve_payment_of_own_program_works_without_a_usable_payment_plan_in_the_path(
+    api_client: APIClient,
+    cross_ba_kwargs: dict[str, str],
+    attacker_second_plan_payment: Payment,
+) -> None:
+    url = reverse(
+        "api:payments:payments-detail",
+        kwargs={
+            **cross_ba_kwargs,
+            "payment_plan_pk": "undefined",
+            "payment_id": str(attacker_second_plan_payment.id),
+        },
+    )
+
+    response = api_client.get(url)
+
+    assert response.status_code == status.HTTP_200_OK, response.status_code
+
+
+def test_retrieve_verification_record_under_mismatched_payment_plan_path_is_denied(
+    api_client: APIClient,
+    cross_ba_kwargs: dict[str, str],
+    attacker_payment_plan: PaymentPlan,
+    attacker_second_plan_payment: Payment,
+) -> None:
+    url = reverse(
+        "api:payments:verification-records-detail",
+        kwargs={
+            **cross_ba_kwargs,
+            "payment_verification_pk": str(attacker_payment_plan.id),
+            "pk": str(attacker_second_plan_payment.id),
+        },
+    )
+
+    response = api_client.get(url)
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND, response.status_code
+
+
+def test_delete_verification_plan_of_another_payment_plan_is_denied(
+    api_client: APIClient,
+    cross_ba_kwargs: dict[str, str],
+    attacker_payment_plan: PaymentPlan,
+    attacker_second_plan_verification_plan: PaymentVerificationPlan,
+) -> None:
+    url = reverse(
+        "api:payments:payment-verifications-delete-payment-verification-plan",
+        kwargs={
+            **cross_ba_kwargs,
+            "pk": str(attacker_payment_plan.id),
+            "verification_plan_id": str(attacker_second_plan_verification_plan.id),
+        },
+    )
+
+    response = api_client.post(url, {}, format="json")
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND, response.status_code
+    assert PaymentVerificationPlan.objects.filter(id=attacker_second_plan_verification_plan.id).exists()
+
+
+def test_activate_verification_plan_of_another_payment_plan_is_denied(
+    api_client: APIClient,
+    cross_ba_kwargs: dict[str, str],
+    attacker_payment_plan: PaymentPlan,
+    attacker_second_plan_verification_plan: PaymentVerificationPlan,
+) -> None:
+    url = reverse(
+        "api:payments:payment-verifications-activate-payment-verification-plan",
+        kwargs={
+            **cross_ba_kwargs,
+            "pk": str(attacker_payment_plan.id),
+            "verification_plan_id": str(attacker_second_plan_verification_plan.id),
+        },
+    )
+
+    response = api_client.post(url, {}, format="json")
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND, response.status_code
+    attacker_second_plan_verification_plan.refresh_from_db()
+    assert attacker_second_plan_verification_plan.status == PaymentVerificationPlan.STATUS_PENDING
+
+
+def test_create_target_population_in_cycle_of_other_business_area_is_denied(
+    api_client: APIClient,
+    cross_ba_kwargs: dict[str, str],
+    attacker_purpose: PaymentPlanPurpose,
+    victim_payment_plan: PaymentPlan,
+) -> None:
+    victim_cycle = victim_payment_plan.program_cycle
+    victim_household = HouseholdFactory(
+        business_area=victim_payment_plan.business_area,
+        program=victim_payment_plan.program,
+        create_role=False,
+    )
+    url = reverse("api:payments:target-populations-list", kwargs=cross_ba_kwargs)
+
+    response = api_client.post(
+        url,
+        {
+            "name": "cross ba target population",
+            "program_cycle_id": str(victim_cycle.id),
+            "payment_plan_group_id": str(PaymentPlanGroupFactory(cycle=victim_cycle).id),
+            "payment_plan_purposes": [str(attacker_purpose.id)],
+            "rules": [
+                {
+                    "household_filters_blocks": [],
+                    "household_ids": victim_household.unicef_id,
+                    "individual_ids": "",
+                    "individuals_filters_blocks": [],
+                }
+            ],
+            "flag_exclude_if_on_sanction_list": False,
+            "flag_exclude_if_active_adjudication_ticket": False,
+        },
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND, response.json()
+    assert not PaymentPlan.objects.filter(name="cross ba target population").exists()
+
+
+def test_create_target_population_in_cycle_of_other_program_is_denied(
+    api_client: APIClient,
+    cross_ba_kwargs: dict[str, str],
+    attacker_business_area: BusinessArea,
+    attacker_purpose: PaymentPlanPurpose,
+) -> None:
+    other_program = ProgramFactory(business_area=attacker_business_area)
+    other_plan = PaymentPlanFactory(status=PaymentPlan.Status.OPEN, program_cycle__program=other_program)
+    household = HouseholdFactory(business_area=attacker_business_area, program=other_program, create_role=False)
+    url = reverse("api:payments:target-populations-list", kwargs=cross_ba_kwargs)
+
+    response = api_client.post(
+        url,
+        {
+            "name": "cross program target population",
+            "program_cycle_id": str(other_plan.program_cycle.id),
+            "payment_plan_group_id": str(PaymentPlanGroupFactory(cycle=other_plan.program_cycle).id),
+            "payment_plan_purposes": [str(attacker_purpose.id)],
+            "rules": [
+                {
+                    "household_filters_blocks": [],
+                    "household_ids": household.unicef_id,
+                    "individual_ids": "",
+                    "individuals_filters_blocks": [],
+                }
+            ],
+            "flag_exclude_if_on_sanction_list": False,
+            "flag_exclude_if_active_adjudication_ticket": False,
+        },
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND, response.json()
+    assert not PaymentPlan.objects.filter(name="cross program target population").exists()
+
+
+@pytest.fixture
+def victim_fsp(victim_business_area: BusinessArea) -> Any:
+    delivery_mechanism = DeliveryMechanismFactory()
+    fsp = FinancialServiceProviderFactory(delivery_mechanisms=[delivery_mechanism])
+    fsp.allowed_business_areas.set([victim_business_area])
+    return fsp
+
+
+def test_create_target_population_with_fsp_of_other_business_area_is_denied(
+    api_client: APIClient,
+    cross_ba_kwargs: dict[str, str],
+    attacker_payment_plan: PaymentPlan,
+    attacker_purpose: PaymentPlanPurpose,
+    victim_fsp: Any,
+) -> None:
+    household = HouseholdFactory(
+        business_area=attacker_payment_plan.business_area,
+        program=attacker_payment_plan.program,
+        create_role=False,
+    )
+    url = reverse("api:payments:target-populations-list", kwargs=cross_ba_kwargs)
+
+    response = api_client.post(
+        url,
+        {
+            "name": "target population with a foreign fsp",
+            "program_cycle_id": str(attacker_payment_plan.program_cycle.id),
+            "payment_plan_group_id": str(PaymentPlanGroupFactory(cycle=attacker_payment_plan.program_cycle).id),
+            "payment_plan_purposes": [str(attacker_purpose.id)],
+            "fsp_id": str(victim_fsp.id),
+            "delivery_mechanism_code": victim_fsp.delivery_mechanisms.first().code,
+            "rules": [
+                {
+                    "household_filters_blocks": [],
+                    "household_ids": household.unicef_id,
+                    "individual_ids": "",
+                    "individuals_filters_blocks": [],
+                }
+            ],
+            "flag_exclude_if_on_sanction_list": False,
+            "flag_exclude_if_active_adjudication_ticket": False,
+        },
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND, response.json()
+    assert not PaymentPlan.objects.filter(name="target population with a foreign fsp").exists()
+
+
+@pytest.fixture
+def attacker_target_population(attacker_payment_plan: PaymentPlan) -> PaymentPlan:
+    return PaymentPlanFactory(
+        status=PaymentPlan.Status.TP_OPEN,
+        program_cycle__program=attacker_payment_plan.program,
+    )
+
+
+def test_move_target_population_into_cycle_of_other_business_area_is_denied(
+    api_client: APIClient,
+    cross_ba_kwargs: dict[str, str],
+    attacker_target_population: PaymentPlan,
+    victim_payment_plan: PaymentPlan,
+) -> None:
+    victim_cycle = victim_payment_plan.program_cycle
+    own_cycle_id = attacker_target_population.program_cycle_id
+    url = reverse(
+        "api:payments:target-populations-detail",
+        kwargs={**cross_ba_kwargs, "pk": str(attacker_target_population.id)},
+    )
+
+    response = api_client.patch(
+        url,
+        {
+            "program_cycle_id": str(victim_cycle.id),
+            "payment_plan_group_id": str(PaymentPlanGroupFactory(cycle=victim_cycle).id),
+        },
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND, response.status_code
+    attacker_target_population.refresh_from_db()
+    assert attacker_target_population.program_cycle_id == own_cycle_id
+
+
+def test_update_target_population_with_fsp_of_other_business_area_keeps_the_old_rules(
+    api_client: APIClient,
+    cross_ba_kwargs: dict[str, str],
+    attacker_payment_plan: PaymentPlan,
+    attacker_target_population: PaymentPlan,
+    victim_fsp: Any,
+) -> None:
+    """The foreign fsp is rejected after the rules are rewritten, so the whole update must roll back."""
+    old_rule = TargetingCriteriaRuleFactory(payment_plan=attacker_target_population, household_ids="HH-0000001")
+    household = HouseholdFactory(
+        business_area=attacker_payment_plan.business_area,
+        program=attacker_payment_plan.program,
+        create_role=False,
+    )
+    url = reverse(
+        "api:payments:target-populations-detail",
+        kwargs={**cross_ba_kwargs, "pk": str(attacker_target_population.id)},
+    )
+
+    response = api_client.patch(
+        url,
+        {
+            "fsp_id": str(victim_fsp.id),
+            "delivery_mechanism_code": victim_fsp.delivery_mechanisms.first().code,
+            "rules": [
+                {
+                    "household_filters_blocks": [],
+                    "household_ids": household.unicef_id,
+                    "individual_ids": "",
+                    "individuals_filters_blocks": [],
+                }
+            ],
+        },
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND, response.status_code
+    assert list(attacker_target_population.rules.values_list("id", flat=True)) == [old_rule.id]
+    attacker_target_population.refresh_from_db()
+    assert attacker_target_population.financial_service_provider is None
+
+
+@pytest.fixture
+def victim_engine_rule(victim_business_area: BusinessArea) -> Any:
+    rule = RuleCommitFactory(rule__type=Rule.TYPE_PAYMENT_PLAN, rule__enabled=True).rule
+    rule.allowed_business_areas.set([victim_business_area])
+    return rule
+
+
+def test_apply_engine_formula_with_rule_of_other_business_area_is_denied(
+    api_client: APIClient,
+    cross_ba_kwargs: dict[str, str],
+    attacker_payment_plan: PaymentPlan,
+    victim_engine_rule: Any,
+) -> None:
+    attacker_payment_plan.status = PaymentPlan.Status.LOCKED
+    attacker_payment_plan.save(update_fields=["status"])
+    url = reverse(
+        "api:payments:payment-plans-apply-engine-formula",
+        kwargs={**cross_ba_kwargs, "pk": str(attacker_payment_plan.id)},
+    )
+
+    response = api_client.post(url, {"engine_formula_rule_id": str(victim_engine_rule.id)}, format="json")
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND, response.status_code
+    attacker_payment_plan.refresh_from_db()
+    assert attacker_payment_plan.background_action_status is None
+
+
+def test_apply_engine_formula_on_target_population_with_rule_of_other_business_area_is_denied(
+    api_client: APIClient,
+    cross_ba_kwargs: dict[str, str],
+    attacker_target_population: PaymentPlan,
+    victim_business_area: BusinessArea,
+) -> None:
+    rule = RuleCommitFactory(rule__type=Rule.TYPE_TARGETING, rule__enabled=True, is_release=True).rule
+    rule.allowed_business_areas.set([victim_business_area])
+    attacker_target_population.status = PaymentPlan.Status.TP_LOCKED
+    attacker_target_population.save(update_fields=["status"])
+    url = reverse(
+        "api:payments:target-populations-apply-engine-formula",
+        kwargs={**cross_ba_kwargs, "pk": str(attacker_target_population.id)},
+    )
+
+    response = api_client.post(url, {"engine_formula_rule_id": str(rule.id)}, format="json")
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND, response.status_code
+    attacker_target_population.refresh_from_db()
+    assert attacker_target_population.steficon_rule_targeting is None

--- a/tests/unit/apps/payment/test_filters.py
+++ b/tests/unit/apps/payment/test_filters.py
@@ -6,7 +6,6 @@ from uuid import uuid4
 from django.http import Http404
 import pytest
 
-from extras.test_utils.factories.activity_log import LogEntryFactory
 from extras.test_utils.factories.core import BusinessAreaFactory
 from extras.test_utils.factories.household import HouseholdFactory
 from extras.test_utils.factories.payment import (
@@ -26,7 +25,6 @@ from hope.apps.payment.filters import (
     PaymentFilter,
     PaymentPlanFilter,
     PaymentVerificationFilter,
-    PaymentVerificationLogEntryFilter,
     PaymentVerificationPlanFilter,
     PaymentVerificationSummaryFilter,
 )
@@ -34,7 +32,6 @@ from hope.models import (
     FinancialServiceProvider,
     FinancialServiceProviderXlsxTemplate,
     Individual,
-    LogEntry,
     Payment,
     PaymentPlan,
     PaymentVerification,
@@ -331,26 +328,6 @@ def test_payment_verification_summary_filter_returns_all(business_area):
     filtered = PaymentVerificationSummaryFilter(data={}, queryset=qs).qs
 
     assert list(filtered.values_list("pk", flat=True)) == [summary.pk]
-
-
-# ---------------------------------------------------------------------------
-# PaymentVerificationLogEntryFilter
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.enable_activity_log
-def test_payment_verification_log_entry_filter_object_id(business_area):
-    plan = PaymentPlanFactory(business_area=business_area, status=PaymentPlan.Status.FINISHED)
-    pvp_a = PaymentVerificationPlanFactory(payment_plan=plan)
-    pvp_b = PaymentVerificationPlanFactory(payment_plan=plan)
-    matching_a = LogEntryFactory(business_area=business_area, object_id=pvp_a.pk)
-    matching_b = LogEntryFactory(business_area=business_area, object_id=pvp_b.pk)
-    LogEntryFactory(business_area=business_area, object_id=uuid4())
-
-    qs = LogEntry.objects.all()
-    filtered = PaymentVerificationLogEntryFilter(data={"object_id": str(plan.pk)}, queryset=qs).qs
-
-    assert set(filtered.values_list("pk", flat=True)) == {matching_a.pk, matching_b.pk}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/apps/payment/test_payment_plan_actions_views.py
+++ b/tests/unit/apps/payment/test_payment_plan_actions_views.py
@@ -814,6 +814,7 @@ def test_apply_engine_formula_pp(
         payment_plan_actions_context["program_active"],
     )
     rule_for_pp = RuleCommitFactory(rule__type=Rule.TYPE_PAYMENT_PLAN, rule__enabled=True, version=11).rule
+    rule_for_pp.allowed_business_areas.add(payment_plan_actions_context["business_area"])
     payment_plan_actions_context["pp"].status = PaymentPlan.Status.LOCKED
     payment_plan_actions_context["pp"].save()
     payment_plan_actions_context["pp"].refresh_from_db()
@@ -847,6 +848,7 @@ def test_apply_engine_formula_pp_validation_errors(
         payment_plan_actions_context["program_active"],
     )
     rule_for_pp = RuleCommitFactory(rule__type=Rule.TYPE_PAYMENT_PLAN, rule__enabled=False, version=22).rule
+    rule_for_pp.allowed_business_areas.add(payment_plan_actions_context["business_area"])
     payment_plan_actions_context["pp"].status = PaymentPlan.Status.LOCKED
     payment_plan_actions_context["pp"].save()
 
@@ -1046,6 +1048,7 @@ def test_entitlement_actions_are_blocked_for_follow_up_payment_plans(
 
     if url_key == "url_apply_steficon":
         rule_for_pp = RuleCommitFactory(rule__type=Rule.TYPE_PAYMENT_PLAN, rule__enabled=True, version=99).rule
+        rule_for_pp.allowed_business_areas.add(payment_plan_actions_context["business_area"])
         payload = {
             "engine_formula_rule_id": str(rule_for_pp.pk),
             "version": payment_plan_actions_context["pp"].version,
@@ -2045,6 +2048,7 @@ def test_apply_engine_formula_without_version_skips_concurrency_check(
         payment_plan_actions_context["program_active"],
     )
     rule = RuleCommitFactory(rule__type=Rule.TYPE_PAYMENT_PLAN, rule__enabled=True, version=12).rule
+    rule.allowed_business_areas.add(payment_plan_actions_context["business_area"])
     payment_plan_actions_context["pp"].status = PaymentPlan.Status.LOCKED
     payment_plan_actions_context["pp"].save()
 
@@ -2067,6 +2071,7 @@ def test_apply_engine_formula_rejects_when_rule_engine_already_running(
         payment_plan_actions_context["program_active"],
     )
     rule = RuleCommitFactory(rule__type=Rule.TYPE_PAYMENT_PLAN, rule__enabled=True, version=13).rule
+    rule.allowed_business_areas.add(payment_plan_actions_context["business_area"])
     payment_plan_actions_context["pp"].status = PaymentPlan.Status.LOCKED
     payment_plan_actions_context["pp"].background_action_status = PaymentPlan.BackgroundActionStatus.RULE_ENGINE_RUN
     payment_plan_actions_context["pp"].save()

--- a/tests/unit/apps/payment/test_payment_plan_services.py
+++ b/tests/unit/apps/payment/test_payment_plan_services.py
@@ -55,6 +55,7 @@ from hope.apps.payment.flows import PaymentPlanFlow
 from hope.apps.payment.services.payment_plan_services import PaymentPlanService
 from hope.models import (
     AccountType,
+    BusinessArea,
     DeliveryMechanism,
     FileTemp,
     FinancialServiceProvider,
@@ -114,12 +115,15 @@ def dm_transfer_to_digital_wallet() -> Any:
 
 
 @pytest.fixture
-def fsp(dm_transfer_to_account: Any, dm_transfer_to_digital_wallet: Any) -> FinancialServiceProvider:
+def fsp(
+    business_area: BusinessArea, dm_transfer_to_account: Any, dm_transfer_to_digital_wallet: Any
+) -> FinancialServiceProvider:
     fsp = FinancialServiceProviderFactory(
         name="Test FSP 1",
         communication_channel=FinancialServiceProvider.COMMUNICATION_CHANNEL_API,
     )
     fsp.delivery_mechanisms.add(dm_transfer_to_account, dm_transfer_to_digital_wallet)
+    fsp.allowed_business_areas.add(business_area)
     return fsp
 
 
@@ -268,7 +272,7 @@ def test_create_validation_errors(user: User, business_area: Any) -> None:
         PaymentPlanService.create(
             input_data=create_input_data,
             user=user,
-            business_area_slug=business_area.slug,
+            program=program,
         )
     assert error.value.detail[0] == f"Target Population with name: TEST_123 and program: {program.name} already exists."
 
@@ -279,7 +283,7 @@ def test_create_validation_errors(user: User, business_area: Any) -> None:
         PaymentPlanService.create(
             input_data=create_input_data,
             user=user,
-            business_area_slug=business_area.slug,
+            program=program,
         )
     assert error.value.detail[0] == "Impossible to create Target Population for Programme within not Active status"
 
@@ -289,7 +293,7 @@ def test_create_validation_errors(user: User, business_area: Any) -> None:
         PaymentPlanService.create(
             input_data=create_input_data,
             user=user,
-            business_area_slug=business_area.slug,
+            program=program,
         )
     assert error.value.detail[0] == "Impossible to create Target Population for Programme Cycle within Finished status"
 
@@ -306,7 +310,7 @@ def test_create_validation_errors(user: User, business_area: Any) -> None:
     pp = PaymentPlanService.create(
         input_data=create_input_data,
         user=user,
-        business_area_slug=business_area.slug,
+        program=program,
     )
     pp.status = PaymentPlan.Status.TP_OPEN
     pp.save()
@@ -402,11 +406,11 @@ def test_create(
     }
 
     with mock.patch("hope.apps.payment.services.payment_plan_services.transaction") as mock_transaction:
-        with django_assert_num_queries(25):
+        with django_assert_num_queries(23):
             pp = PaymentPlanService.create(
                 input_data=input_data,
                 user=user,
-                business_area_slug=business_area.slug,
+                program=program,
             )
         assert mock_transaction.on_commit.call_count == 1
 
@@ -443,7 +447,7 @@ def test_create_raises_when_payment_plan_group_belongs_to_different_cycle(user: 
     }
 
     with pytest.raises(ValidationError) as error:
-        PaymentPlanService.create(input_data=input_data, user=user, business_area_slug=business_area.slug)
+        PaymentPlanService.create(input_data=input_data, user=user, program=program)
     assert error.value.detail[0] == "Payment Plan Group does not exist in the given Programme Cycle."
 
 
@@ -462,7 +466,7 @@ def test_create_raises_when_payment_plan_group_does_not_exist(user: User, busine
     }
 
     with pytest.raises(ValidationError) as error:
-        PaymentPlanService.create(input_data=input_data, user=user, business_area_slug=business_area.slug)
+        PaymentPlanService.create(input_data=input_data, user=user, program=program)
     assert error.value.detail[0] == "Payment Plan Group does not exist in the given Programme Cycle."
 
 
@@ -995,7 +999,7 @@ def test_create_with_program_cycle_validation_error(user: User, business_area: A
         PaymentPlanService.create(
             input_data=input_data,
             user=user,
-            business_area_slug=business_area.slug,
+            program=program,
         )
     assert error.value.detail[0] == "Impossible to create Target Population for Programme Cycle within Finished status"
 
@@ -1006,7 +1010,7 @@ def test_create_with_program_cycle_validation_error(user: User, business_area: A
     PaymentPlanService.create(
         input_data=input_data,
         user=user,
-        business_area_slug=business_area.slug,
+        program=program,
     )
     cycle.refresh_from_db()
     assert cycle.status == ProgramCycle.DRAFT
@@ -1060,11 +1064,11 @@ def test_full_rebuild(
         "payment_plan_purposes": [purpose],
     }
     with mock.patch("hope.apps.payment.services.payment_plan_services.transaction") as mock_transaction:
-        with django_assert_num_queries(18):
+        with django_assert_num_queries(16):
             pp = PaymentPlanService.create(
                 input_data=input_data,
                 user=user,
-                business_area_slug=business_area.slug,
+                program=program,
             )
         assert mock_transaction.on_commit.call_count == 1
 

--- a/tests/unit/apps/payment/test_payment_plan_supporting_documents.py
+++ b/tests/unit/apps/payment/test_payment_plan_supporting_documents.py
@@ -11,6 +11,7 @@ from extras.test_utils.factories import (
     BusinessAreaFactory,
     PaymentPlanFactory,
     PaymentPlanSupportingDocumentFactory,
+    ProgramFactory,
     UserFactory,
 )
 from hope.apps.account.permissions import Permissions
@@ -29,7 +30,7 @@ def business_area() -> Any:
 def payment_plan(business_area: Any) -> PaymentPlan:
     return PaymentPlanFactory(
         status=PaymentPlan.Status.OPEN,
-        business_area=business_area,
+        program_cycle__program=ProgramFactory(business_area=business_area),
     )
 
 

--- a/tests/unit/apps/payment/test_payment_signature.py
+++ b/tests/unit/apps/payment/test_payment_signature.py
@@ -149,6 +149,7 @@ def test_signature_after_prepare_payment_plan(
 ) -> None:
     DeliveryMechanismFactory(code="cash", name="Cash")
     fsp = FinancialServiceProviderFactory()
+    fsp.allowed_business_areas.add(business_area)
 
     hoh1 = IndividualFactory(household=None, program=program, business_area=business_area)
     hoh2 = IndividualFactory(household=None, program=program, business_area=business_area)
@@ -210,7 +211,7 @@ def test_signature_after_prepare_payment_plan(
         pp = PaymentPlanService.create(
             input_data=input_data,
             user=user,
-            business_area_slug=business_area.slug,
+            program=program,
         )
 
     pp.refresh_from_db()

--- a/tests/unit/apps/payment/test_payment_verification_plan_view.py
+++ b/tests/unit/apps/payment/test_payment_verification_plan_view.py
@@ -1219,13 +1219,21 @@ def test_record_viewset_get_object_returns_parent_payment_plan(
     verification_context: dict[str, Any],
 ) -> None:
     viewset = PaymentVerificationRecordViewSet()
-    viewset.kwargs = {"payment_verification_pk": str(verification_context["payment_plan"].pk)}
+    viewset.kwargs = {
+        "business_area_slug": verification_context["business_area"].slug,
+        "program_code": verification_context["program_active"].code,
+        "payment_verification_pk": str(verification_context["payment_plan"].pk),
+    }
     assert viewset.get_object() == verification_context["payment_plan"]
 
 
-def test_record_viewset_get_object_raises_404_for_unknown_id() -> None:
+def test_record_viewset_get_object_raises_404_for_unknown_id(verification_context: dict[str, Any]) -> None:
     viewset = PaymentVerificationRecordViewSet()
-    viewset.kwargs = {"payment_verification_pk": "00000000-0000-0000-0000-000000000000"}
+    viewset.kwargs = {
+        "business_area_slug": verification_context["business_area"].slug,
+        "program_code": verification_context["program_active"].code,
+        "payment_verification_pk": "00000000-0000-0000-0000-000000000000",
+    }
     with pytest.raises(Http404):
         viewset.get_object()
 

--- a/tests/unit/apps/payment/test_target_population_views.py
+++ b/tests/unit/apps/payment/test_target_population_views.py
@@ -963,6 +963,7 @@ def test_create_tp_rejects_fsp_conflicting_with_group(
         status=PaymentPlan.Status.TP_OPEN,
     )
     different_fsp = FinancialServiceProviderFactory()
+    different_fsp.allowed_business_areas.add(target_population_create_update_context["business_area"])
 
     response = target_population_create_update_context["client"].post(
         target_population_create_update_context["create_url"],
@@ -1007,6 +1008,7 @@ def test_update_tp_rejects_fsp_conflicting_with_group(
         status=PaymentPlan.Status.TP_OPEN,
     )
     different_fsp = FinancialServiceProviderFactory()
+    different_fsp.allowed_business_areas.add(target_population_create_update_context["business_area"])
 
     response = target_population_create_update_context["client"].patch(
         target_population_create_update_context["update_url"],
@@ -1038,6 +1040,7 @@ def test_update_tp_rejects_group_change_with_fsp_conflict(
     tp.save()
     new_group = PaymentPlanGroupFactory(cycle=cycle)
     different_fsp = FinancialServiceProviderFactory()
+    different_fsp.allowed_business_areas.add(target_population_create_update_context["business_area"])
     PaymentPlanFactory(
         business_area=target_population_create_update_context["business_area"],
         program_cycle=cycle,
@@ -1381,6 +1384,7 @@ def test_apply_engine_formula_tp(
         version=11,
         is_release=True,
     ).rule
+    rule_for_tp.allowed_business_areas.add(target_population_actions_context["business_area"])
     target_population_actions_context["target_population"].status = PaymentPlan.Status.TP_LOCKED
     target_population_actions_context["target_population"].save()
     data = {
@@ -1412,6 +1416,7 @@ def test_apply_engine_formula_tp_validation_errors(
         target_population_actions_context["program_active"],
     )
     rule_for_tp = RuleCommitFactory(rule__type=Rule.TYPE_TARGETING, rule__enabled=False, version=22).rule
+    rule_for_tp.allowed_business_areas.add(target_population_actions_context["business_area"])
     target_population_actions_context["target_population"].status = PaymentPlan.Status.TP_STEFICON_ERROR
     target_population_actions_context["target_population"].save()
 
@@ -1545,6 +1550,7 @@ def test_vulnerability_score_filter_applies_correctly(
     steficon_rule_commit = RuleCommitFactory(
         rule__type=Rule.TYPE_TARGETING, rule__enabled=True, enabled=True, is_release=True
     )
+    steficon_rule_commit.rule.allowed_business_areas.add(target_population_actions_context["business_area"])
     target_population_actions_context["target_population"].save()
     target_population_actions_context["target_population"].refresh_from_db()
 
@@ -1680,6 +1686,7 @@ def test_vulnerability_score_filter_set_before_engine_formula(
     steficon_rule_commit = RuleCommitFactory(
         rule__type=Rule.TYPE_TARGETING, rule__enabled=True, enabled=True, is_release=True
     )
+    steficon_rule_commit.rule.allowed_business_areas.add(target_population_actions_context["business_area"])
     target_population_actions_context["target_population"].save()
     target_population_actions_context["target_population"].refresh_from_db()
 
@@ -1873,6 +1880,7 @@ def test_apply_engine_formula_tp_without_version_skips_concurrency_check(
         version=33,
         is_release=True,
     ).rule
+    rule_for_tp.allowed_business_areas.add(target_population_actions_context["business_area"])
     target_population_actions_context["target_population"].status = PaymentPlan.Status.TP_LOCKED
     target_population_actions_context["target_population"].save()
 


### PR DESCRIPTION
Split out of #6309. **Based on `feature/fix-cross-ba-idor-core`** — the base retargets to develop once that merges.

## Problem

Every lookup under a payment plan took an id and never compared it with the program of the path: the plan itself, its verification plans, its verification records, and its supporting documents.

`PaymentPlanService.create` took a business area slug and read the program from the cycle the caller named — so a cycle of another program decided which program the plan landed in.

`update` was not atomic: a foreign provider rejected *after* the targeting rules were rewritten left the rules replaced and the plan unsaved.

## Fix

- `ScopedPaymentPlanMixin` resolves the plan of the path once, and the verification plans, records and documents hang off it
- `PaymentPlanService.create` takes the program of the path and scopes the cycle to it — which also drops two queries per call
- `update` is wrapped in a transaction, addressing @MarekBiczysko's review on #6309
- `PaymentVerificationLogEntryFilter` is deleted; no view referenced it

The one payment change that needs the `ScopedRelatedField` mechanism — the `cycle` field on `PaymentPlanGroupCreateSerializer` — stays in #6309.

Part of GHSA-2xf8-jjc2-9pmv.
