### PR TITLE
Grievance Dashboard 500s on a Beneficiary ticket with an admin area

### DIFF
--- a/src/frontend/src/components/grievances/GrievancesDashboard/charts/TicketsByLocationAndCategoryChart.tsx
+++ b/src/frontend/src/components/grievances/GrievancesDashboard/charts/TicketsByLocationAndCategoryChart.tsx
@@ -46,6 +46,20 @@ export const TicketsByLocationAndCategoryChart: FC<
 
   const options: any = {
     indexAxis: 'y',
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+      datalabels: {
+        anchor: 'start',
+        align: 'left',
+        offset: 4,
+        color: '#FFF',
+        font: {
+          weight: 'bold',
+        },
+        formatter: formatThousands,
+      },
+    },
     legend: {
       labels: {
         padding: 40,
@@ -55,8 +69,9 @@ export const TicketsByLocationAndCategoryChart: FC<
       x: {
         display: true,
         position: 'top',
-        beginAtZero: true,
         ticks: {
+          beginAtZero: true,
+          stepSize: 1,
           callback: formatThousands,
         },
       },
@@ -69,13 +84,16 @@ export const TicketsByLocationAndCategoryChart: FC<
     },
   };
 
+  const visibleRowCount = matchDataSize(data.labels).length;
+  const chartHeight = Math.max(400, visibleRowCount * 45 + 80);
+
   return (
     <Box
       sx={{
         flexDirection: 'column',
       }}
     >
-      <div style={{ height: '400px' }}>
+      <div style={{ height: `${chartHeight}px` }}>
         <Bar data={chartData} options={options} plugins={[ChartDataLabels]} />
       </div>
       {data.labels.length > lessDataCount ? (

--- a/src/frontend/src/components/grievances/GrievancesTable/GrievancesFilters.tsx
+++ b/src/frontend/src/components/grievances/GrievancesTable/GrievancesFilters.tsx
@@ -86,7 +86,7 @@ export const GrievancesFilters = ({
 
   const categoryChoices = useMemo(() => {
     if (isUserGeneratedTab)
-      return choicesData.grievanceTicketManualCategoryChoices;
+      return choicesData.grievanceTicketFilterCategoryChoices;
     // Data Change is a manual category, but it also owns a system-generated issue type
     // (Biometric Photo Error), so it has to be selectable on the system tab too.
     const dataChangeCategory = choicesData.grievanceTicketCategoryChoices?.find(

--- a/src/frontend/src/components/grievances/utils/createGrievanceUtils.ts
+++ b/src/frontend/src/components/grievances/utils/createGrievanceUtils.ts
@@ -444,6 +444,7 @@ export const categoriesAndColors = [
   { category: 'Referral', color: '#FFAA20' },
   { category: 'Sensitive Grievance', color: '#7FCB28' },
   { category: 'System Flagging', color: '#00867B' },
+  { category: 'Beneficiary', color: '#8B5CF6' },
 ];
 
 /**

--- a/src/hope/apps/grievance/api/serializers/grievance_ticket.py
+++ b/src/hope/apps/grievance/api/serializers/grievance_ticket.py
@@ -315,7 +315,7 @@ class GrievanceChoicesSerializer(serializers.Serializer):
         return to_choice_object(GrievanceTicket.CREATE_CATEGORY_CHOICES)
 
     def get_grievance_ticket_filter_category_choices(self, info: Any, **kwargs: Any) -> list[dict[str, Any]]:
-        """All non system-generated categories"""
+        """All non system-generated categories."""
         return to_choice_object(GrievanceTicket.MANUAL_CATEGORIES)
 
     def get_grievance_ticket_system_category_choices(self, info: Any, **kwargs: Any) -> list[dict[str, Any]]:

--- a/src/hope/apps/grievance/api/serializers/grievance_ticket.py
+++ b/src/hope/apps/grievance/api/serializers/grievance_ticket.py
@@ -292,6 +292,7 @@ class GrievanceChoicesSerializer(serializers.Serializer):
     grievance_ticket_status_choices = serializers.SerializerMethodField()
     grievance_ticket_category_choices = serializers.SerializerMethodField()
     grievance_ticket_manual_category_choices = serializers.SerializerMethodField()
+    grievance_ticket_filter_category_choices = serializers.SerializerMethodField()
     grievance_ticket_system_category_choices = serializers.SerializerMethodField()
     grievance_ticket_priority_choices = serializers.SerializerMethodField()
     grievance_ticket_urgency_choices = serializers.SerializerMethodField()
@@ -310,7 +311,12 @@ class GrievanceChoicesSerializer(serializers.Serializer):
         return to_choice_object(GrievanceTicket.CATEGORY_CHOICES)
 
     def get_grievance_ticket_manual_category_choices(self, info: Any, **kwargs: Any) -> list[dict[str, Any]]:
+        """Categories a user is allowed to create a ticket in."""
         return to_choice_object(GrievanceTicket.CREATE_CATEGORY_CHOICES)
+
+    def get_grievance_ticket_filter_category_choices(self, info: Any, **kwargs: Any) -> list[dict[str, Any]]:
+        """All non system-generated categories"""
+        return to_choice_object(GrievanceTicket.MANUAL_CATEGORIES)
 
     def get_grievance_ticket_system_category_choices(self, info: Any, **kwargs: Any) -> list[dict[str, Any]]:
         return to_choice_object(GrievanceTicket.SYSTEM_CATEGORIES)

--- a/src/hope/apps/grievance/services/dashboard_datasets.py
+++ b/src/hope/apps/grievance/services/dashboard_datasets.py
@@ -14,28 +14,34 @@ from django.utils.encoding import force_str
 from hope.apps.grievance.models import GrievanceTicket
 from hope.models import Area
 
-TICKET_ORDERING_KEYS = [
-    "Data Change",
-    "Grievance Complaint",
-    "Needs Adjudication",
-    "Negative Feedback",
-    "Payment Verification",
-    "Positive Feedback",
-    "Referral",
-    "Sensitive Grievance",
-    "System Flagging",
-]
 
-TICKET_ORDERING = {
-    "Data Change": 0,
-    "Grievance Complaint": 1,
-    "Needs Adjudication": 2,
-    "Negative Feedback": 3,
-    "Payment Verification": 4,
-    "Positive Feedback": 5,
-    "Referral": 6,
-    "Sensitive Grievance": 7,
-    "System Flagging": 8,
+def choice_labels(choices: tuple) -> dict[Any, str]:
+    return {value: force_str(label) for value, label in choices}
+
+
+TICKET_ORDERING_CODES = (
+    GrievanceTicket.CATEGORY_DATA_CHANGE,
+    GrievanceTicket.CATEGORY_GRIEVANCE_COMPLAINT,
+    GrievanceTicket.CATEGORY_NEEDS_ADJUDICATION,
+    GrievanceTicket.CATEGORY_NEGATIVE_FEEDBACK,
+    GrievanceTicket.CATEGORY_PAYMENT_VERIFICATION,
+    GrievanceTicket.CATEGORY_POSITIVE_FEEDBACK,
+    GrievanceTicket.CATEGORY_REFERRAL,
+    GrievanceTicket.CATEGORY_SENSITIVE_GRIEVANCE,
+    GrievanceTicket.CATEGORY_SYSTEM_FLAGGING,
+    GrievanceTicket.CATEGORY_BENEFICIARY,
+)
+
+
+class Series(TypedDict):
+    index: int
+    label: str
+
+
+_CATEGORY_LABELS = choice_labels(GrievanceTicket.CATEGORY_CHOICES)
+
+TICKET_SERIES: dict[int, Series] = {
+    code: Series(index=index, label=_CATEGORY_LABELS[code]) for index, code in enumerate(TICKET_ORDERING_CODES)
 }
 
 
@@ -58,10 +64,6 @@ def transform_to_chart_dataset(rows: Iterable[tuple[Any, Any]]) -> dict[str, Any
         data.append(value)
 
     return {"labels": labels, "datasets": [{"data": data}]}
-
-
-def choice_labels(choices: tuple) -> dict[Any, str]:
-    return {value: force_str(label) for value, label in choices}
 
 
 def is_user_generated(category: int, issue_type: int | None) -> bool:
@@ -164,29 +166,33 @@ class TicketsByChoice(DashboardDataset):
 class TicketsByLocationAndCategory(DashboardDataset):
     """Per-admin2 category breakdown, one row per area name and one series per category."""
 
-    per_area: dict[Any, list[int]] = field(default_factory=lambda: defaultdict(lambda: [0] * len(TICKET_ORDERING_KEYS)))
-    labels: dict[Any, str] = field(init=False)
-
-    def __post_init__(self) -> None:
-        self.labels = choice_labels(GrievanceTicket.CATEGORY_CHOICES)
+    per_area: dict[Any, list[int]] = field(default_factory=lambda: defaultdict(lambda: [0] * len(TICKET_SERIES)))
 
     def add(self, group: TicketGroup) -> None:
-        if group["admin2"] is None:
+        admin2, category = group["admin2"], group["category"]
+
+        if admin2 is None:
             return
-        self.per_area[group["admin2"]][TICKET_ORDERING[self.labels[group["category"]]]] += group["ticket_count"]
+
+        category_index = TICKET_SERIES[category]["index"]
+        self.per_area[admin2][category_index] += group["ticket_count"]
 
     def result(self) -> dict[str, Any]:
         rows: dict[str, list[int]] = {}
         for name, area_id in Area.objects.filter(id__in=list(self.per_area)).order_by("name").values_list("name", "id"):
-            row = rows.setdefault(name, [0] * len(TICKET_ORDERING_KEYS))
+            row = rows.setdefault(name, [0] * len(TICKET_SERIES))
             for index, count in enumerate(self.per_area[area_id]):
                 row[index] += count
 
-        columns = list(zip(*rows.values(), strict=True)) if rows else []
+        if not rows:
+            return {"labels": [], "datasets": []}
+
+        columns = zip(*rows.values(), strict=True)
         return {
             "labels": list(rows),
             "datasets": [
-                {"label": TICKET_ORDERING_KEYS[index], "data": list(column)} for index, column in enumerate(columns)
+                {"label": series["label"], "data": list(column)}
+                for series, column in zip(TICKET_SERIES.values(), columns, strict=True)
             ],
         }
 

--- a/tests/unit/apps/grievance/test_grievance_choices.py
+++ b/tests/unit/apps/grievance/test_grievance_choices.py
@@ -92,6 +92,7 @@ def test_get_choices(
         "grievance_ticket_status_choices": to_choice_object(GrievanceTicket.STATUS_CHOICES),
         "grievance_ticket_category_choices": to_choice_object(GrievanceTicket.CATEGORY_CHOICES),
         "grievance_ticket_manual_category_choices": to_choice_object(GrievanceTicket.CREATE_CATEGORY_CHOICES),
+        "grievance_ticket_filter_category_choices": to_choice_object(GrievanceTicket.MANUAL_CATEGORIES),
         "grievance_ticket_system_category_choices": to_choice_object(GrievanceTicket.SYSTEM_CATEGORIES),
         "grievance_ticket_priority_choices": to_choice_object(PRIORITY_CHOICES),
         "grievance_ticket_urgency_choices": to_choice_object(URGENCY_CHOICES),

--- a/tests/unit/apps/grievance/test_grievance_dashboard_api.py
+++ b/tests/unit/apps/grievance/test_grievance_dashboard_api.py
@@ -4,6 +4,7 @@ from typing import Any, Callable
 from django.db import connection
 from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
+from django.utils.encoding import force_str
 import pytest
 from rest_framework import status
 
@@ -19,6 +20,7 @@ from extras.test_utils.factories import (
 from extras.test_utils.sql import joined_tables, statements_from
 from hope.apps.account.permissions import Permissions
 from hope.apps.grievance.models import GrievanceTicket
+from hope.apps.grievance.services.dashboard_datasets import TICKET_SERIES
 from hope.models import Program
 
 pytestmark = pytest.mark.django_db
@@ -546,6 +548,18 @@ def ticket_without_admin_area(dashboard_context: dict[str, Any]) -> Any:
 
 
 @pytest.fixture
+def beneficiary_ticket_with_admin_area(dashboard_context: dict[str, Any]) -> Any:
+    return GrievanceTicketFactory(
+        category=GrievanceTicket.CATEGORY_BENEFICIARY,
+        issue_type=None,
+        status=GrievanceTicket.STATUS_NEW,
+        created_by=dashboard_context["user"],
+        business_area=dashboard_context["business_area"],
+        admin2=dashboard_context["tickets"][0].admin2,
+    )
+
+
+@pytest.fixture
 def two_referral_tickets(dashboard_context: dict[str, Any]) -> None:
     GrievanceTicketFactory.create_batch(
         2,
@@ -694,6 +708,7 @@ def test_global_dashboard_counts_tickets_per_area_and_category(
             {"label": "Referral", "data": [0]},
             {"label": "Sensitive Grievance", "data": [0]},
             {"label": "System Flagging", "data": [0]},
+            {"label": "Beneficiary", "data": [0]},
         ],
     }
 
@@ -741,3 +756,32 @@ def test_global_dashboard_omits_tickets_without_an_admin_area_from_the_location_
     assert {"label": "Referral", "data": [0]} in chart["datasets"]
     # the ticket is still counted everywhere the area is not the key
     assert data["tickets_by_type"]["user_generated_count"] == 5
+
+
+def test_global_dashboard_charts_a_beneficiary_ticket_that_has_an_admin_area(
+    authenticated_client: Any,
+    dashboard_context: dict[str, Any],
+    beneficiary_ticket_with_admin_area: Any,
+    create_user_role_with_permissions: Callable,
+) -> None:
+    create_user_role_with_permissions(
+        dashboard_context["user"],
+        [Permissions.GRIEVANCES_VIEW_LIST_EXCLUDING_SENSITIVE],
+        dashboard_context["business_area"],
+        whole_business_area_access=True,
+    )
+
+    response = authenticated_client.get(dashboard_context["global_url"])
+
+    assert response.status_code == status.HTTP_200_OK
+    chart = response.json()["tickets_by_location_and_category"]
+    assert chart["labels"] == ["City Test"]
+    assert chart["datasets"][-1] == {"label": "Beneficiary", "data": [1]}
+
+
+def test_location_chart_ordering_covers_every_ticket_category() -> None:
+    assert set(TICKET_SERIES) == {code for code, _label in GrievanceTicket.CATEGORY_CHOICES}
+    assert [series["index"] for series in TICKET_SERIES.values()] == list(range(len(GrievanceTicket.CATEGORY_CHOICES)))
+    assert [series["label"] for series in TICKET_SERIES.values()] == [
+        force_str(dict(GrievanceTicket.CATEGORY_CHOICES)[code]) for code in TICKET_SERIES
+    ]


### PR DESCRIPTION
[AB#338025](https://unicef.visualstudio.com/4e044e8d-bc28-4768-8074-f80ff6e4a0e5/_workitems/edit/338025)

## Why
`/grievance/dashboard` 500s (KeyError) whenever a Beneficiary ticket has an admin area: the location chart's category ordering was a hardcoded list of 9 names, while CATEGORY_CHOICES has 10. Pre-existing on develop.

## What
- dashboard_datasets: replace TICKET_ORDERING_KEYS/TICKET_ORDERING with TICKET_SERIES built from the category codes + their labels; index by code, not by translated label.
- FE: add the Beneficiary colour to categoriesAndColors.
- FE: grow the tickets-by-location chart with the row count instead of a fixed 400px, and configure the datalabels plugin (it was registered with no options, so the values rendered unformatted and collided with the bars) - now anchored at the start of the bar, white/bold, formatted with formatThousands.
- API: new grievance_ticket_filter_category_choices on the choices endpoint (all non system-generated categories); the ticket list filter uses it instead of the create-only manual choices, which hid Beneficiary and Positive/Negative Feedback.

FE Before (only on larger screens):
<img width="1499" height="799" alt="Screenshot 2026-08-27 at 14 26 20" src="https://github.com/user-attachments/assets/ead96816-77d3-45c7-a237-2d7ccb4cf7b7" />

FE After:
<img width="1506" height="570" alt="Screenshot 2026-08-27 at 14 38 16" src="https://github.com/user-attachments/assets/d295db9e-a165-4ba2-a771-6da5c6ada73d" />

---
### Show More Locations:
FE Before:
<img width="951" height="567" alt="Screenshot 2026-08-28 at 09 08 07" src="https://github.com/user-attachments/assets/7bf137a7-c615-430b-8703-a7755092b599" />

FE After:
<img width="3966" height="5600" alt="localhost_3000_grievance-bench-prod_programs_all_grievance_dashboard (1)" src="https://github.com/user-attachments/assets/73caa640-cc00-4139-b094-afbd9be4f54c" />
