### PR TITLE
Scope feedback, surveys and messages to the url path

### DIFF
--- a/src/hope/apps/accountability/api/serializers.py
+++ b/src/hope/apps/accountability/api/serializers.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from rest_framework import serializers
 
+from hope.apps.core.api.fields import ScopedRelatedField, ScopedSlugRelatedField
 from hope.apps.core.api.mixins import AdminUrlSerializerMixin
 from hope.apps.geo.api.serializers import AreaSimpleSerializer
 from hope.apps.household.api.serializers.household import HouseholdSmallSerializer
@@ -187,14 +188,18 @@ class MessageCreateSerializer(serializers.Serializer):
     sampling_type = serializers.ChoiceField(choices=Message.SamplingChoices)  # type: ignore[arg-type]
     full_list_arguments = FullListSerializer(required=False, allow_null=True)
     random_sampling_arguments = RandomSamplingSerializer(required=False, allow_null=True)
-    payment_plan = serializers.PrimaryKeyRelatedField(
-        queryset=PaymentPlan.objects.all(), required=False, allow_null=True
+    payment_plan = ScopedRelatedField(
+        queryset=PaymentPlan.objects.all(),
+        scope="program",
+        scope_path="program_cycle__program",
+        required=False,
+        allow_null=True,
     )
-    registration_data_import = serializers.PrimaryKeyRelatedField(
-        queryset=RegistrationDataImport.objects.all(), required=False, allow_null=True
+    registration_data_import = ScopedRelatedField(
+        queryset=RegistrationDataImport.objects.all(), scope="program", required=False, allow_null=True
     )
     households = serializers.ListSerializer(
-        child=serializers.PrimaryKeyRelatedField(queryset=Household.objects.all()),
+        child=ScopedRelatedField(queryset=Household.objects.all(), scope="program"),
         required=False,
         allow_empty=True,
     )
@@ -221,8 +226,10 @@ class SurveySerializer(serializers.ModelSerializer):
     body = serializers.CharField(required=False, allow_blank=True)
     sampling_type = serializers.CharField()
     flow = serializers.CharField(required=False, write_only=True, allow_blank=True)
-    payment_plan = serializers.SlugRelatedField(
+    payment_plan = ScopedSlugRelatedField(
         slug_field="id",
+        scope="program",
+        scope_path="program_cycle__program",
         required=False,
         allow_null=True,
         queryset=PaymentPlan.objects.all(),
@@ -290,8 +297,12 @@ class SurveyRapidProFlowSerializer(serializers.Serializer):
 
 
 class SurveySampleSizeSerializer(serializers.Serializer):
-    payment_plan = serializers.PrimaryKeyRelatedField(
-        queryset=PaymentPlan.objects.all(), required=False, allow_null=True
+    payment_plan = ScopedRelatedField(
+        queryset=PaymentPlan.objects.all(),
+        scope="program",
+        scope_path="program_cycle__program",
+        required=False,
+        allow_null=True,
     )
     sampling_type = serializers.ChoiceField(required=True, choices=Survey.SAMPLING_CHOICES, allow_null=True)
     full_list_arguments = AccountabilityFullListArgumentsSerializer(required=False, allow_null=True)
@@ -306,15 +317,19 @@ class SampleSizeSerializer(serializers.Serializer):
 
 class MessageSampleSizeSerializer(serializers.Serializer):
     households = serializers.ListSerializer(
-        child=serializers.PrimaryKeyRelatedField(queryset=Household.objects.all()),
+        child=ScopedRelatedField(queryset=Household.objects.all(), scope="program"),
         required=False,
         allow_empty=True,
     )
-    payment_plan = serializers.PrimaryKeyRelatedField(
-        queryset=PaymentPlan.objects.all(), required=False, allow_null=True
+    payment_plan = ScopedRelatedField(
+        queryset=PaymentPlan.objects.all(),
+        scope="program",
+        scope_path="program_cycle__program",
+        required=False,
+        allow_null=True,
     )
-    registration_data_import = serializers.PrimaryKeyRelatedField(
-        queryset=RegistrationDataImport.objects.all(), required=False, allow_null=True
+    registration_data_import = ScopedRelatedField(
+        queryset=RegistrationDataImport.objects.all(), scope="program", required=False, allow_null=True
     )
     sampling_type = serializers.ChoiceField(choices=Message.SamplingChoices)  # type: ignore[arg-type]
     full_list_arguments = AccountabilityFullListArgumentsSerializer(required=False, allow_null=True)

--- a/src/hope/apps/accountability/api/views.py
+++ b/src/hope/apps/accountability/api/views.py
@@ -114,7 +114,7 @@ class FeedbackViewSet(
     program_model_field = "program"
 
     def get_object(self) -> Feedback:
-        return get_object_or_404(Feedback, id=self.kwargs.get("pk"))
+        return get_object_or_404(self.get_queryset(), id=self.kwargs.get("pk"))
 
     def get_queryset(self) -> QuerySet[Feedback]:
         queryset = super().get_queryset()
@@ -136,10 +136,10 @@ class FeedbackViewSet(
         program_code = self.kwargs.get("program_code")
         program = None
         if program_code:
-            program = Program.objects.get(code=program_code)
+            program = get_object_or_404(Program, code=program_code, business_area=business_area)
 
         if program_id := serializer.validated_data.get("program_id"):
-            program = Program.objects.get(id=program_id)
+            program = get_object_or_404(Program, id=program_id, business_area=business_area)
 
         if program and program.status == Program.FINISHED:
             raise ValidationError("It is not possible to create Feedback for a Finished Program.")
@@ -193,7 +193,7 @@ class FeedbackViewSet(
         program = feedback.program
 
         if program_id := serializer.validated_data.get("program_id"):
-            program = Program.objects.get(id=program_id)
+            program = get_object_or_404(Program, id=program_id, business_area=business_area)
 
         if program and program.status == Program.FINISHED:
             raise ValidationError("It is not possible to update Feedback for a Finished Program.")
@@ -303,8 +303,8 @@ class MessageViewSet(
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
-        business_area = BusinessArea.objects.get(slug=self.kwargs.get("business_area_slug"))
-        program = Program.objects.get(code=self.program_code)
+        business_area = self.business_area
+        program = self.program
 
         input_data = serializer.validated_data
         input_data["program"] = str(program.pk)
@@ -403,8 +403,8 @@ class SurveyViewSet(
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
-        business_area = BusinessArea.objects.get(slug=self.business_area_slug)
-        program = Program.objects.get(code=self.program_code)
+        business_area = self.business_area
+        program = self.program
 
         input_data = serializer.validated_data
         input_data["business_area"] = business_area

--- a/src/hope/apps/accountability/api/views.py
+++ b/src/hope/apps/accountability/api/views.py
@@ -137,9 +137,16 @@ class FeedbackViewSet(
         program = None
         if program_code:
             program = get_object_or_404(Program, code=program_code, business_area=business_area)
-
-        if program_id := serializer.validated_data.get("program_id"):
+        elif program_id := serializer.validated_data.get("program_id"):
             program = get_object_or_404(Program, id=program_id, business_area=business_area)
+
+        if household_id := serializer.validated_data.get("household_lookup"):
+            household = get_object_or_404(Household, id=household_id, business_area=business_area)
+            household_program = household.program or household.programs.first()
+            if program is None:
+                program = household_program
+            elif household_program != program:
+                raise ValidationError("Household does not belong to this program.")
 
         if program and program.status == Program.FINISHED:
             raise ValidationError("It is not possible to create Feedback for a Finished Program.")

--- a/src/hope/apps/accountability/services/feedback_crud_services.py
+++ b/src/hope/apps/accountability/services/feedback_crud_services.py
@@ -7,10 +7,9 @@ from django.shortcuts import get_object_or_404
 from hope.models import Area, BusinessArea, Feedback, Household, Individual, Program, User
 
 _SIMPLE_FIELDS = ("comments", "area", "language", "consent")
-_FK_FIELDS = {
+_SCOPED_FK_FIELDS = {
     "household_lookup": Household,
     "individual_lookup": Individual,
-    "admin2": Area,
 }
 
 
@@ -20,13 +19,16 @@ class FeedbackCrudServices:
         return key in input_data and input_data[key] is not None and input_data[key] != ""
 
     @classmethod
-    def _apply_fields(cls, obj: Feedback, input_data: dict) -> None:
+    def _apply_fields(cls, obj: Feedback, input_data: dict, business_area: BusinessArea) -> None:
         for field in _SIMPLE_FIELDS:
             if cls._has_value(input_data, field):
                 setattr(obj, field, input_data[field])
-        for field, model in _FK_FIELDS.items():
+        for field, model in _SCOPED_FK_FIELDS.items():
             if cls._has_value(input_data, field):
-                setattr(obj, field, get_object_or_404(model, id=input_data[field]))
+                setattr(obj, field, get_object_or_404(model, id=input_data[field], business_area=business_area))
+        if cls._has_value(input_data, "admin2"):
+            # admin areas are shared reference data, not owned by a business area
+            obj.admin2 = get_object_or_404(Area, id=input_data["admin2"])
 
     @classmethod
     def validate_lookup(cls, feedback: Feedback) -> None:
@@ -49,7 +51,7 @@ class FeedbackCrudServices:
             issue_type=input_data["issue_type"],
             description=input_data["description"],
         )
-        cls._apply_fields(obj, input_data)
+        cls._apply_fields(obj, input_data, business_area)
 
         if obj.household_lookup:
             obj.program = obj.household_lookup.program or obj.household_lookup.programs.first()
@@ -66,7 +68,7 @@ class FeedbackCrudServices:
         for field in ("issue_type", "description"):
             if cls._has_value(input_data, field):
                 setattr(feedback, field, input_data[field])
-        cls._apply_fields(feedback, input_data)
+        cls._apply_fields(feedback, input_data, feedback.business_area)
         if cls._has_value(input_data, "program"):
             feedback.program = get_object_or_404(Program, id=input_data["program"])
         cls.validate_lookup(feedback)

--- a/src/hope/apps/accountability/services/feedback_crud_services.py
+++ b/src/hope/apps/accountability/services/feedback_crud_services.py
@@ -53,10 +53,8 @@ class FeedbackCrudServices:
         )
         cls._apply_fields(obj, input_data, business_area)
 
-        if obj.household_lookup:
-            obj.program = obj.household_lookup.program or obj.household_lookup.programs.first()
-
-        if not obj.program and cls._has_value(input_data, "program"):
+        # program is resolved and authorized by the view (url path, body or household lookup)
+        if cls._has_value(input_data, "program"):
             obj.program = get_object_or_404(Program, id=input_data["program"])
         obj.created_by = cast("User", user)
         cls.validate_lookup(obj)

--- a/tests/unit/apps/accountability/test_feedback_cross_business_area_access.py
+++ b/tests/unit/apps/accountability/test_feedback_cross_business_area_access.py
@@ -1,0 +1,210 @@
+from typing import Any
+
+from django.urls import reverse
+import pytest
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from extras.test_utils.factories import (
+    BusinessAreaFactory,
+    FeedbackFactory,
+    HouseholdFactory,
+    IndividualFactory,
+    ProgramFactory,
+    UserFactory,
+)
+from hope.apps.account.permissions import Permissions
+from hope.models import BusinessArea, Feedback, Household, Individual, Program, User
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def attacker_business_area() -> BusinessArea:
+    return BusinessAreaFactory(slug="afghanistan")
+
+
+@pytest.fixture
+def attacker_program(attacker_business_area: BusinessArea) -> Program:
+    return ProgramFactory(business_area=attacker_business_area)
+
+
+@pytest.fixture
+def victim_feedback() -> Feedback:
+    business_area = BusinessAreaFactory(slug="ukraine")
+    return FeedbackFactory(
+        business_area=business_area,
+        program=ProgramFactory(business_area=business_area),
+        created_by=UserFactory(),
+    )
+
+
+@pytest.fixture
+def attacker(
+    attacker_business_area: BusinessArea,
+    attacker_program: Program,
+    create_user_role_with_permissions: Any,
+) -> User:
+    user = UserFactory()
+    create_user_role_with_permissions(
+        user,
+        [
+            Permissions.GRIEVANCES_FEEDBACK_VIEW_LIST,
+            Permissions.GRIEVANCES_FEEDBACK_VIEW_DETAILS,
+            Permissions.GRIEVANCES_FEEDBACK_VIEW_UPDATE,
+            Permissions.GRIEVANCES_FEEDBACK_VIEW_CREATE,
+        ],
+        attacker_business_area,
+        program=attacker_program,
+    )
+    return user
+
+
+@pytest.fixture
+def api_client(attacker: User) -> APIClient:
+    client = APIClient()
+    client.force_authenticate(user=attacker)
+    return client
+
+
+@pytest.fixture
+def cross_ba_detail_url(attacker_business_area: BusinessArea, victim_feedback: Feedback) -> str:
+    return reverse(
+        "api:accountability:feedbacks-detail",
+        kwargs={"business_area_slug": attacker_business_area.slug, "pk": str(victim_feedback.id)},
+    )
+
+
+def test_retrieve_feedback_from_other_business_area_is_denied(api_client: APIClient, cross_ba_detail_url: str) -> None:
+    response = api_client.get(cross_ba_detail_url)
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND, response.status_code
+
+
+def test_update_feedback_from_other_business_area_is_denied(
+    api_client: APIClient, cross_ba_detail_url: str, victim_feedback: Feedback
+) -> None:
+    response = api_client.patch(cross_ba_detail_url, {"description": "hijacked"}, format="json")
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND, response.status_code
+    victim_feedback.refresh_from_db()
+    assert victim_feedback.description != "hijacked"
+
+
+@pytest.fixture
+def feedback_in_program_without_role(attacker_business_area: BusinessArea) -> Feedback:
+    return FeedbackFactory(
+        business_area=attacker_business_area,
+        program=ProgramFactory(business_area=attacker_business_area),
+        created_by=UserFactory(),
+    )
+
+
+def test_retrieve_feedback_from_program_without_role_is_denied(
+    api_client: APIClient, attacker_business_area: BusinessArea, feedback_in_program_without_role: Feedback
+) -> None:
+    url = reverse(
+        "api:accountability:feedbacks-detail",
+        kwargs={
+            "business_area_slug": attacker_business_area.slug,
+            "pk": str(feedback_in_program_without_role.id),
+        },
+    )
+
+    response = api_client.get(url)
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND, response.status_code
+
+
+@pytest.fixture
+def attacker_feedback(attacker_business_area: BusinessArea, attacker_program: Program) -> Feedback:
+    return FeedbackFactory(
+        business_area=attacker_business_area,
+        program=attacker_program,
+        created_by=UserFactory(),
+    )
+
+
+def test_move_feedback_to_program_in_other_business_area_is_denied(
+    api_client: APIClient,
+    attacker_business_area: BusinessArea,
+    attacker_feedback: Feedback,
+    victim_feedback: Feedback,
+) -> None:
+    url = reverse(
+        "api:accountability:feedbacks-detail",
+        kwargs={"business_area_slug": attacker_business_area.slug, "pk": str(attacker_feedback.id)},
+    )
+
+    response = api_client.patch(
+        url,
+        {
+            "issue_type": attacker_feedback.issue_type,
+            "description": attacker_feedback.description,
+            "program_id": str(victim_feedback.program_id),
+        },
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND, response.status_code
+    attacker_feedback.refresh_from_db()
+    assert attacker_feedback.program_id != victim_feedback.program_id
+
+
+@pytest.fixture
+def victim_household() -> Household:
+    program = ProgramFactory(business_area=BusinessAreaFactory(slug="ukraine"))
+    return HouseholdFactory(business_area=program.business_area, program=program, create_role=False)
+
+
+@pytest.fixture
+def victim_individual(victim_household: Household) -> Individual:
+    return IndividualFactory(
+        household=victim_household,
+        business_area=victim_household.business_area,
+        program=victim_household.program,
+        registration_data_import=victim_household.registration_data_import,
+    )
+
+
+@pytest.fixture
+def create_url(attacker_business_area: BusinessArea) -> str:
+    return reverse("api:accountability:feedbacks-list", kwargs={"business_area_slug": attacker_business_area.slug})
+
+
+def test_create_feedback_for_household_from_other_business_area_is_denied(
+    api_client: APIClient,
+    create_url: str,
+    victim_household: Household,
+) -> None:
+    response = api_client.post(
+        create_url,
+        {
+            "issue_type": Feedback.POSITIVE_FEEDBACK,
+            "description": "cross business area feedback",
+            "household_lookup": str(victim_household.id),
+        },
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND, response.status_code
+    assert not Feedback.objects.filter(household_lookup=victim_household).exists()
+
+
+def test_create_feedback_for_individual_from_other_business_area_is_denied(
+    api_client: APIClient,
+    create_url: str,
+    victim_individual: Individual,
+) -> None:
+    response = api_client.post(
+        create_url,
+        {
+            "issue_type": Feedback.POSITIVE_FEEDBACK,
+            "description": "cross business area feedback",
+            "individual_lookup": str(victim_individual.id),
+        },
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND, response.status_code
+    assert not Feedback.objects.filter(individual_lookup=victim_individual).exists()

--- a/tests/unit/apps/accountability/test_feedback_cross_business_area_access.py
+++ b/tests/unit/apps/accountability/test_feedback_cross_business_area_access.py
@@ -208,3 +208,81 @@ def test_create_feedback_for_individual_from_other_business_area_is_denied(
 
     assert response.status_code == status.HTTP_404_NOT_FOUND, response.status_code
     assert not Feedback.objects.filter(individual_lookup=victim_individual).exists()
+
+
+@pytest.fixture
+def unauthorized_program(attacker_business_area: BusinessArea) -> Program:
+    return ProgramFactory(business_area=attacker_business_area)
+
+
+@pytest.fixture
+def household_in_unauthorized_program(unauthorized_program: Program) -> Household:
+    return HouseholdFactory(
+        business_area=unauthorized_program.business_area, program=unauthorized_program, create_role=False
+    )
+
+
+@pytest.fixture
+def program_create_url(attacker_business_area: BusinessArea, attacker_program: Program) -> str:
+    return reverse(
+        "api:accountability:feedbacks-per-program-list",
+        kwargs={"business_area_slug": attacker_business_area.slug, "program_code": attacker_program.code},
+    )
+
+
+def test_create_feedback_in_program_path_ignores_program_from_body(
+    api_client: APIClient,
+    program_create_url: str,
+    attacker_program: Program,
+    unauthorized_program: Program,
+) -> None:
+    response = api_client.post(
+        program_create_url,
+        {
+            "issue_type": Feedback.POSITIVE_FEEDBACK,
+            "description": "program from the url wins",
+            "program_id": str(unauthorized_program.id),
+        },
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_201_CREATED, response.content
+    assert Feedback.objects.get(id=response.data["id"]).program == attacker_program
+
+
+def test_create_feedback_for_household_from_other_program_is_denied(
+    api_client: APIClient,
+    program_create_url: str,
+    household_in_unauthorized_program: Household,
+) -> None:
+    response = api_client.post(
+        program_create_url,
+        {
+            "issue_type": Feedback.POSITIVE_FEEDBACK,
+            "description": "household from another program",
+            "household_lookup": str(household_in_unauthorized_program.id),
+        },
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST, response.content
+    assert not Feedback.objects.filter(household_lookup=household_in_unauthorized_program).exists()
+
+
+def test_create_feedback_for_household_from_program_without_role_is_denied(
+    api_client: APIClient,
+    create_url: str,
+    household_in_unauthorized_program: Household,
+) -> None:
+    response = api_client.post(
+        create_url,
+        {
+            "issue_type": Feedback.POSITIVE_FEEDBACK,
+            "description": "program derived from the household lookup",
+            "household_lookup": str(household_in_unauthorized_program.id),
+        },
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN, response.content
+    assert not Feedback.objects.filter(household_lookup=household_in_unauthorized_program).exists()

--- a/tests/unit/apps/accountability/test_feedback_viewset.py
+++ b/tests/unit/apps/accountability/test_feedback_viewset.py
@@ -896,7 +896,8 @@ def test_update_feedback_with_program_without_permission_in_program(
         },
         format="json",
     )
-    assert response.status_code == status.HTTP_403_FORBIDDEN
+    # not visible in that program, so not found rather than forbidden
+    assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
 def test_update_feedback_hh_lookup_returns_data_with_permission(
@@ -1400,7 +1401,8 @@ def test_create_feedback_message_with_program_without_permission_in_program(
         {"description": "Message for Feedback #1"},
         format="json",
     )
-    assert response.status_code == status.HTTP_403_FORBIDDEN
+    # not visible in that program, so not found rather than forbidden
+    assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
 def test_create_feedback_message_per_program_returns_created_with_permission(

--- a/tests/unit/apps/accountability/test_feedback_viewset.py
+++ b/tests/unit/apps/accountability/test_feedback_viewset.py
@@ -683,7 +683,6 @@ def test_create_feedback_for_finished_program(
             "comments": "Test Comments",
             "consent": True,
             "description": "Test new description",
-            "household_lookup": str(household_1.pk),
             "issue_type": "POSITIVE_FEEDBACK",
             "admin2": str(area_1.pk),
             "language": "polish",

--- a/tests/unit/apps/accountability/test_survey_message_cross_business_area_access.py
+++ b/tests/unit/apps/accountability/test_survey_message_cross_business_area_access.py
@@ -1,0 +1,138 @@
+from typing import Any
+
+from django.urls import reverse
+import pytest
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from extras.test_utils.factories import (
+    BusinessAreaFactory,
+    HouseholdFactory,
+    IndividualFactory,
+    PaymentFactory,
+    PaymentPlanFactory,
+    ProgramFactory,
+    UserFactory,
+)
+from hope.apps.account.permissions import Permissions
+from hope.models import BusinessArea, Household, Message, PaymentPlan, Program, Survey, User
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def attacker_business_area() -> BusinessArea:
+    return BusinessAreaFactory(slug="afghanistan")
+
+
+@pytest.fixture
+def attacker_program(attacker_business_area: BusinessArea) -> Program:
+    return ProgramFactory(business_area=attacker_business_area)
+
+
+@pytest.fixture
+def victim_payment_plan() -> PaymentPlan:
+    business_area = BusinessAreaFactory(slug="ukraine")
+    return PaymentPlanFactory(
+        status=PaymentPlan.Status.ACCEPTED,
+        program_cycle__program=ProgramFactory(business_area=business_area),
+    )
+
+
+@pytest.fixture
+def victim_household(victim_payment_plan: PaymentPlan) -> Household:
+    victim_program = victim_payment_plan.program
+    head_of_household = IndividualFactory(
+        household=None,
+        program=victim_program,
+        business_area=victim_program.business_area,
+        phone_no="+48600123450",
+        phone_no_valid=True,
+    )
+    household = HouseholdFactory(
+        program=victim_program,
+        business_area=victim_program.business_area,
+        head_of_household=head_of_household,
+        registration_data_import=head_of_household.registration_data_import,
+    )
+    PaymentFactory(parent=victim_payment_plan, household=household, collector=head_of_household)
+    return household
+
+
+@pytest.fixture
+def attacker(
+    attacker_business_area: BusinessArea,
+    attacker_program: Program,
+    create_user_role_with_permissions: Any,
+) -> User:
+    user = UserFactory()
+    create_user_role_with_permissions(
+        user,
+        [
+            Permissions.ACCOUNTABILITY_SURVEY_VIEW_CREATE,
+            Permissions.ACCOUNTABILITY_COMMUNICATION_MESSAGE_VIEW_CREATE,
+        ],
+        attacker_business_area,
+        program=attacker_program,
+    )
+    return user
+
+
+@pytest.fixture
+def api_client(attacker: User) -> APIClient:
+    client = APIClient()
+    client.force_authenticate(user=attacker)
+    return client
+
+
+@pytest.fixture
+def program_kwargs(attacker_business_area: BusinessArea, attacker_program: Program) -> dict[str, str]:
+    return {"business_area_slug": attacker_business_area.slug, "program_code": attacker_program.code}
+
+
+def test_create_survey_for_payment_plan_from_other_business_area_is_denied(
+    api_client: APIClient,
+    program_kwargs: dict[str, str],
+    victim_payment_plan: PaymentPlan,
+    victim_household: Household,
+) -> None:
+    url = reverse("api:accountability:surveys-list", kwargs=program_kwargs)
+
+    response = api_client.post(
+        url,
+        {
+            "title": "cross business area survey",
+            "body": "body",
+            "category": Survey.CATEGORY_MANUAL,
+            "sampling_type": Survey.SAMPLING_FULL_LIST,
+            "payment_plan": str(victim_payment_plan.id),
+            "full_list_arguments": {"excluded_admin_areas": []},
+        },
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST, response.status_code
+    assert not Survey.objects.exists()
+
+
+def test_create_message_for_households_from_other_business_area_is_denied(
+    api_client: APIClient,
+    program_kwargs: dict[str, str],
+    victim_household: Household,
+) -> None:
+    url = reverse("api:accountability:messages-list", kwargs=program_kwargs)
+
+    response = api_client.post(
+        url,
+        {
+            "title": "cross business area message",
+            "body": "body",
+            "sampling_type": Message.SamplingChoices.FULL_LIST,
+            "households": [str(victim_household.id)],
+            "full_list_arguments": {"excluded_admin_areas": []},
+        },
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST, response.status_code
+    assert not Message.objects.exists()


### PR DESCRIPTION
Split out of #6309 — layer 4 of the stack, on the `ScopedRelatedField` layer below.

## Problem

**Feedback.** `FeedbackCrudServices._apply_fields` resolved `household_lookup` and `individual_lookup` with a global `get_object_or_404`. A feedback created in one business area attached beneficiaries of another and was then dragged into their program — this is the PoC @Jeeziorny posted on #6309. The program was resolved the same unscoped way, from both the `program_id` of the body and the `program_code` of the path, and `get_object` bypassed the queryset that scopes the list.

**Surveys and messages.** Both accepted foreign household ids in the body — 201, and the message was already on its way to RapidPro.

## Fix

- the survey and message serializers scope their household and payment-plan fields with `ScopedRelatedField`
- `household_lookup` and `individual_lookup` are scoped to the feedback's business area
- `admin2` stays global on purpose — admin areas are shared reference data, not owned by a business area
- both program lookups are scoped to the business area of the path
- `get_object` goes through `get_queryset()`
- the message and survey actions read `self.business_area` / `self.program` instead of re-fetching them unscoped

Part of GHSA-2xf8-jjc2-9pmv. Replaces closed #6344.
