### PR TITLE
[HOTFIX] [338764] Fix exclusion crash on cycles with no end date 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [ "setuptools" ]
 
 [project]
 name = "hope"
-version = "4.18.0"
+version = "4.18.1"
 description = "HCT MIS is UNICEF's humanitarian cash transfer platform."
 readme = "README.md"
 license = { text = "None" }

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "4.18.0",
+  "version": "4.18.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/frontend/src/components/paymentmodule/PaymentPlanDetails/ExcludeSection/ExcludeSection.test.tsx
+++ b/src/frontend/src/components/paymentmodule/PaymentPlanDetails/ExcludeSection/ExcludeSection.test.tsx
@@ -141,6 +141,34 @@ describe('ExcludeSection', () => {
     expect(apply.disabled).toBe(true);
   });
 
+  it('says the action is running when one is still in progress', async () => {
+    renderComponent({ backgroundActionStatus: 'EXCLUDE_BENEFICIARIES' });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    const save = screen.getByRole('button', { name: 'Save' });
+    fireEvent.mouseOver(save.parentElement as HTMLElement);
+
+    expect(
+      await screen.findByText(
+        'Another background action is currently running on this Payment Plan',
+      ),
+    ).toBeTruthy();
+  });
+
+  it('says the action failed when it is at a terminal error status', async () => {
+    renderComponent({ backgroundActionStatus: 'XLSX_EXPORT_ERROR' });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    const save = screen.getByRole('button', { name: 'Save' });
+    fireEvent.mouseOver(save.parentElement as HTMLElement);
+
+    expect(
+      await screen.findByText(
+        'Another background action on this Payment Plan failed and must be resolved first',
+      ),
+    ).toBeTruthy();
+  });
+
   it('shows the stored exclusion error when no exclusion reason is set', () => {
     renderComponent({
       exclusionReason: '',

--- a/src/frontend/src/components/paymentmodule/PaymentPlanDetails/ExcludeSection/ExcludeSection.test.tsx
+++ b/src/frontend/src/components/paymentmodule/PaymentPlanDetails/ExcludeSection/ExcludeSection.test.tsx
@@ -1,0 +1,162 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, renderWithProviders, screen } from 'src/testUtils/testUtils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PaymentPlanStatusEnum } from '@restgenerated/models/PaymentPlanStatusEnum';
+import { PERMISSIONS } from 'src/config/permissions';
+import ExcludeSection from './ExcludeSection';
+
+vi.mock('@components/core/withErrorBoundary', () => ({
+  default: (Component) => Component,
+}));
+
+vi.mock('@hooks/useBaseUrl', () => ({
+  useBaseUrl: () => ({
+    businessArea: 'afghanistan',
+    programId: 'test-program',
+    baseUrl: 'afghanistan/test-program',
+  }),
+}));
+
+vi.mock('@hooks/useSnackBar', () => ({
+  useSnackbar: () => ({ showMessage: vi.fn() }),
+}));
+
+vi.mock('@hooks/usePermissions', () => ({
+  usePermissions: () => [PERMISSIONS.PM_EXCLUDE_BENEFICIARIES_FROM_FOLLOW_UP_PP],
+}));
+
+vi.mock('@restgenerated/services/RestService', () => ({
+  RestService: {
+    restBusinessAreasProgramsPaymentPlansExcludeBeneficiariesCreate: vi.fn(() =>
+      Promise.resolve({}),
+    ),
+    restBusinessAreasProgramsPaymentPlansRetrieve: vi.fn(),
+  },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const basePaymentPlan = {
+  id: 'payment-plan-1',
+  status: PaymentPlanStatusEnum.OPEN,
+  backgroundActionStatus: null,
+  backgroundActionStatusDisplay: '',
+  exclusionReason: 'Awaiting confirmation',
+  excludeHouseholdError: '',
+  excludedHouseholds: [{ unicefId: 'HH-26-0000.0001' }],
+} as const;
+
+function renderComponent(overrides = {}) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return renderWithProviders(
+    <QueryClientProvider client={queryClient}>
+      <ExcludeSection
+        paymentPlan={{ ...basePaymentPlan, ...overrides } as any}
+        initialOpen
+      />
+    </QueryClientProvider>,
+  );
+}
+
+describe('ExcludeSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('enables Save after a failed exclusion so the user can retry', () => {
+    renderComponent({ backgroundActionStatus: 'EXCLUDE_BENEFICIARIES_ERROR' });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+
+    const save = screen.getByRole('button', {
+      name: 'Save',
+    }) as HTMLButtonElement;
+    expect(save.disabled).toBe(false);
+  });
+
+  it('disables Save while an exclusion is still running', () => {
+    renderComponent({ backgroundActionStatus: 'EXCLUDE_BENEFICIARIES' });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+
+    const save = screen.getByRole('button', {
+      name: 'Save',
+    }) as HTMLButtonElement;
+    expect(save.disabled).toBe(true);
+  });
+
+  it('disables Save while an unrelated background action is running', () => {
+    renderComponent({ backgroundActionStatus: 'RULE_ENGINE_RUN' });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+
+    const save = screen.getByRole('button', {
+      name: 'Save',
+    }) as HTMLButtonElement;
+    expect(save.disabled).toBe(true);
+  });
+
+  it('disables Save when another action failed, which the exclude FSM rejects', () => {
+    renderComponent({ backgroundActionStatus: 'XLSX_EXPORT_ERROR' });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+
+    const save = screen.getByRole('button', {
+      name: 'Save',
+    }) as HTMLButtonElement;
+    expect(save.disabled).toBe(true);
+  });
+
+  it('enables Apply after a failed exclusion so the user can retry', () => {
+    renderComponent({ backgroundActionStatus: 'EXCLUDE_BENEFICIARIES_ERROR' });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    fireEvent.change(screen.getByRole('textbox', { name: 'Households Ids' }), {
+      target: { value: 'HH-26-0000.0002' },
+    });
+
+    const apply = screen.getByRole('button', {
+      name: 'Apply',
+    }) as HTMLButtonElement;
+    expect(apply.disabled).toBe(false);
+  });
+
+  it('disables Apply while an exclusion is still running', () => {
+    renderComponent({ backgroundActionStatus: 'EXCLUDE_BENEFICIARIES' });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    fireEvent.change(screen.getByRole('textbox', { name: 'Households Ids' }), {
+      target: { value: 'HH-26-0000.0002' },
+    });
+
+    const apply = screen.getByRole('button', {
+      name: 'Apply',
+    }) as HTMLButtonElement;
+    expect(apply.disabled).toBe(true);
+  });
+
+  it('shows the stored exclusion error when no exclusion reason is set', () => {
+    renderComponent({
+      exclusionReason: '',
+      excludeHouseholdError: "['Something went wrong.']",
+    });
+
+    expect(screen.getByText('Something went wrong.')).toBeTruthy();
+  });
+
+  it('shows the stored exclusion error while editing the list', () => {
+    renderComponent({
+      excludeHouseholdError: "['Something went wrong.']",
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+
+    expect(screen.getByText('Something went wrong.')).toBeTruthy();
+  });
+});

--- a/src/frontend/src/components/paymentmodule/PaymentPlanDetails/ExcludeSection/ExcludeSection.tsx
+++ b/src/frontend/src/components/paymentmodule/PaymentPlanDetails/ExcludeSection/ExcludeSection.tsx
@@ -11,6 +11,7 @@ import { ReactElement, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import * as Yup from 'yup';
 import { PaymentPlanStatusEnum } from '@restgenerated/models/PaymentPlanStatusEnum';
+import { PaymentPlanDetailBackgroundActionStatusEnum } from '@restgenerated/models/PaymentPlanDetailBackgroundActionStatusEnum';
 import { PERMISSIONS, hasPermissions } from '../../../../config/permissions';
 import { usePermissions } from '@hooks/usePermissions';
 import { useSnackbar } from '@hooks/useSnackBar';
@@ -91,6 +92,12 @@ function ExcludeSection({
     PERMISSIONS.PM_EXCLUDE_BENEFICIARIES_FROM_FOLLOW_UP_PP,
     permissions,
   );
+  // mirrors flows.py: an exclusion can only start when no background action is set,
+  // or when the previous exclusion failed.
+  const canRunExclusion =
+    !backgroundActionStatus ||
+    backgroundActionStatus ===
+      PaymentPlanDetailBackgroundActionStatusEnum.EXCLUDE_BENEFICIARIES_ERROR;
   const hasOpenOrLockedStatus =
     status === PaymentPlanStatusEnum.LOCKED ||
     status === PaymentPlanStatusEnum.OPEN;
@@ -101,6 +108,11 @@ function ExcludeSection({
     }
     if (!hasExcludePermission) {
       return t('Permission denied');
+    }
+    if (!canRunExclusion) {
+      return t(
+        'Another background action is currently running on this Payment Plan',
+      );
     }
     return '';
   };
@@ -200,7 +212,7 @@ function ExcludeSection({
       !hasExcludePermission ||
       !hasOpenOrLockedStatus ||
       excludedIds.length === 0 ||
-      Boolean(backgroundActionStatus);
+      !canRunExclusion;
 
     const editExclusionsDisabled =
       !hasExcludePermission || !hasOpenOrLockedStatus;
@@ -321,7 +333,7 @@ function ExcludeSection({
     const applyDisabled =
       !hasExcludePermission ||
       !hasOpenOrLockedStatus ||
-      Boolean(backgroundActionStatus);
+      !canRunExclusion;
 
     if (isEdit || numberOfExcluded === 0) {
       return (
@@ -477,27 +489,26 @@ function ExcludeSection({
                           </Box>
                           <Typography>{exclusionReason}</Typography>
                         </Box>
-                        {excludeHouseholdError && (
-                          <Box
-                            sx={{
-                              display: 'flex',
-                              flexDirection: 'column',
-                              mt: 2,
-                            }}
-                          >
-                            {formatErrorToArray(excludeHouseholdError).map(
-                              (el) => (
-                                <FormHelperText key={el} error>
-                                  {el}
-                                </FormHelperText>
-                              ),
-                            )}
-                          </Box>
-                        )}
                       </Box>
                     </Grid>
                   </Grid>
                 ) : null}
+                {excludeHouseholdError && (
+                  <Box
+                    sx={{
+                      display: 'flex',
+                      flexDirection: 'column',
+                      mt: 2,
+                    }}
+                    data-cy="exclude-household-error"
+                  >
+                    {formatErrorToArray(excludeHouseholdError).map((el) => (
+                      <FormHelperText key={el} error>
+                        {el}
+                      </FormHelperText>
+                    ))}
+                  </Box>
+                )}
                 {renderInputAndApply()}
                 <Grid container size={{ xs: 6 }}>
                   {errors?.map((formError) => (

--- a/src/frontend/src/components/paymentmodule/PaymentPlanDetails/ExcludeSection/ExcludeSection.tsx
+++ b/src/frontend/src/components/paymentmodule/PaymentPlanDetails/ExcludeSection/ExcludeSection.tsx
@@ -12,6 +12,7 @@ import { useTranslation } from 'react-i18next';
 import * as Yup from 'yup';
 import { PaymentPlanStatusEnum } from '@restgenerated/models/PaymentPlanStatusEnum';
 import { PaymentPlanDetailBackgroundActionStatusEnum } from '@restgenerated/models/PaymentPlanDetailBackgroundActionStatusEnum';
+import { PAYMENT_PLAN_BACKGROUND_ACTION_ERROR_STATUSES } from '@utils/constants';
 import { PERMISSIONS, hasPermissions } from '../../../../config/permissions';
 import { usePermissions } from '@hooks/usePermissions';
 import { useSnackbar } from '@hooks/useSnackBar';
@@ -110,9 +111,13 @@ function ExcludeSection({
       return t('Permission denied');
     }
     if (!canRunExclusion) {
-      return t(
-        'Another background action is currently running on this Payment Plan',
-      );
+      return PAYMENT_PLAN_BACKGROUND_ACTION_ERROR_STATUSES.includes(
+        backgroundActionStatus,
+      )
+        ? t(
+            'Another background action on this Payment Plan failed and must be resolved first',
+          )
+        : t('Another background action is currently running on this Payment Plan');
     }
     return '';
   };

--- a/src/frontend/src/containers/pages/paymentmodule/FollowUpPaymentPlanDetailsPage.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/FollowUpPaymentPlanDetailsPage.tsx
@@ -12,12 +12,12 @@ import { SupportingDocumentsSection } from '@components/paymentmodule/PaymentPla
 import PaymentsTable from '@containers/tables/paymentmodule/PaymentsTable/PaymentsTable';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { usePermissions } from '@hooks/usePermissions';
-import { PaymentPlanDetailBackgroundActionStatusEnum } from '@restgenerated/models/PaymentPlanDetailBackgroundActionStatusEnum';
 import { PaymentPlanDetail } from '@restgenerated/models/PaymentPlanDetail';
 import { PaymentPlanStatusEnum } from '@restgenerated/models/PaymentPlanStatusEnum';
 import { RestService } from '@restgenerated/services/RestService';
 import { useQuery } from '@tanstack/react-query';
 import { restQueryKey } from '@utils/queryKeys';
+import { PAYMENT_PLAN_BACKGROUND_ACTION_ERROR_STATUSES } from '@utils/constants';
 import { isPermissionDeniedError } from '@utils/utils';
 import { ReactElement } from 'react';
 import { useParams } from 'react-router-dom';
@@ -38,16 +38,12 @@ export function FollowUpPaymentPlanDetailsPage(): ReactElement {
       }),
     refetchInterval: (query) => {
       const data = query.state.data;
-      const errorStatuses = [
-        PaymentPlanDetailBackgroundActionStatusEnum.EXCLUDE_BENEFICIARIES_ERROR,
-        PaymentPlanDetailBackgroundActionStatusEnum.XLSX_EXPORT_ERROR,
-        PaymentPlanDetailBackgroundActionStatusEnum.XLSX_IMPORT_ERROR,
-        PaymentPlanDetailBackgroundActionStatusEnum.APPLYING_CUSTOM_EXCHANGE_RATE_ERROR,
-      ];
       if (
         data?.status === PaymentPlanStatusEnum.PREPARING ||
         (data?.backgroundActionStatus !== null &&
-          !errorStatuses.includes(data?.backgroundActionStatus))
+          !PAYMENT_PLAN_BACKGROUND_ACTION_ERROR_STATUSES.includes(
+            data?.backgroundActionStatus,
+          ))
       ) {
         return 3000;
       }

--- a/src/frontend/src/containers/pages/paymentmodule/ProgramCycle/PaymentPlanDetails/PaymentPlanDetailsPage.tsx
+++ b/src/frontend/src/containers/pages/paymentmodule/ProgramCycle/PaymentPlanDetails/PaymentPlanDetailsPage.tsx
@@ -8,7 +8,6 @@ import { UniversalActivityLogTable } from '@containers/tables/UniversalActivityL
 import { LoadingComponent } from '@core/LoadingComponent';
 import { PermissionDenied } from '@core/PermissionDenied';
 import { PaymentPlanStatusEnum } from '@restgenerated/models/PaymentPlanStatusEnum';
-import { PaymentPlanDetailBackgroundActionStatusEnum } from '@restgenerated/models/PaymentPlanDetailBackgroundActionStatusEnum';
 import { useBaseUrl } from '@hooks/useBaseUrl';
 import { usePermissions } from '@hooks/usePermissions';
 import { Box } from '@mui/material';
@@ -20,6 +19,7 @@ import PaymentsTable from '@containers/tables/paymentmodule/PaymentsTable/Paymen
 import ExcludeSection from '@components/paymentmodule/PaymentPlanDetails/ExcludeSection/ExcludeSection';
 import { useQuery } from '@tanstack/react-query';
 import { restQueryKey } from '@utils/queryKeys';
+import { PAYMENT_PLAN_BACKGROUND_ACTION_ERROR_STATUSES } from '@utils/constants';
 import { RestService } from '@restgenerated/services/RestService';
 import { PaymentPlanDetail } from '@restgenerated/models/PaymentPlanDetail';
 import FundsCommitmentSection from '@components/paymentmodule/PaymentPlanDetails/FundsCommitment/FundsCommitmentSection';
@@ -47,16 +47,12 @@ const PaymentPlanDetailsPage = (): ReactElement => {
       }),
     refetchInterval: (query) => {
       const data = query.state.data;
-      const errorStatuses = [
-        PaymentPlanDetailBackgroundActionStatusEnum.EXCLUDE_BENEFICIARIES_ERROR,
-        PaymentPlanDetailBackgroundActionStatusEnum.XLSX_EXPORT_ERROR,
-        PaymentPlanDetailBackgroundActionStatusEnum.XLSX_IMPORT_ERROR,
-        PaymentPlanDetailBackgroundActionStatusEnum.APPLYING_CUSTOM_EXCHANGE_RATE_ERROR,
-      ];
       if (
         data?.status === PaymentPlanStatusEnum.PREPARING ||
         (data?.backgroundActionStatus !== null &&
-          !errorStatuses.includes(data?.backgroundActionStatus))
+          !PAYMENT_PLAN_BACKGROUND_ACTION_ERROR_STATUSES.includes(
+            data?.backgroundActionStatus,
+          ))
       ) {
         return 3000;
       }

--- a/src/frontend/src/utils/constants.ts
+++ b/src/frontend/src/utils/constants.ts
@@ -1,4 +1,5 @@
 import { PaymentPlanStatusEnum } from '@restgenerated/models/PaymentPlanStatusEnum';
+import { PaymentPlanDetailBackgroundActionStatusEnum } from '@restgenerated/models/PaymentPlanDetailBackgroundActionStatusEnum';
 import { PaymentPlanBackgroundActionStatusEnum } from '@restgenerated/models/PaymentPlanBackgroundActionStatusEnum';
 import { BeneficiaryGroup } from '@restgenerated/models/BeneficiaryGroup';
 
@@ -314,9 +315,12 @@ export const generateTableOrderOptionsMember = (
   ];
 };
 
-export const PAYMENT_PLAN_BACKGROUND_ACTION_ERROR_STATUSES: string[] = [
-  'EXCLUDE_BENEFICIARIES_ERROR',
-  'XLSX_EXPORT_ERROR',
-  'XLSX_IMPORT_ERROR',
-  'APPLYING_CUSTOM_EXCHANGE_RATE_ERROR',
-];
+export const PAYMENT_PLAN_BACKGROUND_ACTION_ERROR_STATUSES: PaymentPlanDetailBackgroundActionStatusEnum[] =
+  [
+    PaymentPlanDetailBackgroundActionStatusEnum.EXCLUDE_BENEFICIARIES_ERROR,
+    PaymentPlanDetailBackgroundActionStatusEnum.XLSX_EXPORT_ERROR,
+    PaymentPlanDetailBackgroundActionStatusEnum.XLSX_IMPORT_ERROR,
+    PaymentPlanDetailBackgroundActionStatusEnum.APPLYING_CUSTOM_EXCHANGE_RATE_ERROR,
+    PaymentPlanDetailBackgroundActionStatusEnum.RULE_ENGINE_ERROR,
+    PaymentPlanDetailBackgroundActionStatusEnum.SEND_TO_PAYMENT_GATEWAY_ERROR,
+  ];

--- a/src/frontend/src/utils/constants.ts
+++ b/src/frontend/src/utils/constants.ts
@@ -313,3 +313,10 @@ export const generateTableOrderOptionsMember = (
     { name: 'Registration Date: descending', value: '-last_registration_date' },
   ];
 };
+
+export const PAYMENT_PLAN_BACKGROUND_ACTION_ERROR_STATUSES: string[] = [
+  'EXCLUDE_BENEFICIARIES_ERROR',
+  'XLSX_EXPORT_ERROR',
+  'XLSX_IMPORT_ERROR',
+  'APPLYING_CUSTOM_EXCHANGE_RATE_ERROR',
+];

--- a/src/hope/apps/payment/api/serializers.py
+++ b/src/hope/apps/payment/api/serializers.py
@@ -603,7 +603,7 @@ class VolumeByDeliveryMechanismSerializer(serializers.ModelSerializer):
 
 class PaymentPlanExcludeBeneficiariesSerializer(serializers.Serializer):
     excluded_households_ids = serializers.ListField(child=serializers.CharField())
-    exclusion_reason = serializers.CharField(required=False)
+    exclusion_reason = serializers.CharField(required=False, allow_blank=True)
 
     def validate_excluded_households_ids(self, value: list[str]) -> list[str]:
         if len(value) != len(set(value)):

--- a/src/hope/apps/payment/celery_tasks.py
+++ b/src/hope/apps/payment/celery_tasks.py
@@ -1064,6 +1064,7 @@ def prepare_child_payment_plan_async_task(
 def payment_plan_exclude_beneficiaries_async_task_action(job: AsyncRetryJob) -> None:  # noqa: PLR0915
     from django.db.models import Q
 
+    from hope.apps.core.celery_tasks import NonRetriableTaskError
     from hope.models import Payment, PaymentPlan
 
     payment_plan = PaymentPlan.objects.select_related("program_cycle__program").get(id=job.config["payment_plan_id"])
@@ -1163,7 +1164,7 @@ def payment_plan_exclude_beneficiaries_async_task_action(job: AsyncRetryJob) -> 
         if error_msg:
             payment_plan.exclude_household_error = str([*error_msg, *info_msg])
         else:
-            payment_plan.exclude_household_error = str(["Exclusion failed due to an unexpected error."])
+            payment_plan.exclude_household_error = str([*info_msg, "Exclusion failed due to an unexpected error."])
         payment_plan.save(
             update_fields=[
                 "exclusion_reason",
@@ -1173,7 +1174,7 @@ def payment_plan_exclude_beneficiaries_async_task_action(job: AsyncRetryJob) -> 
         )
         if error_msg:
             return
-        raise
+        raise NonRetriableTaskError(str(exc)) from exc
 
 
 def payment_plan_exclude_beneficiaries_async_task(

--- a/src/hope/apps/payment/celery_tasks.py
+++ b/src/hope/apps/payment/celery_tasks.py
@@ -1104,8 +1104,6 @@ def payment_plan_exclude_beneficiaries_async_task_action(job: AsyncRetryJob) -> 
                 Payment.objects.exclude(parent__id=payment_plan.pk)
                 .filter(parent__program_cycle_id=payment_plan.program_cycle_id)
                 .filter(
-                    Q(parent__program_cycle__start_date__lte=payment_plan.program_cycle.end_date)
-                    & Q(parent__program_cycle__end_date__gte=payment_plan.program_cycle.start_date),
                     ~Q(parent__status=PaymentPlan.Status.OPEN),
                     Q(**{f"{filter_key}__in": undo_exclude_hh_ids}) & Q(conflicted=False),
                 )
@@ -1164,6 +1162,8 @@ def payment_plan_exclude_beneficiaries_async_task_action(job: AsyncRetryJob) -> 
 
         if error_msg:
             payment_plan.exclude_household_error = str([*error_msg, *info_msg])
+        else:
+            payment_plan.exclude_household_error = str(["Exclusion failed due to an unexpected error."])
         payment_plan.save(
             update_fields=[
                 "exclusion_reason",

--- a/tests/unit/apps/payment/test_exclude_households.py
+++ b/tests/unit/apps/payment/test_exclude_households.py
@@ -10,7 +10,7 @@ from extras.test_utils.factories.payment import PaymentFactory, PaymentPlanFacto
 from extras.test_utils.factories.program import ProgramCycleFactory, ProgramFactory
 from hope.apps.core.celery_tasks import async_retry_job_task
 from hope.apps.payment.celery_tasks import payment_plan_exclude_beneficiaries_async_task
-from hope.models import AsyncRetryJob, DataCollectingType, PaymentPlan
+from hope.models import AsyncRetryJob, DataCollectingType, PaymentPlan, ProgramCycle
 
 pytestmark = pytest.mark.django_db
 
@@ -257,4 +257,108 @@ def test_exclude_handles_exception_during_updates(payment_plan, payment_plan_dat
     assert money_mock.called is False
     assert payment_plan.exclusion_reason == "reason exception"
     assert payment_plan.background_action_status == PaymentPlan.BackgroundActionStatus.EXCLUDE_BENEFICIARIES_ERROR
-    assert payment_plan.exclude_household_error is None
+    assert payment_plan.exclude_household_error == "['Exclusion failed due to an unexpected error.']"
+
+
+@pytest.fixture
+def active_cycle_without_end_date(program):
+    return ProgramCycleFactory(
+        program=program,
+        start_date=date.today(),
+        end_date=None,
+        status=ProgramCycle.ACTIVE,
+    )
+
+
+@pytest.fixture
+def open_payment_plan_in_active_cycle(active_cycle_without_end_date):
+    return PaymentPlanFactory(
+        status=PaymentPlan.Status.OPEN,
+        program_cycle=active_cycle_without_end_date,
+    )
+
+
+@pytest.fixture
+def two_excluded_payments(open_payment_plan_in_active_cycle, program):
+    households = [HouseholdFactory(program=program), HouseholdFactory(program=program)]
+    payments = [
+        PaymentFactory(
+            parent=open_payment_plan_in_active_cycle,
+            household=households[0],
+            collector=households[0].head_of_household,
+            excluded=True,
+        ),
+        PaymentFactory(
+            parent=open_payment_plan_in_active_cycle,
+            household=households[1],
+            collector=households[1].head_of_household,
+            excluded=True,
+        ),
+    ]
+    return {"households": households, "payments": payments}
+
+
+def test_undo_exclude_when_program_cycle_has_no_end_date(
+    open_payment_plan_in_active_cycle,
+    two_excluded_payments,
+):
+    open_payment_plan_in_active_cycle.background_action_status = (
+        PaymentPlan.BackgroundActionStatus.EXCLUDE_BENEFICIARIES
+    )
+    open_payment_plan_in_active_cycle.save(update_fields=["background_action_status"])
+
+    still_excluded_id = two_excluded_payments["households"][0].unicef_id
+
+    queue_and_run_retry_task(
+        payment_plan_exclude_beneficiaries_async_task,
+        payment_plan=open_payment_plan_in_active_cycle,
+        excluding_hh_or_ind_ids=[still_excluded_id],
+        exclusion_reason="removed one household from the exclusion list",
+    )
+
+    open_payment_plan_in_active_cycle.refresh_from_db()
+    two_excluded_payments["payments"][0].refresh_from_db()
+    two_excluded_payments["payments"][1].refresh_from_db()
+
+    assert open_payment_plan_in_active_cycle.background_action_status is None
+    assert two_excluded_payments["payments"][0].excluded is True
+    assert two_excluded_payments["payments"][1].excluded is False
+
+
+def test_undo_exclude_detects_hard_conflict_when_cycle_has_no_end_date(
+    open_payment_plan_in_active_cycle,
+    two_excluded_payments,
+    active_cycle_without_end_date,
+):
+    household_1 = two_excluded_payments["households"][0]
+
+    finished_payment_plan = PaymentPlanFactory(
+        status=PaymentPlan.Status.FINISHED,
+        plan_type=PaymentPlan.PlanType.REGULAR,
+        program_cycle=active_cycle_without_end_date,
+    )
+    PaymentFactory(parent=finished_payment_plan, household=household_1, excluded=False)
+
+    open_payment_plan_in_active_cycle.background_action_status = (
+        PaymentPlan.BackgroundActionStatus.EXCLUDE_BENEFICIARIES
+    )
+    open_payment_plan_in_active_cycle.save(update_fields=["background_action_status"])
+
+    queue_and_run_retry_task(
+        payment_plan_exclude_beneficiaries_async_task,
+        payment_plan=open_payment_plan_in_active_cycle,
+        excluding_hh_or_ind_ids=[two_excluded_payments["households"][1].unicef_id],
+        exclusion_reason="undo household_1",
+    )
+
+    open_payment_plan_in_active_cycle.refresh_from_db()
+
+    error_msg = (
+        f"['It is not possible to undo exclude Beneficiary with ID {household_1.unicef_id} "
+        "because of hard conflict(s) with other Payment Plan(s).']"
+    )
+    assert (
+        open_payment_plan_in_active_cycle.background_action_status
+        == PaymentPlan.BackgroundActionStatus.EXCLUDE_BENEFICIARIES_ERROR
+    )
+    assert open_payment_plan_in_active_cycle.exclude_household_error == error_msg

--- a/tests/unit/apps/payment/test_exclude_households.py
+++ b/tests/unit/apps/payment/test_exclude_households.py
@@ -8,7 +8,7 @@ from extras.test_utils.factories.core import BeneficiaryGroupFactory, DataCollec
 from extras.test_utils.factories.household import HouseholdFactory
 from extras.test_utils.factories.payment import PaymentFactory, PaymentPlanFactory
 from extras.test_utils.factories.program import ProgramCycleFactory, ProgramFactory
-from hope.apps.core.celery_tasks import async_retry_job_task
+from hope.apps.core.celery_tasks import NonRetriableTaskError, async_retry_job_task
 from hope.apps.payment.celery_tasks import payment_plan_exclude_beneficiaries_async_task
 from hope.models import AsyncRetryJob, DataCollectingType, PaymentPlan, ProgramCycle
 
@@ -239,11 +239,11 @@ def test_exclude_handles_exception_during_updates(payment_plan, payment_plan_dat
     hh_unicef_id_1 = payment_plan_data["households"][0].unicef_id
 
     with (
-        mock.patch("hope.apps.core.celery_tasks.async_retry_job_task.retry", side_effect=Retry("retry")),
+        mock.patch("hope.apps.core.celery_tasks.async_retry_job_task.retry", side_effect=Retry("retry")) as retry_mock,
         mock.patch.object(PaymentPlan, "update_population_count_fields", side_effect=Exception("boom")) as pop_mock,
         mock.patch.object(PaymentPlan, "update_money_fields") as money_mock,
     ):
-        with pytest.raises(Retry):
+        with pytest.raises(NonRetriableTaskError):
             queue_and_run_retry_task(
                 payment_plan_exclude_beneficiaries_async_task,
                 payment_plan=payment_plan,
@@ -255,6 +255,7 @@ def test_exclude_handles_exception_during_updates(payment_plan, payment_plan_dat
 
     assert pop_mock.called is True
     assert money_mock.called is False
+    assert retry_mock.called is False
     assert payment_plan.exclusion_reason == "reason exception"
     assert payment_plan.background_action_status == PaymentPlan.BackgroundActionStatus.EXCLUDE_BENEFICIARIES_ERROR
     assert payment_plan.exclude_household_error == "['Exclusion failed due to an unexpected error.']"

--- a/tests/unit/apps/payment/test_payment_plan_actions_views.py
+++ b/tests/unit/apps/payment/test_payment_plan_actions_views.py
@@ -617,6 +617,29 @@ def test_exclude_beneficiaries(
         assert resp_data["background_action_status"] == "EXCLUDE_BENEFICIARIES"
 
 
+def test_exclude_beneficiaries_accepts_blank_exclusion_reason(
+    payment_plan_actions_context: dict[str, Any],
+    create_user_role_with_permissions: Any,
+) -> None:
+    create_user_role_with_permissions(
+        payment_plan_actions_context["user"],
+        [Permissions.PM_EXCLUDE_BENEFICIARIES_FROM_FOLLOW_UP_PP],
+        payment_plan_actions_context["business_area"],
+        payment_plan_actions_context["program_active"],
+    )
+    payment_plan_actions_context["pp"].status = PaymentPlan.Status.LOCKED
+    payment_plan_actions_context["pp"].save()
+
+    response = payment_plan_actions_context["client"].post(
+        payment_plan_actions_context["url_exclude_hh"],
+        {"excluded_households_ids": ["HH-1"], "exclusion_reason": ""},
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["background_action_status"] == "EXCLUDE_BENEFICIARIES"
+
+
 def test_exclude_beneficiaries_validation_errors(
     payment_plan_actions_context: dict[str, Any],
     create_user_role_with_permissions: Any,

--- a/uv.lock
+++ b/uv.lock
@@ -1922,7 +1922,7 @@ wheels = [
 
 [[package]]
 name = "hope"
-version = "4.18.0"
+version = "4.18.1"
 source = { editable = "." }
 dependencies = [
     { name = "black" },


### PR DESCRIPTION
[AB#338764](https://unicef.visualstudio.com/4e044e8d-bc28-4768-8074-f80ff6e4a0e5/_workitems/edit/338764)

  **Issues found**                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 

- Removing a household from the exclusion list crashed when the programme cycle had no end date.
- The crash put the plan into Exclude Beneficiaries Error but saved no message, so nothing in the UI or in admin said what went wrong.                                                                                                                                                                
- The error status disabled the Save and Apply buttons, so the user could not retry, undo, or clear the list. The backend accepts a retry, the UI just never sent one.                                                                                                               
                                                                                                                                                                                                                                                                                                                             
Two more issues found while investigating, not related to the crash

  - Saving without an exclusion reason returned 400. Empty should be accepted.                                                                                                                                                                                                                                               
  - A stored error message is not shown if no reason was filled in, or while the user is editing the list.                                                                                                                                                                                                               

                                                                                                                                                                                                                                                                                                                             
  **Applied fixes**                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          

  - Removed the two date comparisons in the hard conflict query. The query is already filtered to one cycle, so those lines compared the cycle against itself and never filtered anything. They only crashed when the end date was null.
  - Unexpected failures now save an error message instead of leaving the field empty.  
  - Unexpected failures are no longer retried. The job used to keep retrying for about 3 minutes, while the plan already showed the error status and Save was available again. A retry could then re-apply its own old list of IDs over whatever the user saved in the meantime. The task already treats a failure as final, it sets the error status and writes a message, so retrying underneath that was wrong. Transient failures no longer recover on their own, the user retries from the UI instead.
  it sets the error status and writes a message, so retrying underneath that was wrong. Transient failures no longer recover on their own, the user retries from the UI instead.                                                                                                                                                                                                                                    
  - Save and Apply now follow the same rule as the backend: an exclusion can start when there is no background action, or when the last exclusion failed. Added a tooltip explaining why the button is disabled.                                                                                                             
  - Empty exclusion reason is accepted.                                                                                                                                                                                                                                                                                      
  - The stored error message now always shows. It used to require an exclusion reason and disappear while editing the list.                                                                                                                                                                                                                                 
  - Moved the duplicated error status list into utils/constants.ts.