### PR TITLE
Scope grievance tickets, documents and bulk actions to the url path

### DIFF
--- a/src/hope/apps/grievance/api/mixins.py
+++ b/src/hope/apps/grievance/api/mixins.py
@@ -483,7 +483,7 @@ class GrievanceMutationMixin:
             delete_grievance_documents(ticket.id, ids_to_delete)
         if documents_to_update := input_data.pop("documentation_to_update", None):
             validate_grievance_documents_size(ticket.id, documents_to_update, is_updated=True)
-            update_grievance_documents(documents_to_update)
+            update_grievance_documents(ticket.id, documents_to_update)
         if documents := input_data.pop("documentation", None):
             validate_grievance_documents_size(ticket.id, documents)
             create_grievance_documents(approver, ticket, documents)

--- a/src/hope/apps/grievance/api/serializers/grievance_ticket.py
+++ b/src/hope/apps/grievance/api/serializers/grievance_ticket.py
@@ -3,6 +3,7 @@ from typing import Any
 from rest_framework import serializers
 
 from hope.apps.account.api.serializers import PartnerSerializer, UserSerializer
+from hope.apps.core.api.fields import ScopedRelatedField
 from hope.apps.core.api.mixins import AdminUrlSerializerMixin
 from hope.apps.core.utils import to_choice_object
 from hope.apps.geo.api.serializers import AreaListSerializer
@@ -117,7 +118,7 @@ class TicketNoteSerializer(serializers.ModelSerializer):
 
 
 class HouseholdUpdateRolesSerializer(serializers.Serializer):
-    individual = serializers.PrimaryKeyRelatedField(queryset=Individual.objects.all(), required=True)
+    individual = ScopedRelatedField(queryset=Individual.objects.all(), required=True)
     new_role = serializers.ChoiceField(choices=ROLE_CHOICE + (("NO_ROLE", "No role"),), required=False)
 
     def validate_new_role(self, value: Any) -> Any:
@@ -351,7 +352,7 @@ class IndividualDocumentSerializer(serializers.Serializer):
 
 
 class EditIndividualDocumentSerializer(serializers.Serializer):
-    id = serializers.PrimaryKeyRelatedField(queryset=Document.objects.all())
+    id = ScopedRelatedField(queryset=Document.objects.all(), scope_path="individual__business_area")
     country = serializers.CharField()
     key = serializers.CharField()
     number = serializers.CharField()
@@ -366,7 +367,7 @@ class IndividualIdentityGTSerializer(serializers.Serializer):
 
 
 class EditIndividualIdentitySerializer(serializers.Serializer):
-    id = serializers.PrimaryKeyRelatedField(queryset=IndividualIdentity.objects.all())
+    id = ScopedRelatedField(queryset=IndividualIdentity.objects.all(), scope_path="individual__business_area")
     country = serializers.CharField()
     partner = serializers.CharField()
     number = serializers.CharField()
@@ -524,21 +525,21 @@ class IndividualUpdateDataSerializer(serializers.Serializer):
 
 
 class PositiveFeedbackTicketExtras(serializers.Serializer):
-    household = serializers.PrimaryKeyRelatedField(required=False, queryset=Household.objects.all())
-    individual = serializers.PrimaryKeyRelatedField(required=False, queryset=Individual.objects.all())
+    household = ScopedRelatedField(required=False, queryset=Household.objects.all())
+    individual = ScopedRelatedField(required=False, queryset=Individual.objects.all())
 
 
 class NegativeFeedbackTicketExtras(serializers.Serializer):
-    household = serializers.PrimaryKeyRelatedField(required=False, queryset=Household.objects.all())
-    individual = serializers.PrimaryKeyRelatedField(required=False, queryset=Individual.objects.all())
+    household = ScopedRelatedField(required=False, queryset=Household.objects.all())
+    individual = ScopedRelatedField(required=False, queryset=Individual.objects.all())
 
 
 class GrievanceComplaintTicketExtras(serializers.Serializer):
-    household = serializers.PrimaryKeyRelatedField(required=False, queryset=Household.objects.all(), allow_null=True)
-    individual = serializers.PrimaryKeyRelatedField(required=False, queryset=Individual.objects.all(), allow_null=True)
+    household = ScopedRelatedField(required=False, queryset=Household.objects.all(), allow_null=True)
+    individual = ScopedRelatedField(required=False, queryset=Individual.objects.all(), allow_null=True)
     payment_record = serializers.ListField(
         required=False,
-        child=serializers.PrimaryKeyRelatedField(queryset=Payment.objects.all()),
+        child=ScopedRelatedField(queryset=Payment.objects.all()),
     )
 
 
@@ -547,21 +548,21 @@ class PaymentVerificationTicketExtras(serializers.Serializer):
 
 
 class ReferralTicketExtras(serializers.Serializer):
-    household = serializers.PrimaryKeyRelatedField(required=False, queryset=Household.objects.all())
-    individual = serializers.PrimaryKeyRelatedField(required=False, queryset=Individual.objects.all())
+    household = ScopedRelatedField(required=False, queryset=Household.objects.all())
+    individual = ScopedRelatedField(required=False, queryset=Individual.objects.all())
 
 
 class SensitiveGrievanceTicketExtras(serializers.Serializer):
-    household = serializers.PrimaryKeyRelatedField(required=False, queryset=Household.objects.all())
-    individual = serializers.PrimaryKeyRelatedField(required=False, queryset=Individual.objects.all())
+    household = ScopedRelatedField(required=False, queryset=Household.objects.all())
+    individual = ScopedRelatedField(required=False, queryset=Individual.objects.all())
     payment_record = serializers.ListField(
-        child=serializers.PrimaryKeyRelatedField(queryset=Payment.objects.all()),
+        child=ScopedRelatedField(queryset=Payment.objects.all()),
         required=False,
     )
 
 
 class AddIndividualIssueTypeExtras(serializers.Serializer):
-    household = serializers.PrimaryKeyRelatedField(queryset=Household.objects.all())
+    household = ScopedRelatedField(queryset=Household.objects.all())
     individual_data = AddIndividualDataSerializer()
 
 
@@ -570,15 +571,15 @@ class UpdateAddIndividualIssueTypeExtras(serializers.Serializer):
 
 
 class HouseholdDeleteIssueTypeExtras(serializers.Serializer):
-    household = serializers.PrimaryKeyRelatedField(queryset=Household.objects.all())
+    household = ScopedRelatedField(queryset=Household.objects.all())
 
 
 class IndividualDeleteIssueTypeExtras(serializers.Serializer):
-    individual = serializers.PrimaryKeyRelatedField(queryset=Individual.objects.all())
+    individual = ScopedRelatedField(queryset=Individual.objects.all())
 
 
 class HouseholdDataUpdateIssueTypeExtras(serializers.Serializer):
-    household = serializers.PrimaryKeyRelatedField(queryset=Household.objects.all())
+    household = ScopedRelatedField(queryset=Household.objects.all())
     household_data = HouseholdUpdateDataSerializer()
 
 
@@ -587,7 +588,7 @@ class UpdateHouseholdDataUpdateIssueTypeExtras(serializers.Serializer):
 
 
 class IndividualDataUpdateIssueTypeExtras(serializers.Serializer):
-    individual = serializers.PrimaryKeyRelatedField(required=False, queryset=Individual.objects.all())
+    individual = ScopedRelatedField(required=False, queryset=Individual.objects.all())
     individual_data = IndividualUpdateDataSerializer()
 
 
@@ -639,7 +640,7 @@ class CreateGrievanceTicketSerializer(serializers.Serializer):
     language = serializers.CharField(required=False, allow_blank=True)
     consent = serializers.BooleanField()
     linked_tickets = serializers.ListField(
-        child=serializers.PrimaryKeyRelatedField(queryset=GrievanceTicket.objects.all()),
+        child=ScopedRelatedField(queryset=GrievanceTicket.objects.all()),
         required=False,
         allow_empty=True,
     )
@@ -647,11 +648,9 @@ class CreateGrievanceTicketSerializer(serializers.Serializer):
     priority = serializers.IntegerField(required=False)
     urgency = serializers.IntegerField(required=False)
     partner = serializers.PrimaryKeyRelatedField(queryset=Partner.objects.all(), required=False, allow_null=True)
-    program = serializers.PrimaryKeyRelatedField(queryset=Program.objects.all(), required=False, allow_null=True)
+    program = ScopedRelatedField(queryset=Program.objects.all(), required=False, allow_null=True)
     comments = serializers.CharField(required=False, allow_null=True)
-    linked_feedback_id = serializers.PrimaryKeyRelatedField(
-        queryset=Feedback.objects.all(), required=False, allow_null=True
-    )
+    linked_feedback_id = ScopedRelatedField(queryset=Feedback.objects.all(), required=False, allow_null=True)
     documentation = GrievanceDocumentCreateSerializer(many=True, required=False, allow_null=True)
 
 
@@ -687,13 +686,13 @@ class UpdateGrievanceTicketSerializer(serializers.Serializer):
     area = serializers.CharField(required=False, allow_blank=True)
     language = serializers.CharField(allow_blank=True)
     linked_tickets = serializers.ListField(
-        child=serializers.PrimaryKeyRelatedField(queryset=GrievanceTicket.objects.all()),
+        child=ScopedRelatedField(queryset=GrievanceTicket.objects.all()),
         required=False,
         allow_empty=True,
     )
-    household = serializers.PrimaryKeyRelatedField(queryset=Household.objects.all(), required=False)
-    individual = serializers.PrimaryKeyRelatedField(queryset=Individual.objects.all(), required=False)
-    payment_record = serializers.PrimaryKeyRelatedField(queryset=Payment.objects.all(), required=False)
+    household = ScopedRelatedField(queryset=Household.objects.all(), required=False)
+    individual = ScopedRelatedField(queryset=Individual.objects.all(), required=False)
+    payment_record = ScopedRelatedField(queryset=Payment.objects.all(), required=False)
     extras = UpdateGrievanceTicketExtrasSerializer(required=False)
     priority = serializers.IntegerField()
     urgency = serializers.IntegerField()
@@ -701,7 +700,7 @@ class UpdateGrievanceTicketSerializer(serializers.Serializer):
     # value back; validate_submission_channel rejects HOPE on anything that is not system-generated.
     submission_channel = serializers.ChoiceField(choices=SUBMISSION_CHANNEL_CHOICES, required=False, allow_null=True)
     partner = serializers.PrimaryKeyRelatedField(queryset=Partner.objects.all(), required=False, allow_null=True)
-    program = serializers.PrimaryKeyRelatedField(queryset=Program.objects.all(), required=False, allow_null=True)
+    program = ScopedRelatedField(queryset=Program.objects.all(), required=False, allow_null=True)
     comments = serializers.CharField(required=False, allow_null=True, allow_blank=True)
     documentation = CreateGrievanceDocumentSerializer(many=True, required=False, allow_null=True)
     documentation_to_update = UpdateGrievanceDocumentSerializer(many=True, required=False, allow_null=True)
@@ -763,34 +762,32 @@ class GrievanceDeleteHouseholdApproveStatusSerializer(serializers.Serializer):
 
 
 class GrievanceNeedsAdjudicationApproveSerializer(serializers.Serializer):
-    selected_individual_id = serializers.PrimaryKeyRelatedField(
-        queryset=Individual.objects.all(), required=False, allow_null=True
-    )
+    selected_individual_id = ScopedRelatedField(queryset=Individual.objects.all(), required=False, allow_null=True)
     duplicate_individual_ids = serializers.ListField(
-        child=serializers.PrimaryKeyRelatedField(queryset=Individual.objects.all()),
+        child=ScopedRelatedField(queryset=Individual.objects.all()),
         required=False,
     )
     distinct_individual_ids = serializers.ListField(
-        child=serializers.PrimaryKeyRelatedField(queryset=Individual.objects.all()),
+        child=ScopedRelatedField(queryset=Individual.objects.all()),
         required=False,
     )
     clear_individual_ids = serializers.ListField(
-        child=serializers.PrimaryKeyRelatedField(queryset=Individual.objects.all()),
+        child=ScopedRelatedField(queryset=Individual.objects.all()),
         required=False,
     )
     version = serializers.IntegerField(required=False)
 
 
 class GrievanceReassignRoleSerializer(serializers.Serializer):
-    household_id = serializers.PrimaryKeyRelatedField(
+    household_id = ScopedRelatedField(
         queryset=Household.objects.all(),
     )
     household_version = serializers.IntegerField(required=False)
-    individual_id = serializers.PrimaryKeyRelatedField(
+    individual_id = ScopedRelatedField(
         queryset=Individual.objects.all(),
     )
     individual_version = serializers.IntegerField(required=False)
-    new_individual_id = serializers.PrimaryKeyRelatedField(queryset=Individual.objects.all(), required=False)
+    new_individual_id = ScopedRelatedField(queryset=Individual.objects.all(), required=False)
     role = serializers.CharField()
     version = serializers.IntegerField(required=False)
 

--- a/src/hope/apps/grievance/services/bulk_action_service.py
+++ b/src/hope/apps/grievance/services/bulk_action_service.py
@@ -43,6 +43,13 @@ _ACTIVITY_LOG_SELECT_RELATED = (
 
 
 class BulkActionService:
+    def _open_tickets(self, tickets_ids: Sequence[str], business_area_slug: str) -> QuerySet[GrievanceTicket]:
+        return GrievanceTicket.objects.filter(
+            ~Q(status=GrievanceTicket.STATUS_CLOSED),
+            id__in=tickets_ids,
+            business_area__slug=business_area_slug,
+        )
+
     def _clear_cache(self, business_area_slug: str) -> None:
         cache_key = f"count_{business_area_slug}_GrievanceTicketNodeConnection_"
         clear_cache_for_key(cache_key)
@@ -56,7 +63,7 @@ class BulkActionService:
         action_user: User | None = None,
     ) -> QuerySet[GrievanceTicket]:
         user = get_object_or_404(User, id=assigned_to_id)
-        queryset = GrievanceTicket.objects.filter(~Q(status=GrievanceTicket.STATUS_CLOSED), id__in=tickets_ids)
+        queryset = self._open_tickets(tickets_ids, business_area_slug)
 
         new_tickets = queryset.filter(status=GrievanceTicket.STATUS_NEW)
         # Capture which tickets actually change assignee before the update; only those count as assigned.
@@ -83,7 +90,7 @@ class BulkActionService:
     ) -> QuerySet[GrievanceTicket]:
         if priority not in [x for x, y in PRIORITY_CHOICES]:
             raise ValidationError("Invalid priority")
-        queryset = GrievanceTicket.objects.filter(~Q(status=GrievanceTicket.STATUS_CLOSED), id__in=tickets_ids)
+        queryset = self._open_tickets(tickets_ids, business_area_slug)
         updated_count = queryset.update(priority=priority)
         if updated_count != len(tickets_ids):
             raise ValidationError("Some tickets do not exist or are closed")
@@ -97,7 +104,7 @@ class BulkActionService:
     ) -> QuerySet[GrievanceTicket]:
         if urgency not in [x for x, y in URGENCY_CHOICES]:
             raise ValidationError("Invalid priority")
-        queryset = GrievanceTicket.objects.filter(~Q(status=GrievanceTicket.STATUS_CLOSED), id__in=tickets_ids)
+        queryset = self._open_tickets(tickets_ids, business_area_slug)
         updated_count = queryset.update(urgency=urgency)
         if updated_count != len(tickets_ids):
             raise ValidationError("Some tickets do not exist or are closed")
@@ -266,7 +273,7 @@ class BulkActionService:
         comment: str,
         business_area_slug: str,
     ) -> QuerySet[GrievanceTicket]:
-        tickets = GrievanceTicket.objects.filter(~Q(status=GrievanceTicket.STATUS_CLOSED), id__in=tickets_ids)
+        tickets = self._open_tickets(tickets_ids, business_area_slug)
         if len(tickets) != len(tickets_ids):
             raise ValidationError("Some tickets do not exist, or are closed")
         for ticket in tickets:

--- a/src/hope/apps/grievance/utils.py
+++ b/src/hope/apps/grievance/utils.py
@@ -101,9 +101,9 @@ def create_grievance_documents(user: AbstractUser, grievance_ticket: GrievanceTi
     GrievanceDocument.objects.bulk_create(grievance_documents)
 
 
-def update_grievance_documents(documents: list[dict]) -> None:
+def update_grievance_documents(ticket_id: str, documents: list[dict]) -> None:
     for document in documents:
-        current_document = GrievanceDocument.objects.filter(id=document["id"]).first()
+        current_document = GrievanceDocument.objects.filter(id=document["id"], grievance_ticket_id=ticket_id).first()
         if current_document:
             os.remove(current_document.file.path)
 

--- a/tests/unit/apps/grievance/test_grievance_cross_business_area_access.py
+++ b/tests/unit/apps/grievance/test_grievance_cross_business_area_access.py
@@ -1,0 +1,204 @@
+from typing import Any, Callable
+
+from django.urls import reverse
+import pytest
+from rest_framework import status
+
+from extras.test_utils.factories import (
+    BusinessAreaFactory,
+    FeedbackFactory,
+    GrievanceTicketFactory,
+    HouseholdFactory,
+    IndividualFactory,
+    ProgramFactory,
+    UserFactory,
+)
+from hope.apps.account.permissions import Permissions
+from hope.apps.grievance.constants import PRIORITY_HIGH, PRIORITY_LOW
+from hope.apps.grievance.models import GrievanceTicket
+from hope.models import BusinessArea, Feedback, Household, Individual, Program, User
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def attacker_business_area() -> BusinessArea:
+    return BusinessAreaFactory(name="Afghanistan", slug="afghanistan", code="0060")
+
+
+@pytest.fixture
+def attacker_program(attacker_business_area: BusinessArea) -> Program:
+    return ProgramFactory(status=Program.ACTIVE, business_area=attacker_business_area)
+
+
+@pytest.fixture
+def attacker(
+    attacker_business_area: BusinessArea,
+    attacker_program: Program,
+    create_user_role_with_permissions: Callable,
+) -> User:
+    user = UserFactory()
+    create_user_role_with_permissions(
+        user,
+        [Permissions.GRIEVANCES_CREATE, Permissions.GRIEVANCES_UPDATE],
+        attacker_business_area,
+        attacker_program,
+    )
+    return user
+
+
+@pytest.fixture
+def authenticated_client(api_client: Callable, attacker: User) -> Any:
+    return api_client(attacker)
+
+
+@pytest.fixture
+def victim_program() -> Program:
+    return ProgramFactory(
+        status=Program.ACTIVE,
+        business_area=BusinessAreaFactory(name="Ukraine", slug="ukraine", code="0070"),
+    )
+
+
+@pytest.fixture
+def victim_household(victim_program: Program) -> Household:
+    household = HouseholdFactory(
+        business_area=victim_program.business_area,
+        program=victim_program,
+        create_role=False,
+    )
+    individual = IndividualFactory(
+        household=household,
+        business_area=victim_program.business_area,
+        program=victim_program,
+        registration_data_import=household.registration_data_import,
+    )
+    household.head_of_household = individual
+    household.save(update_fields=["head_of_household"])
+    return household
+
+
+@pytest.fixture
+def victim_individual(victim_household: Household) -> Individual:
+    return victim_household.head_of_household
+
+
+@pytest.fixture
+def victim_feedback(victim_program: Program) -> Feedback:
+    return FeedbackFactory(
+        business_area=victim_program.business_area,
+        program=victim_program,
+        created_by=UserFactory(),
+    )
+
+
+@pytest.fixture
+def victim_ticket(victim_program: Program) -> GrievanceTicket:
+    ticket = GrievanceTicketFactory(
+        business_area=victim_program.business_area,
+        status=GrievanceTicket.STATUS_NEW,
+        priority=PRIORITY_LOW,
+    )
+    ticket.programs.add(victim_program)
+    return ticket
+
+
+@pytest.fixture
+def bulk_priority_url(attacker_business_area: BusinessArea) -> str:
+    return reverse(
+        "api:grievance-tickets:grievance-tickets-global-bulk-update-priority",
+        kwargs={"business_area_slug": attacker_business_area.slug},
+    )
+
+
+@pytest.fixture
+def list_url(attacker_business_area: BusinessArea) -> str:
+    return reverse(
+        "api:grievance-tickets:grievance-tickets-global-list",
+        kwargs={"business_area_slug": attacker_business_area.slug},
+    )
+
+
+def test_create_referral_ticket_for_individual_from_other_business_area_is_denied(
+    authenticated_client: Any,
+    list_url: str,
+    victim_individual: Individual,
+) -> None:
+    response = authenticated_client.post(
+        list_url,
+        {
+            "description": "cross business area referral",
+            "category": GrievanceTicket.CATEGORY_REFERRAL,
+            "consent": True,
+            "extras": {"category": {"referral_ticket_extras": {"individual": str(victim_individual.id)}}},
+        },
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST, response.status_code
+    assert not GrievanceTicket.objects.exists()
+
+
+def test_create_data_change_ticket_for_individual_from_other_business_area_is_denied(
+    authenticated_client: Any,
+    list_url: str,
+    victim_individual: Individual,
+) -> None:
+    response = authenticated_client.post(
+        list_url,
+        {
+            "description": "cross business area data change",
+            "category": GrievanceTicket.CATEGORY_DATA_CHANGE,
+            "issue_type": GrievanceTicket.ISSUE_TYPE_INDIVIDUAL_DATA_CHANGE_DATA_UPDATE,
+            "consent": True,
+            "extras": {
+                "issue_type": {
+                    "individual_data_update_issue_type_extras": {
+                        "individual": str(victim_individual.id),
+                        "individual_data": {"given_name": "Attacker"},
+                    }
+                }
+            },
+        },
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST, response.status_code
+    assert not GrievanceTicket.objects.exists()
+
+
+def test_create_ticket_linked_to_feedback_from_other_business_area_is_denied(
+    authenticated_client: Any,
+    list_url: str,
+    victim_feedback: Feedback,
+) -> None:
+    response = authenticated_client.post(
+        list_url,
+        {
+            "description": "cross business area feedback link",
+            "category": GrievanceTicket.CATEGORY_REFERRAL,
+            "consent": True,
+            "linked_feedback_id": str(victim_feedback.id),
+        },
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST, response.status_code
+    victim_feedback.refresh_from_db()
+    assert victim_feedback.linked_grievance is None
+
+
+def test_bulk_update_priority_of_ticket_from_other_business_area_is_denied(
+    authenticated_client: Any,
+    bulk_priority_url: str,
+    victim_ticket: GrievanceTicket,
+) -> None:
+    response = authenticated_client.post(
+        bulk_priority_url,
+        {"grievance_ticket_ids": [str(victim_ticket.id)], "priority": PRIORITY_HIGH},
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST, response.status_code
+    victim_ticket.refresh_from_db()
+    assert victim_ticket.priority == PRIORITY_LOW

--- a/tests/unit/apps/grievance/test_grievance_ticket_update.py
+++ b/tests/unit/apps/grievance/test_grievance_ticket_update.py
@@ -12,6 +12,7 @@ from extras.test_utils.factories import (
     BusinessAreaFactory,
     CurrencyFactory,
     DocumentFactory,
+    GrievanceDocumentFactory,
     GrievanceTicketFactory,
     HouseholdFactory,
     IndividualFactory,
@@ -1889,3 +1890,81 @@ def test_update_grievance_ticket_with_null_assigned_to_unassigns_the_ticket(
     assert response.status_code == status.HTTP_200_OK
     assigned_referral_ticket.refresh_from_db()
     assert assigned_referral_ticket.assigned_to is None
+
+
+@pytest.fixture
+def complaint_ticket_document(complaint_ticket: GrievanceTicket) -> Any:
+    return GrievanceDocumentFactory(
+        grievance_ticket=complaint_ticket,
+        name="old name",
+        file=SimpleUploadedFile("old.jpg", b"old-bytes", content_type="image/jpeg"),
+        file_size=9,
+    )
+
+
+@pytest.fixture
+def other_ticket_document(afghanistan: BusinessArea) -> Any:
+    return GrievanceDocumentFactory(
+        grievance_ticket=GrievanceTicketFactory(business_area=afghanistan),
+        name="old name",
+        file=SimpleUploadedFile("old.jpg", b"old-bytes", content_type="image/jpeg"),
+        file_size=9,
+    )
+
+
+@pytest.mark.usefixtures("mock_elasticsearch")
+def test_update_grievance_ticket_documentation(
+    api_client: Any,
+    user: User,
+    afghanistan: BusinessArea,
+    program: Program,
+    complaint_ticket_detail_url: str,
+    complaint_ticket_document: Any,
+    create_user_role_with_permissions: Callable,
+) -> None:
+    create_user_role_with_permissions(user, [Permissions.GRIEVANCES_UPDATE], afghanistan, program)
+
+    client = api_client(user)
+    response = client.patch(
+        complaint_ticket_detail_url,
+        {
+            "documentation_to_update[0].id": str(complaint_ticket_document.id),
+            "documentation_to_update[0].name": "new name",
+            "documentation_to_update[0].file": SimpleUploadedFile("new.jpg", b"new-bytes!", content_type="image/jpeg"),
+        },
+        format="multipart",
+    )
+
+    assert response.status_code == status.HTTP_200_OK, response.json()
+    complaint_ticket_document.refresh_from_db()
+    assert complaint_ticket_document.name == "new name"
+    assert complaint_ticket_document.file_size == 10
+
+
+@pytest.mark.usefixtures("mock_elasticsearch")
+def test_update_grievance_ticket_documentation_of_other_ticket_is_denied(
+    api_client: Any,
+    user: User,
+    afghanistan: BusinessArea,
+    program: Program,
+    complaint_ticket_detail_url: str,
+    other_ticket_document: Any,
+    create_user_role_with_permissions: Callable,
+) -> None:
+    create_user_role_with_permissions(user, [Permissions.GRIEVANCES_UPDATE], afghanistan, program)
+
+    client = api_client(user)
+    response = client.patch(
+        complaint_ticket_detail_url,
+        {
+            "documentation_to_update[0].id": str(other_ticket_document.id),
+            "documentation_to_update[0].name": "new name",
+            "documentation_to_update[0].file": SimpleUploadedFile("new.jpg", b"new-bytes!", content_type="image/jpeg"),
+        },
+        format="multipart",
+    )
+
+    assert response.status_code == status.HTTP_200_OK, response.json()
+    other_ticket_document.refresh_from_db()
+    assert other_ticket_document.name == "old name"
+    assert other_ticket_document.file_size == 9

--- a/tests/unit/apps/grievance/test_grievance_utils.py
+++ b/tests/unit/apps/grievance/test_grievance_utils.py
@@ -189,7 +189,10 @@ def test_update_grievance_documents_replaces_file_and_metadata(grievance_documen
     assert "old" in grievance_document.file.name
     new_file = SimpleUploadedFile("new.jpg", b"new-bytes!", content_type="image/jpeg")
 
-    update_grievance_documents([{"id": grievance_document.id, "name": "updated name", "file": new_file}])
+    update_grievance_documents(
+        grievance_document.grievance_ticket_id,
+        [{"id": grievance_document.id, "name": "updated name", "file": new_file}],
+    )
 
     grievance_document.refresh_from_db()
     assert grievance_document.name == "updated name"
@@ -201,7 +204,22 @@ def test_update_grievance_documents_replaces_file_and_metadata(grievance_documen
 def test_update_grievance_documents_skips_missing_document(grievance_document: Any) -> None:
     new_file = SimpleUploadedFile("new.jpg", b"new-bytes!", content_type="image/jpeg")
 
-    update_grievance_documents([{"id": uuid4(), "name": "updated name", "file": new_file}])
+    update_grievance_documents(
+        grievance_document.grievance_ticket_id, [{"id": uuid4(), "name": "updated name", "file": new_file}]
+    )
 
     grievance_document.refresh_from_db()
     assert grievance_document.name != "updated name"
+
+
+def test_update_grievance_documents_skips_document_of_another_ticket(grievance_document: Any) -> None:
+    other_ticket = GrievanceTicketFactory()
+    new_file = SimpleUploadedFile("new.jpg", b"new-bytes!", content_type="image/jpeg")
+
+    update_grievance_documents(
+        other_ticket.id, [{"id": grievance_document.id, "name": "updated name", "file": new_file}]
+    )
+
+    grievance_document.refresh_from_db()
+    assert grievance_document.name != "updated name"
+    assert "old" in grievance_document.file.name


### PR DESCRIPTION
Split out of #6309 — layer 2 of the stack, on the `ScopedRelatedField` layer below.

## Problem

**Ticket create and update.** The grievance ticket serializer takes 35 writable relation fields — individuals, households, payments, documents, linked tickets, linked feedback — all looked up by bare id. Proven exploitable from the body: a ticket created with a foreign individual (201), a ticket linked to a foreign feedback (201, and the foreign feedback row was written to).

**Documents.** `update_grievance_documents` took a document id straight from the body and looked it up globally. An edit on your own ticket could point at a document of someone else's ticket — the file on disk was removed and replaced.

**Bulk actions.** Assign, priority, urgency and add-note filtered tickets by `id__in` alone. Ids of another business area, posted to an endpoint scoped to the caller's, were updated — the business area of the url was used only to clear a cache.

## Fix

- the 35 relation fields become `ScopedRelatedField`s, scoped to the business area or program of the path
- `update_grievance_documents` takes the ticket id and filters on it
- the four bulk actions share one `_open_tickets()` helper that filters by `business_area__slug` of the path

Part of GHSA-2xf8-jjc2-9pmv. Replaces closed #6342.
