### PR TITLE
Scope the token API endpoints to the business area of the url

### DIFF
--- a/src/hope/api/endpoints/base.py
+++ b/src/hope/api/endpoints/base.py
@@ -29,6 +29,9 @@ class SelectedBusinessAreaMixin:
         except ObjectDoesNotExist:
             raise Http404
 
+    def get_serializer_context(self) -> dict[str, Any]:
+        return {**super().get_serializer_context(), "business_area": self.selected_business_area}
+
 
 class HOPEAPIView(APIView):
     permission_classes = [HOPEPermission]

--- a/src/hope/api/endpoints/beneficiary_ticket/serializers.py
+++ b/src/hope/api/endpoints/beneficiary_ticket/serializers.py
@@ -2,6 +2,7 @@ from typing import Any
 
 from rest_framework import serializers
 
+from hope.apps.core.api.fields import ScopedRelatedField
 from hope.apps.grievance.constants import PRIORITY_CHOICES, URGENCY_CHOICES
 from hope.apps.grievance.models import GrievanceTicket
 from hope.models import Program, User
@@ -9,7 +10,7 @@ from hope.models import Program, User
 
 class BeneficiaryTicketCreateSerializer(serializers.Serializer):
     description = serializers.CharField(required=True)
-    program = serializers.PrimaryKeyRelatedField(
+    program = ScopedRelatedField(
         queryset=Program.objects.all(),
         required=False,
         allow_null=True,

--- a/src/hope/api/endpoints/rdi/base.py
+++ b/src/hope/api/endpoints/rdi/base.py
@@ -16,6 +16,7 @@ from hope.api.endpoints.base import HOPEAPIBusinessAreaView, HOPEAPIView
 from hope.api.endpoints.rdi.mixin import HouseholdUploadMixin
 from hope.api.endpoints.rdi.upload import HouseholdSerializer
 from hope.api.utils import humanize_errors
+from hope.apps.core.api.fields import ScopedSlugRelatedField
 from hope.apps.registration_data.celery_tasks import classify_findings_and_schedule_merge_async_task
 from hope.models import Country, Grant, PendingHousehold, PendingIndividual, Program, RegistrationDataImport, User
 
@@ -24,9 +25,7 @@ if TYPE_CHECKING:
 
 
 class RDISerializer(serializers.ModelSerializer):
-    program = serializers.SlugRelatedField(
-        slug_field="id", required=True, queryset=Program.objects.all(), write_only=True
-    )
+    program = ScopedSlugRelatedField(slug_field="id", required=True, queryset=Program.objects.all(), write_only=True)
     imported_by_email = serializers.EmailField(required=True, write_only=True)
     country_workspace_id = serializers.CharField(
         required=False,

--- a/src/hope/api/endpoints/rdi/base.py
+++ b/src/hope/api/endpoints/rdi/base.py
@@ -99,7 +99,7 @@ class PushToRDIView(HOPEAPIBusinessAreaView, HouseholdUploadMixin, HOPEAPIView):
             return RegistrationDataImport.objects.get(
                 status=RegistrationDataImport.LOADING,
                 id=self.kwargs["rdi"],
-                business_area__slug=self.kwargs["business_area"],
+                business_area=self.selected_business_area,
             )
         except RegistrationDataImport.DoesNotExist:
             raise Http404
@@ -133,7 +133,7 @@ class PushLaxToRDIView(HOPEAPIBusinessAreaView, HouseholdUploadMixin, HOPEAPIVie
             return RegistrationDataImport.objects.get(
                 status=RegistrationDataImport.LOADING,
                 id=self.kwargs["rdi"],
-                business_area__slug=self.kwargs["business_area"],
+                business_area=self.selected_business_area,
             )
         except RegistrationDataImport.DoesNotExist:
             raise Http404
@@ -203,7 +203,7 @@ class CompleteRDIView(HOPEAPIBusinessAreaView, UpdateAPIView):
             return RegistrationDataImport.objects.get(
                 status=RegistrationDataImport.LOADING,
                 id=self.kwargs["rdi"],
-                business_area__slug=self.kwargs["business_area"],
+                business_area=self.selected_business_area,
             )
         except RegistrationDataImport.DoesNotExist:
             raise Http404

--- a/src/hope/api/endpoints/rdi/delegate_people.py
+++ b/src/hope/api/endpoints/rdi/delegate_people.py
@@ -1,13 +1,19 @@
+from functools import reduce
+from operator import or_
 from typing import TYPE_CHECKING
 from uuid import UUID
 
+from django.db import transaction
+from django.db.models import Q
+from django.http.response import Http404
+from django.utils.functional import cached_property
 from drf_spectacular.utils import extend_schema
 from rest_framework import serializers, status
 from rest_framework.response import Response
 
 from hope.api.endpoints.base import HOPEAPIBusinessAreaView, HOPEAPIView
 from hope.apps.household.const import ROLE_PRIMARY
-from hope.models import Grant, PendingIndividualRoleInHousehold
+from hope.models import Grant, PendingIndividual, PendingIndividualRoleInHousehold, RegistrationDataImport
 
 if TYPE_CHECKING:
     from rest_framework.request import Request
@@ -21,27 +27,55 @@ class DelegateSerializer(serializers.Serializer):
 class DelegatePeopleSerializer(serializers.Serializer):
     delegates = DelegateSerializer(many=True, required=True, allow_empty=False, allow_null=False)
 
+    def validate_delegates(self, delegates: list[dict]) -> list[dict]:
+        """Reject a delegate from outside this import before any role is reassigned."""
+        rdi = self.context["registration_data_import"]
+        delegate_ids = {delegate["delegate_id"] for delegate in delegates}
+        ids_in_import = set(
+            PendingIndividual.objects.filter(id__in=delegate_ids, registration_data_import=rdi).values_list(
+                "id", flat=True
+            )
+        )
+        for delegate_id in delegate_ids - ids_in_import:
+            raise serializers.ValidationError(f"Delegate {delegate_id} does not belong to this import.")
+        return delegates
+
+    @transaction.atomic
     def create(self, validated_data: dict) -> dict:
+        rdi = self.context["registration_data_import"]
         delegates = validated_data.pop("delegates")
         updated = 0
         for delegate in delegates:
-            delegate_id = delegate["delegate_id"]
-            delegated_for = delegate["delegated_for"]
-            for delegated_for_id in delegated_for:
-                updated += PendingIndividualRoleInHousehold.objects.filter(
-                    household__individuals__in=[delegated_for_id],
-                    individual_id=delegated_for_id,
-                    role=ROLE_PRIMARY,
-                ).update(individual_id=delegate_id)
+            # one update per delegate: a role qualifies when its holder is delegated for and lives in the household
+            in_own_household = reduce(
+                or_, (Q(individual_id=i, household__individuals=i) for i in delegate["delegated_for"])
+            )
+            updated += PendingIndividualRoleInHousehold.objects.filter(
+                in_own_household,
+                household__registration_data_import=rdi,
+                role=ROLE_PRIMARY,
+            ).update(individual_id=delegate["delegate_id"])
         return {"updated": updated}
 
 
 class DelegatePeopleRDIView(HOPEAPIBusinessAreaView, HOPEAPIView):
     permission = Grant.API_RDI_UPLOAD
 
+    @cached_property
+    def selected_rdi(self) -> RegistrationDataImport:
+        try:
+            return RegistrationDataImport.objects.get(
+                id=self.kwargs["rdi"],
+                business_area__slug=self.kwargs["business_area"],
+            )
+        except RegistrationDataImport.DoesNotExist:
+            raise Http404
+
     @extend_schema(request=DelegatePeopleSerializer)
     def post(self, request: "Request", business_area: str, rdi: UUID) -> Response:
-        serializer = DelegatePeopleSerializer(data=request.data)
+        serializer = DelegatePeopleSerializer(
+            data=request.data, context={"registration_data_import": self.selected_rdi}
+        )
         if serializer.is_valid():
             response = serializer.save()
             return Response(response, status=status.HTTP_200_OK)

--- a/src/hope/api/endpoints/rdi/delegate_people.py
+++ b/src/hope/api/endpoints/rdi/delegate_people.py
@@ -66,7 +66,7 @@ class DelegatePeopleRDIView(HOPEAPIBusinessAreaView, HOPEAPIView):
         try:
             return RegistrationDataImport.objects.get(
                 id=self.kwargs["rdi"],
-                business_area__slug=self.kwargs["business_area"],
+                business_area=self.selected_business_area,
             )
         except RegistrationDataImport.DoesNotExist:
             raise Http404

--- a/src/hope/api/endpoints/rdi/lax.py
+++ b/src/hope/api/endpoints/rdi/lax.py
@@ -25,7 +25,7 @@ from hope.api.endpoints.rdi.common import (
 )
 from hope.api.endpoints.rdi.mixin import HouseholdUploadMixin, PhotoMixin
 from hope.api.endpoints.rdi.upload import BirthDateValidator
-from hope.apps.core.api.fields import UTCDateField
+from hope.apps.core.api.fields import ScopedSlugRelatedField, UTCDateField
 from hope.apps.household.const import (
     DATA_SHARING_CHOICES,
     DISABILITY_CHOICES,
@@ -564,19 +564,22 @@ class HouseholdSerializer(serializers.ModelSerializer):
         allow_null=True,
         queryset=Currency.objects.all(),
     )
-    head_of_household_id = serializers.SlugRelatedField(
+    head_of_household_id = ScopedSlugRelatedField(
         source="head_of_household",
         slug_field="unicef_id",
+        scope="registration_data_import",
         required=True,
         queryset=PendingIndividual.objects.all(),
     )
-    primary_collector_id = serializers.SlugRelatedField(
+    primary_collector_id = ScopedSlugRelatedField(
         slug_field="unicef_id",
+        scope="registration_data_import",
         required=True,
         queryset=PendingIndividual.objects.all(),
     )
-    alternate_collector_id = serializers.SlugRelatedField(
+    alternate_collector_id = ScopedSlugRelatedField(
         slug_field="unicef_id",
+        scope="registration_data_import",
         required=False,
         queryset=PendingIndividual.objects.all(),
     )
@@ -678,7 +681,9 @@ class CreateLaxHouseholds(CreateLaxBaseView, HouseholdUploadMixin):
                     "alternate_collector_id",
                 },
             )
-            serializer: HouseholdSerializer = HouseholdSerializer(data=household_data)
+            serializer: HouseholdSerializer = HouseholdSerializer(
+                data=household_data, context={"registration_data_import": self.selected_rdi}
+            )
             if serializer.is_valid():
                 data = dict(serializer.validated_data)
                 members: list[str] = data.pop("members", [])

--- a/src/hope/api/endpoints/rdi/upload.py
+++ b/src/hope/api/endpoints/rdi/upload.py
@@ -15,7 +15,7 @@ from rest_framework.response import Response
 from hope.api.endpoints.base import HOPEAPIBusinessAreaView
 from hope.api.endpoints.rdi.mixin import HouseholdUploadMixin
 from hope.api.utils import humanize_errors
-from hope.apps.core.api.fields import UTCDateField
+from hope.apps.core.api.fields import ScopedSlugRelatedField, UTCDateField
 from hope.apps.core.utils import IDENTIFICATION_TYPE_TO_KEY_MAPPING
 from hope.apps.household.const import (
     DATA_SHARING_CHOICES,
@@ -246,9 +246,7 @@ class HouseholdSerializer(serializers.ModelSerializer):
 class RDINestedSerializer(HouseholdUploadMixin, serializers.ModelSerializer):
     name = serializers.CharField(required=True)
     households = HouseholdSerializer(many=True, required=True)
-    program = serializers.SlugRelatedField(
-        slug_field="id", required=True, queryset=Program.objects.all(), write_only=True
-    )
+    program = ScopedSlugRelatedField(slug_field="id", required=True, queryset=Program.objects.all(), write_only=True)
 
     class Meta:
         model = RegistrationDataImport
@@ -256,6 +254,8 @@ class RDINestedSerializer(HouseholdUploadMixin, serializers.ModelSerializer):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         self.business_area = kwargs.pop("business_area", None)
+        # built by hand in the view, so the scope has to be set here
+        kwargs.setdefault("context", {})["business_area"] = self.business_area
         super().__init__(*args, **kwargs)
 
     def validate_households(self, value: Any) -> Any:

--- a/tests/unit/api/test_cw_dedup_flow_e2e.py
+++ b/tests/unit/api/test_cw_dedup_flow_e2e.py
@@ -239,7 +239,7 @@ def test_cw_lax_auto_merges_with_duplicate_ticket(
         country_workspace_id=country_workspace_id,
         django_capture_on_commit_callbacks=django_capture_on_commit_callbacks,
         django_assert_num_queries=django_assert_num_queries,
-        expected_queries=188,
+        expected_queries=189,
     )
 
     rdi = RegistrationDataImport.objects.get(id=rdi_id)
@@ -355,7 +355,7 @@ def test_cw_social_workers_auto_merges_with_duplicate_ticket(
         country_workspace_id=country_workspace_id,
         django_capture_on_commit_callbacks=django_capture_on_commit_callbacks,
         django_assert_num_queries=django_assert_num_queries,
-        expected_queries=192,
+        expected_queries=193,
     )
 
     rdi = RegistrationDataImport.objects.get(id=rdi_id)

--- a/tests/unit/api/test_delegate_people.py
+++ b/tests/unit/api/test_delegate_people.py
@@ -1,22 +1,32 @@
 from uuid import UUID
 
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 import pytest
 from rest_framework import status
 from rest_framework.reverse import reverse
 from rest_framework.test import APIClient
 
+from extras.test_utils.factories import (
+    BusinessAreaFactory,
+    PendingHouseholdFactory,
+    PendingIndividualFactory,
+    RegistrationDataImportFactory,
+)
 from extras.test_utils.factories.core import BeneficiaryGroupFactory, DataCollectingTypeFactory
 from extras.test_utils.factories.program import ProgramFactory
 from hope.apps.core.utils import IDENTIFICATION_TYPE_TO_KEY_MAPPING
 from hope.apps.household.const import (
     IDENTIFICATION_TYPE_BIRTH_CERTIFICATE,
     NON_BENEFICIARY,
+    ROLE_PRIMARY,
 )
 from hope.models import (
     BusinessArea,
     DataCollectingType,
     PendingHousehold,
     PendingIndividual,
+    PendingIndividualRoleInHousehold,
     Program,
     RegistrationDataImport,
 )
@@ -116,3 +126,141 @@ def test_delegate_people_reassigns_primary_collector(
     hh2 = PendingHousehold.objects.get(registration_data_import=rdi_loading, village="village2")
     assert hh1.primary_collector.full_name == "John Doe"
     assert hh2.primary_collector.full_name == "Jack Jones"
+
+
+def test_delegate_people_for_many_runs_one_update_per_delegate(
+    token_api_client: APIClient,
+    business_area: BusinessArea,
+    rdi_loading: RegistrationDataImport,
+    people_ids: list[UUID],
+) -> None:
+    """The roles of everybody delegated for are reassigned by a single update, not one per person."""
+    url = reverse("api:rdi-delegate-people", args=[business_area.slug, str(rdi_loading.id)])
+    data = {"delegates": [{"delegate_id": people_ids[2], "delegated_for": [people_ids[0], people_ids[1]]}]}
+
+    with CaptureQueriesContext(connection) as queries:
+        response = token_api_client.post(url, data, format="json")
+
+    assert sum(query["sql"].startswith("UPDATE") for query in queries.captured_queries) == 1
+
+    assert response.status_code == status.HTTP_200_OK, str(response.json())
+    assert response.json()["updated"] == 2
+    hh1 = PendingHousehold.objects.get(registration_data_import=rdi_loading, village="village1")
+    hh2 = PendingHousehold.objects.get(registration_data_import=rdi_loading, village="village2")
+    assert hh1.primary_collector.full_name == "Jack Jones"
+    assert hh2.primary_collector.full_name == "Jack Jones"
+
+
+@pytest.fixture
+def victim_primary_role(afghanistan_country) -> PendingIndividualRoleInHousehold:
+    victim_business_area = BusinessAreaFactory(name="Ukraine", slug="ukraine", code="0070")
+    victim_program = ProgramFactory(status=Program.DRAFT, business_area=victim_business_area)
+    victim_rdi = RegistrationDataImportFactory(
+        business_area=victim_business_area,
+        program=victim_program,
+        status=RegistrationDataImport.LOADING,
+    )
+    household = PendingHouseholdFactory(
+        business_area=victim_business_area,
+        program=victim_program,
+        registration_data_import=victim_rdi,
+        create_role=False,
+    )
+    individual = PendingIndividualFactory(
+        business_area=victim_business_area,
+        program=victim_program,
+        registration_data_import=victim_rdi,
+        household=household,
+    )
+    return PendingIndividualRoleInHousehold.objects.create(
+        household=household, individual=individual, role=ROLE_PRIMARY
+    )
+
+
+def test_delegate_people_of_other_business_area_is_denied(
+    token_api_client: APIClient,
+    business_area: BusinessArea,
+    rdi_loading: RegistrationDataImport,
+    people_ids: list[UUID],
+    victim_primary_role: PendingIndividualRoleInHousehold,
+) -> None:
+    collector_before = victim_primary_role.individual_id
+    url = reverse("api:rdi-delegate-people", args=[business_area.slug, str(rdi_loading.id)])
+    data = {"delegates": [{"delegate_id": people_ids[2], "delegated_for": [str(collector_before)]}]}
+
+    response = token_api_client.post(url, data, format="json")
+
+    assert response.status_code == status.HTTP_200_OK, str(response.json())
+    assert response.json()["updated"] == 0
+    victim_primary_role.refresh_from_db()
+    assert victim_primary_role.individual_id == collector_before
+
+
+def test_delegate_to_individual_of_other_business_area_is_denied(
+    token_api_client: APIClient,
+    business_area: BusinessArea,
+    rdi_loading: RegistrationDataImport,
+    people_ids: list[UUID],
+    victim_primary_role: PendingIndividualRoleInHousehold,
+) -> None:
+    url = reverse("api:rdi-delegate-people", args=[business_area.slug, str(rdi_loading.id)])
+    data = {"delegates": [{"delegate_id": str(victim_primary_role.individual_id), "delegated_for": [people_ids[1]]}]}
+
+    response = token_api_client.post(url, data, format="json")
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST, str(response.json())
+    hh2 = PendingHousehold.objects.get(registration_data_import=rdi_loading, village="village2")
+    assert hh2.primary_collector.full_name == "Mary Doe"
+
+
+def test_delegate_people_rejects_the_whole_batch_when_one_delegate_is_foreign(
+    token_api_client: APIClient,
+    business_area: BusinessArea,
+    rdi_loading: RegistrationDataImport,
+    people_ids: list[UUID],
+    victim_primary_role: PendingIndividualRoleInHousehold,
+) -> None:
+    """A rejected batch must reassign nobody, not even the delegates listed before the bad one."""
+    url = reverse("api:rdi-delegate-people", args=[business_area.slug, str(rdi_loading.id)])
+    data = {
+        "delegates": [
+            {"delegate_id": people_ids[2], "delegated_for": [people_ids[1]]},
+            {"delegate_id": str(victim_primary_role.individual_id), "delegated_for": [people_ids[0]]},
+        ]
+    }
+
+    response = token_api_client.post(url, data, format="json")
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST, str(response.json())
+    hh2 = PendingHousehold.objects.get(registration_data_import=rdi_loading, village="village2")
+    assert hh2.primary_collector.full_name == "Mary Doe"
+
+
+def test_delegate_people_in_import_of_other_business_area_is_denied(
+    token_api_client: APIClient,
+    business_area: BusinessArea,
+    people_ids: list[UUID],
+    victim_primary_role: PendingIndividualRoleInHousehold,
+) -> None:
+    victim_rdi = victim_primary_role.household.registration_data_import
+    url = reverse("api:rdi-delegate-people", args=[business_area.slug, str(victim_rdi.id)])
+    data = {"delegates": [{"delegate_id": people_ids[2], "delegated_for": [str(victim_primary_role.individual_id)]}]}
+
+    response = token_api_client.post(url, data, format="json")
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND, str(response.json())
+    victim_primary_role.refresh_from_db()
+    assert victim_primary_role.individual_id != people_ids[2]
+
+
+def test_delegate_people_without_delegates_is_rejected(
+    token_api_client: APIClient,
+    business_area: BusinessArea,
+    rdi_loading: RegistrationDataImport,
+) -> None:
+    url = reverse("api:rdi-delegate-people", args=[business_area.slug, str(rdi_loading.id)])
+
+    response = token_api_client.post(url, {"delegates": []}, format="json")
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST, str(response.json())
+    assert "delegates" in response.json()

--- a/tests/unit/api/test_lax_households.py
+++ b/tests/unit/api/test_lax_households.py
@@ -752,3 +752,44 @@ def test_household_create_facility(
     assert PendingHousehold.objects.first().facility.name == "NEW ORG LAX TEST"
     assert Facility.objects.first().name == "NEW ORG LAX TEST"
     assert Facility.objects.first().admin_area.p_code == "AF01"
+
+
+@pytest.fixture
+def collector_of_other_business_area() -> PendingIndividual:
+    other_business_area = BusinessAreaFactory(name="Ukraine", slug="ukraine", code="0070")
+    other_rdi = RegistrationDataImportFactory(
+        business_area=other_business_area,
+        status=RegistrationDataImport.LOADING,
+        program__status=Program.DRAFT,
+        program__business_area=other_business_area,
+    )
+    return PendingIndividualFactory(
+        individual_id="IND999",
+        registration_data_import=other_rdi,
+        program=other_rdi.program,
+        business_area=other_business_area,
+    )
+
+
+def test_create_household_with_collector_of_other_business_area_is_denied(
+    api_client: APIClient,
+    lax_households_url: str,
+    afghanistan_country: Country,
+    head_of_household: PendingIndividual,
+    collector_of_other_business_area: PendingIndividual,
+) -> None:
+    household_data = {
+        "country": "AF",
+        "size": 1,
+        "village": "Test Village",
+        "head_of_household_id": head_of_household.unicef_id,
+        "primary_collector_id": collector_of_other_business_area.unicef_id,
+        "members": [head_of_household.unicef_id],
+    }
+
+    response = api_client.post(lax_households_url, [household_data], format="json")
+
+    assert response.status_code == status.HTTP_201_CREATED, str(response.json())
+    assert response.data["accepted"] == 0
+    assert response.data["errors"] == 1
+    assert not PendingHousehold.objects.filter(village="Test Village").exists()

--- a/tests/unit/api/test_token_api_cross_business_area_access.py
+++ b/tests/unit/api/test_token_api_cross_business_area_access.py
@@ -1,0 +1,89 @@
+"""Cross business area scoping of the token api (GHSA-2xf8-jjc2-9pmv)."""
+
+import pytest
+from rest_framework import status
+from rest_framework.reverse import reverse
+from rest_framework.test import APIClient
+
+from extras.test_utils.factories import APITokenFactory, BusinessAreaFactory, ProgramFactory
+from hope.apps.grievance.models import GrievanceTicket
+from hope.models import APIToken, BusinessArea, Program, RegistrationDataImport, User
+from hope.models.grant import Grant
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def beneficiary_ticket_client(business_area: BusinessArea) -> APIClient:
+    token: APIToken = APITokenFactory(grants=[Grant.API_BENEFICIARY_TICKET_CREATE.name])
+    token.valid_for.set([business_area])
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION="Token " + token.key)
+    return client
+
+
+@pytest.fixture
+def other_business_area() -> BusinessArea:
+    return BusinessAreaFactory(name="Ukraine", slug="ukraine", code="0070")
+
+
+@pytest.fixture
+def other_program(other_business_area: BusinessArea) -> Program:
+    return ProgramFactory(status=Program.ACTIVE, business_area=other_business_area)
+
+
+def test_create_rdi_for_program_from_other_business_area_is_denied(
+    token_api_client: APIClient,
+    user_business_area: BusinessArea,
+    other_program: Program,
+    imported_by_user: User,
+) -> None:
+    url = reverse("api:rdi-create", args=[user_business_area.slug])
+
+    response = token_api_client.post(
+        url,
+        {
+            "name": "cross business area rdi",
+            "program": str(other_program.id),
+            "imported_by_email": imported_by_user.email,
+        },
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
+    assert "program" in response.json()
+    assert not RegistrationDataImport.objects.exists()
+
+
+def test_upload_rdi_for_program_from_other_business_area_is_denied(
+    token_api_client: APIClient,
+    upload_url: str,
+    other_program: Program,
+) -> None:
+    response = token_api_client.post(
+        upload_url,
+        {"name": "cross business area upload", "program": str(other_program.id), "households": []},
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
+    assert "program" in str(response.json())
+    assert not RegistrationDataImport.objects.exists()
+
+
+def test_create_beneficiary_ticket_for_program_from_other_business_area_is_denied(
+    beneficiary_ticket_client: APIClient,
+    business_area: BusinessArea,
+    other_program: Program,
+) -> None:
+    url = reverse("api:beneficiary-ticket-create", args=[business_area.slug])
+
+    response = beneficiary_ticket_client.post(
+        url,
+        {"description": "cross business area ticket", "program": str(other_program.id)},
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
+    assert "program" in response.json()
+    assert not GrievanceTicket.objects.exists()

--- a/tests/unit/api/test_token_api_cross_business_area_access.py
+++ b/tests/unit/api/test_token_api_cross_business_area_access.py
@@ -6,6 +6,7 @@ from rest_framework.reverse import reverse
 from rest_framework.test import APIClient
 
 from extras.test_utils.factories import APITokenFactory, BusinessAreaFactory, ProgramFactory
+from extras.test_utils.factories.registration_data import RegistrationDataImportFactory
 from hope.apps.grievance.models import GrievanceTicket
 from hope.models import APIToken, BusinessArea, Program, RegistrationDataImport, User
 from hope.models.grant import Grant
@@ -87,3 +88,37 @@ def test_create_beneficiary_ticket_for_program_from_other_business_area_is_denie
     assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
     assert "program" in response.json()
     assert not GrievanceTicket.objects.exists()
+
+
+@pytest.fixture
+def other_rdi(other_program: Program) -> RegistrationDataImport:
+    return RegistrationDataImportFactory(
+        business_area=other_program.business_area,
+        program=other_program,
+        status=RegistrationDataImport.LOADING,
+        number_of_individuals=0,
+        number_of_households=0,
+    )
+
+
+@pytest.mark.parametrize(
+    ("url_name", "payload"),
+    [
+        ("api:rdi-push", []),
+        ("api:rdi-complete", {}),
+        ("api:rdi-delegate-people", {}),
+    ],
+)
+def test_rdi_action_in_business_area_the_token_is_not_valid_for_is_denied(
+    token_api_client: APIClient,
+    other_rdi: RegistrationDataImport,
+    url_name: str,
+    payload: list | dict,
+) -> None:
+    url = reverse(url_name, args=[other_rdi.business_area.slug, str(other_rdi.id)])
+
+    response = token_api_client.post(url, payload, format="json")
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    other_rdi.refresh_from_db()
+    assert other_rdi.status == RegistrationDataImport.LOADING


### PR DESCRIPTION
Split out of #6309 — layer 3 of the stack, on the `ScopedRelatedField` layer below.

## Problem

The token API resolved caller-supplied ids globally, so a token valid for one business area wrote into another:

| Endpoint | Was |
|---|---|
| RDI upload | 201 into a foreign business area |
| RDI lax push | `accepted: 1` into a foreign import |
| delegate people | `updated: 1` — collector roles of a foreign import reassigned |
| beneficiary ticket create | 201 with foreign individuals |

## Fix

- the upload, lax and beneficiary ticket serializers scope their relation fields with `ScopedRelatedField`
- the delegate-people endpoint resolves the RDI of the path once, filters the role queryset by it, and validates the whole batch in `validate_delegates` **before** any role is written — a bad delegate in the middle of a batch no longer leaves the earlier ones reassigned behind a 400 (this addresses @MarekBiczysko's review on #6309); the writes run in one transaction

Part of GHSA-2xf8-jjc2-9pmv. Replaces closed #6343.
