### PR TITLE
Add ScopedRelatedField and scope core field attributes per action

### DIFF
--- a/src/hope/apps/core/api/fields.py
+++ b/src/hope/apps/core/api/fields.py
@@ -1,0 +1,34 @@
+from typing import Any
+
+from django.db.models import QuerySet
+from rest_framework import serializers
+
+
+class ScopedRelatedFieldMixin:
+    """Narrows the queryset to the scope of the url path, so an id from outside of it fails like a nonexistent one.
+
+    The field relies on two things: the view has to put the scope object in the serializer context
+    under the `scope` key (`BusinessAreaMixin`/`ProgramMixin` do), and `scope_path` has to be a valid
+    ORM path from the queryset model to that object (defaults to the `scope` name itself).
+    """
+
+    def __init__(self, *args: Any, scope: str = "business_area", scope_path: str | None = None, **kwargs: Any) -> None:
+        self.scope = scope
+        self.scope_path = scope_path or scope
+        super().__init__(*args, **kwargs)
+
+    def get_queryset(self) -> QuerySet:
+        if self.scope not in self.context:
+            raise KeyError(
+                f"'{self.scope}' is missing from the serializer context;"
+                f" the view has to provide it for {type(self).__name__}"
+            )
+        return super().get_queryset().filter(**{self.scope_path: self.context[self.scope]})
+
+
+class ScopedRelatedField(ScopedRelatedFieldMixin, serializers.PrimaryKeyRelatedField):
+    pass
+
+
+class ScopedSlugRelatedField(ScopedRelatedFieldMixin, serializers.SlugRelatedField):
+    pass

--- a/src/hope/apps/core/api/mixins.py
+++ b/src/hope/apps/core/api/mixins.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any, Mapping
 
 from django.conf import settings
 from django.db.models import Exists, ManyToManyField, Model, OuterRef, Q, QuerySet
+from django.utils.functional import SimpleLazyObject
 from drf_spectacular.utils import extend_schema, inline_serializer
 from requests import Response, session
 from requests.adapters import HTTPAdapter
@@ -138,6 +139,12 @@ class BusinessAreaMixin:
 
         return get_object_or_404(BusinessArea, slug=self.business_area_slug)
 
+    def get_serializer_context(self) -> dict:
+        context = super().get_serializer_context()
+        # lazy: only the scoped fields pay for the lookup, plain views keep their query count
+        context["business_area"] = SimpleLazyObject(lambda: self.business_area)
+        return context
+
     def get_queryset(self) -> QuerySet:
         return super().get_queryset().filter(**{f"{self.business_area_model_field}": self.business_area})
 
@@ -204,7 +211,7 @@ class BusinessAreaProgramsAccessMixin(BusinessAreaMixin):
 
         program_ids = self.request.user.get_program_ids_for_permissions_in_business_area(
             self.business_area.id,
-            self.PERMISSIONS,
+            self.get_permissions_for_action(),
         )
 
         if self.program_model_field_is_many:

--- a/src/hope/apps/core/api/views.py
+++ b/src/hope/apps/core/api/views.py
@@ -6,6 +6,7 @@ from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework.decorators import action
 from rest_framework.filters import OrderingFilter
+from rest_framework.generics import get_object_or_404
 from rest_framework.mixins import ListModelMixin, RetrieveModelMixin
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
@@ -44,6 +45,7 @@ from hope.models import (
     PaymentVerification,
     PaymentVerificationPlan,
     PaymentVerificationSummary,
+    Program,
     RoleAssignment,
 )
 
@@ -113,6 +115,9 @@ class BusinessAreaViewSet(
     def all_fields_attributes(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         program_id = request.query_params.get("program_id", None)
         business_area_slug = self.kwargs["slug"]
+        if program_id:
+            # checked for scope only, the generator below takes the id
+            get_object_or_404(Program, id=program_id, business_area__slug=business_area_slug)
         result_list = get_fields_attr_generators(business_area_slug=business_area_slug, program_id=program_id)
         return Response(FieldAttributeSerializer(result_list, many=True).data, status=200)
 

--- a/tests/unit/apps/core/test_cross_business_area_access.py
+++ b/tests/unit/apps/core/test_cross_business_area_access.py
@@ -1,0 +1,66 @@
+"""Cross business area scoping of the field attribute lookup (GHSA-2xf8-jjc2-9pmv)."""
+
+from typing import Any, Callable
+
+import pytest
+from rest_framework import status
+from rest_framework.reverse import reverse
+
+from extras.test_utils.factories import BusinessAreaFactory, FlexibleAttributeForPDUFactory, ProgramFactory, UserFactory
+from hope.models import BusinessArea, Program, User
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def attacker_business_area() -> BusinessArea:
+    return BusinessAreaFactory(name="Afghanistan", slug="afghanistan")
+
+
+@pytest.fixture
+def attacker(attacker_business_area: BusinessArea, create_user_role_with_permissions: Callable) -> User:
+    user = UserFactory()
+    create_user_role_with_permissions(user, [], attacker_business_area, whole_business_area_access=True)
+    return user
+
+
+@pytest.fixture
+def authenticated_client(api_client: Callable, attacker: User) -> Any:
+    return api_client(attacker)
+
+
+@pytest.fixture
+def own_program(attacker_business_area: BusinessArea) -> Program:
+    program = ProgramFactory(business_area=attacker_business_area)
+    FlexibleAttributeForPDUFactory(program=program, label="Own round")
+    return program
+
+
+@pytest.fixture
+def victim_program() -> Program:
+    program = ProgramFactory(business_area=BusinessAreaFactory(name="Ukraine", slug="ukraine"))
+    FlexibleAttributeForPDUFactory(program=program, label="Secret round")
+    return program
+
+
+@pytest.fixture
+def url(attacker_business_area: BusinessArea) -> str:
+    return reverse("api:core:business-areas-all-fields-attributes", kwargs={"slug": attacker_business_area.slug})
+
+
+def test_read_field_attributes_of_program_from_other_business_area_is_denied(
+    authenticated_client: Any, url: str, victim_program: Program
+) -> None:
+    response = authenticated_client.get(url, {"program_id": str(victim_program.id)})
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND, response.status_code
+
+
+def test_read_field_attributes_of_program_of_own_business_area_is_allowed(
+    authenticated_client: Any, url: str, own_program: Program
+) -> None:
+    response = authenticated_client.get(url, {"program_id": str(own_program.id)})
+
+    assert response.status_code == status.HTTP_200_OK, response.status_code
+    own_field_name = own_program.pdu_fields.get().name
+    assert any(field["name"] == own_field_name for field in response.json())

--- a/tests/unit/apps/core/test_scoped_related_field.py
+++ b/tests/unit/apps/core/test_scoped_related_field.py
@@ -1,0 +1,85 @@
+"""ScopedRelatedField narrows a related field to the scope the view puts in the context (GHSA-2xf8-jjc2-9pmv)."""
+
+import pytest
+from rest_framework import serializers
+
+from extras.test_utils.factories import BusinessAreaFactory, ProgramFactory
+from hope.apps.core.api.fields import ScopedRelatedField, ScopedSlugRelatedField
+from hope.models import BusinessArea, Program
+
+pytestmark = pytest.mark.django_db
+
+
+class ProgramInputSerializer(serializers.Serializer):
+    program = ScopedRelatedField(queryset=Program.objects.all())
+
+
+class ProgramByCodeInputSerializer(serializers.Serializer):
+    program = ScopedSlugRelatedField(queryset=Program.objects.all(), slug_field="code", scope="business_area")
+
+
+class ProgramCustomPathInputSerializer(serializers.Serializer):
+    program = ScopedRelatedField(
+        queryset=Program.objects.all(), scope="business_area", scope_path="business_area__slug"
+    )
+
+
+@pytest.fixture
+def business_area() -> BusinessArea:
+    return BusinessAreaFactory(name="Afghanistan", slug="afghanistan")
+
+
+@pytest.fixture
+def own_program(business_area: BusinessArea) -> Program:
+    return ProgramFactory(business_area=business_area, code="OWN1")
+
+
+@pytest.fixture
+def foreign_program() -> Program:
+    return ProgramFactory(business_area=BusinessAreaFactory(name="Ukraine", slug="ukraine"), code="FRGN")
+
+
+def test_id_inside_the_scope_resolves(business_area: BusinessArea, own_program: Program) -> None:
+    serializer = ProgramInputSerializer(data={"program": own_program.id}, context={"business_area": business_area})
+
+    assert serializer.is_valid(), serializer.errors
+    assert serializer.validated_data["program"] == own_program
+
+
+def test_id_outside_the_scope_fails_like_a_missing_id(business_area: BusinessArea, foreign_program: Program) -> None:
+    serializer = ProgramInputSerializer(data={"program": foreign_program.id}, context={"business_area": business_area})
+
+    assert not serializer.is_valid()
+    assert "does not exist" in str(serializer.errors["program"][0])
+
+
+def test_slug_inside_the_scope_resolves(business_area: BusinessArea, own_program: Program) -> None:
+    serializer = ProgramByCodeInputSerializer(data={"program": "OWN1"}, context={"business_area": business_area})
+
+    assert serializer.is_valid(), serializer.errors
+    assert serializer.validated_data["program"] == own_program
+
+
+def test_slug_outside_the_scope_fails_like_a_missing_slug(
+    business_area: BusinessArea, foreign_program: Program
+) -> None:
+    serializer = ProgramByCodeInputSerializer(data={"program": "FRGN"}, context={"business_area": business_area})
+
+    assert not serializer.is_valid()
+    assert "does not exist" in str(serializer.errors["program"][0])
+
+
+def test_scope_path_walks_the_named_relation(business_area: BusinessArea, own_program: Program) -> None:
+    serializer = ProgramCustomPathInputSerializer(
+        data={"program": own_program.id}, context={"business_area": business_area.slug}
+    )
+
+    assert serializer.is_valid(), serializer.errors
+    assert serializer.validated_data["program"] == own_program
+
+
+def test_scope_missing_from_the_context_names_the_culprit(own_program: Program) -> None:
+    serializer = ProgramInputSerializer(data={"program": own_program.id}, context={})
+
+    with pytest.raises(KeyError, match="'business_area' is missing from the serializer context"):
+        serializer.is_valid()


### PR DESCRIPTION
Split out of #6309 — bottom of the stack. The layers above build on `ScopedRelatedField` introduced here.

## The mechanism

`ScopedRelatedField` narrows a writable related field to the scope of the url path — business area or program — so an id outside it fails like an id that does not exist (400, same message). The layers above use it on 35 grievance fields, 8 accountability fields, the token API serializers and one payment field. A contract test that walks every REST route and fails on any unscoped writable relation field sits at the top of the stack, where it can pass.

## Two holes in the shared layer

**Field attributes.** `all_fields_attributes` took a `program_id` from the query string and passed it to the generator without comparing it with the business area of the path, so the field attributes of any program could be read.

**Wrong permission set.** `BusinessAreaProgramsAccessMixin` narrowed the queryset to the programs the user holds `self.PERMISSIONS` in — that is the *list* permission. A detail or write action requires a different one, so the narrowing was done against the wrong set. It now uses the permissions of the action actually being served. Not cosmetic: the feedback update endpoint answers 404 for a legitimate request without it. Used by `payment`, `accountability` and `activity_log`.

Part of GHSA-2xf8-jjc2-9pmv. Replaces closed #6338.
