### PR TITLE
[305854] Fix unclear error and slow batches when finalizing Needs Adjudication tickets

### DIFF
--- a/src/hope/apps/grievance/services/bulk_action_service.py
+++ b/src/hope/apps/grievance/services/bulk_action_service.py
@@ -1,6 +1,7 @@
 import copy
 from typing import Sequence
 
+from django.core.exceptions import PermissionDenied as DjangoPermissionDenied
 from django.db import transaction
 from django.db.models import Q, QuerySet
 from django.shortcuts import get_object_or_404
@@ -25,6 +26,10 @@ _ACTIVITY_LOG_SELECT_RELATED = (
     "assigned_to",
     "created_by",
     "admin2",
+)
+
+_ACTIVITY_LOG_PREFETCH_RELATED = (
+    "programs",
     "complaint_ticket_details__household",
     "complaint_ticket_details__individual",
     "complaint_ticket_details__payment",
@@ -40,6 +45,16 @@ _ACTIVITY_LOG_SELECT_RELATED = (
     "needs_adjudication_ticket_details",
     "payment_verification_ticket_details",
 )
+
+
+def _with_ticket_context(error: Exception, unicef_id: str) -> Exception:
+    """Name the ticket a per-ticket failure came from: the batch is atomic, so nothing else identifies it."""
+    detail = getattr(error, "detail", None)
+    message = " ".join(str(item) for item in detail) if isinstance(detail, list) else str(detail or error)
+    prefixed = f"Ticket {unicef_id}: {message}"
+    if isinstance(error, PermissionDenied | DjangoPermissionDenied):
+        return PermissionDenied(prefixed)
+    return ValidationError(prefixed)
 
 
 class BulkActionService:
@@ -123,7 +138,7 @@ class BulkActionService:
             .order_by("pk")
             .select_for_update(of=("self",))
             .select_related(*_ACTIVITY_LOG_SELECT_RELATED)
-            .prefetch_related("programs")
+            .prefetch_related(*_ACTIVITY_LOG_PREFETCH_RELATED)
         )
         if len(tickets) != len(tickets_ids) or any(
             not ticket.can_change_status(GrievanceTicket.STATUS_CLOSED) for ticket in tickets
@@ -187,7 +202,7 @@ class BulkActionService:
             .order_by("pk")
             .select_for_update(of=("self",))
             .select_related(*_ACTIVITY_LOG_SELECT_RELATED)
-            .prefetch_related("programs")
+            .prefetch_related(*_ACTIVITY_LOG_PREFETCH_RELATED)
         )
         skipped_closed: list[GrievanceTicket] = []
         if len(tickets) != len(ticket_ids):
@@ -214,7 +229,10 @@ class BulkActionService:
 
         for ticket in tickets:
             old_ticket = copy.copy(ticket)
-            self._resolve_single_needs_adjudication(ticket, resolutions_by_id[str(ticket.id)], user)
+            try:
+                self._resolve_single_needs_adjudication(ticket, resolutions_by_id[str(ticket.id)], user)
+            except (ValidationError, PermissionDenied, DjangoPermissionDenied) as error:
+                raise _with_ticket_context(error, ticket.unicef_id) from error
             log_create(
                 GrievanceTicket.ACTIVITY_LOG_MAPPING,
                 "business_area",
@@ -242,7 +260,7 @@ class BulkActionService:
 
         unknown = (set(duplicate_ids) | set(distinct_ids)) - ticket_individuals.keys()
         if unknown:
-            raise ValidationError(f"Individuals {sorted(unknown)} do not belong to ticket {ticket.unicef_id}.")
+            raise ValidationError(f"Individuals {sorted(unknown)} do not belong to this ticket.")
 
         for individual_id in duplicate_ids + distinct_ids:
             validate_individual_for_need_adjudication(user.partner, ticket_individuals[individual_id], ticket_details)

--- a/src/hope/models/individual.py
+++ b/src/hope/models/individual.py
@@ -13,6 +13,7 @@ from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 from multiselectfield import MultiSelectField
 from phonenumber_field.modelfields import PhoneNumberField
+from rest_framework.exceptions import ValidationError
 
 from hope.apps.activity_log.utils import create_mapping_dict
 from hope.apps.core.languages import Languages
@@ -510,8 +511,10 @@ class Individual(
                 doc.save()
             # AB#244721
             except IntegrityError:
-                error_message = f"{self.unicef_id}: Valid Document already exists: {doc.document_number}."
-                raise Exception(error_message)
+                raise ValidationError(
+                    f"Individual {self.unicef_id} cannot be marked as distinct: document "
+                    f"{doc.document_number} is already valid for another individual."
+                )
         self.accounts.update(active=True)
         self.duplicate = False
         self.duplicate_date = timezone.now()

--- a/src/hope/models/individual.py
+++ b/src/hope/models/individual.py
@@ -513,7 +513,7 @@ class Individual(
             except IntegrityError:
                 raise ValidationError(
                     f"Individual {self.unicef_id} cannot be marked as distinct: document "
-                    f"{doc.document_number} is already valid for another individual."
+                    f"{doc.document_number} conflicts with an existing valid document."
                 )
         self.accounts.update(active=True)
         self.duplicate = False

--- a/tests/unit/apps/grievance/test_bulk_close_service.py
+++ b/tests/unit/apps/grievance/test_bulk_close_service.py
@@ -16,6 +16,7 @@ from hope.apps.account.permissions import Permissions
 from hope.apps.activity_log.utils import create_diff
 from hope.apps.grievance.models import GrievanceTicket
 from hope.apps.grievance.services.bulk_action_service import (
+    _ACTIVITY_LOG_PREFETCH_RELATED,
     _ACTIVITY_LOG_SELECT_RELATED,
     BulkActionService,
 )
@@ -311,13 +312,13 @@ def test_bulk_close_select_related_covers_activity_log_diff(
     django_assert_num_queries: Any,
 ) -> None:
     # bulk_close logs every closed ticket, and create_diff reads every relation in
-    # ACTIVITY_LOG_MAPPING. This guards that _ACTIVITY_LOG_SELECT_RELATED covers them all so the
+    # ACTIVITY_LOG_MAPPING. This guards that the two tuples together cover them all so the
     # diff stays query-free (no per-ticket N+1); it fails if a relation is added to the mapping
-    # but not to the select_related tuple.
+    # but to neither tuple.
     ticket = (
         GrievanceTicket.objects.filter(pk=complaint_for_approval.pk)
         .select_related(*_ACTIVITY_LOG_SELECT_RELATED)
-        .prefetch_related("programs")
+        .prefetch_related(*_ACTIVITY_LOG_PREFETCH_RELATED)
         .get()
     )
 
@@ -336,8 +337,9 @@ def test_bulk_close_query_count_scales_per_ticket(
 ) -> None:
     # the per-ticket permission check adds a constant cost (the permission set is cached per
     # user/business-area/program scope, and both tickets share the same scope), so it does not
-    # scale per ticket.
-    with django_assert_max_num_queries(22):
+    # scale per ticket. The activity-log detail relations are prefetched rather than joined, which
+    # is one extra query per relation but also constant per call, not per ticket.
+    with django_assert_max_num_queries(30):
         BulkActionService().bulk_close(
             user,
             [complaint_for_approval.id, another_complaint_for_approval.id],

--- a/tests/unit/apps/grievance/test_bulk_needs_adjudication_api.py
+++ b/tests/unit/apps/grievance/test_bulk_needs_adjudication_api.py
@@ -13,6 +13,8 @@ from extras.test_utils.factories import (
     AreaTypeFactory,
     BusinessAreaFactory,
     CountryFactory,
+    DocumentFactory,
+    DocumentTypeFactory,
     GrievanceTicketFactory,
     HouseholdFactory,
     IndividualFactory,
@@ -27,7 +29,7 @@ from hope.apps.account.permissions import Permissions
 from hope.apps.grievance.api.serializers.grievance_ticket import MAX_NEEDS_ADJUDICATION_BATCH
 from hope.apps.grievance.models import GrievanceTicket, TicketNeedsAdjudicationDetails
 from hope.apps.household.const import ROLE_ALTERNATE, ROLE_PRIMARY, UNIQUE
-from hope.models import BusinessArea, IndividualRoleInHousehold, User
+from hope.models import BusinessArea, Document, IndividualRoleInHousehold, User
 
 pytestmark = [
     pytest.mark.usefixtures("mock_elasticsearch"),
@@ -1380,3 +1382,118 @@ def test_bulk_needs_adjudication_rejects_one_individual_marked_both_ways_across_
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert first_ticket.ticket.status == GrievanceTicket.STATUS_NEW
     assert shared.duplicate is False
+
+
+@pytest.fixture
+def na_ticket_sharing_a_document_number(
+    business_area: BusinessArea, program: Any, make_na_ticket: Callable
+) -> TicketNeedsAdjudicationDetails:
+    # the shape hard document deduplication leaves behind: one number, one VALID doc, one flagged doc
+    golden = HouseholdFactory(program=program, business_area=business_area, create_role=False).head_of_household
+    duplicate = HouseholdFactory(program=program, business_area=business_area, create_role=False).head_of_household
+    country = CountryFactory()
+    document_type = DocumentTypeFactory(key="national_id")
+    DocumentFactory(
+        individual=golden,
+        type=document_type,
+        country=country,
+        document_number="1354917433",
+        status=Document.STATUS_VALID,
+    )
+    DocumentFactory(
+        individual=duplicate,
+        type=document_type,
+        country=country,
+        document_number="1354917433",
+        status=Document.STATUS_NEED_INVESTIGATION,
+    )
+    return make_na_ticket(golden, duplicate)
+
+
+def test_bulk_needs_adjudication_both_distinct_on_a_shared_document_number_is_rejected(
+    api_client: Any,
+    user: User,
+    business_area: BusinessArea,
+    na_ticket_sharing_a_document_number: TicketNeedsAdjudicationDetails,
+    bulk_na_url: str,
+    create_user_role_with_permissions: Callable,
+) -> None:
+    create_user_role_with_permissions(
+        user,
+        [
+            Permissions.GRIEVANCES_APPROVE_FLAG_AND_DEDUPE,
+            Permissions.GRIEVANCES_CLOSE_TICKET_EXCLUDING_FEEDBACK,
+        ],
+        business_area,
+        whole_business_area_access=True,
+    )
+    golden = na_ticket_sharing_a_document_number.golden_records_individual
+    duplicate = na_ticket_sharing_a_document_number.possible_duplicates.get()
+
+    client = api_client(user)
+    response = client.post(
+        bulk_na_url,
+        {
+            "tickets": [
+                {
+                    "ticket_id": str(na_ticket_sharing_a_document_number.ticket.id),
+                    "duplicate_individual_ids": [],
+                    "distinct_individual_ids": [str(golden.id), str(duplicate.id)],
+                }
+            ]
+        },
+        format="json",
+    )
+
+    na_ticket_sharing_a_document_number.ticket.refresh_from_db()
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "1354917433" in str(response.data)
+    assert na_ticket_sharing_a_document_number.ticket.status == GrievanceTicket.STATUS_NEW
+
+
+def test_bulk_needs_adjudication_error_names_the_ticket_that_failed(
+    api_client: Any,
+    user: User,
+    business_area: BusinessArea,
+    na_ticket: TicketNeedsAdjudicationDetails,
+    na_ticket_with_withdrawn_duplicate: TicketNeedsAdjudicationDetails,
+    bulk_na_url: str,
+    create_user_role_with_permissions: Callable,
+) -> None:
+    create_user_role_with_permissions(
+        user,
+        [
+            Permissions.GRIEVANCES_APPROVE_FLAG_AND_DEDUPE,
+            Permissions.GRIEVANCES_CLOSE_TICKET_EXCLUDING_FEEDBACK,
+        ],
+        business_area,
+        whole_business_area_access=True,
+    )
+    withdrawn = na_ticket_with_withdrawn_duplicate.possible_duplicates.get()
+
+    client = api_client(user)
+    response = client.post(
+        bulk_na_url,
+        {
+            "tickets": [
+                {
+                    "ticket_id": str(na_ticket.ticket.id),
+                    "duplicate_individual_ids": [str(na_ticket.golden_records_individual.id)],
+                    "distinct_individual_ids": [str(na_ticket.possible_duplicates.get().id)],
+                },
+                {
+                    "ticket_id": str(na_ticket_with_withdrawn_duplicate.ticket.id),
+                    "duplicate_individual_ids": [],
+                    "distinct_individual_ids": [str(withdrawn.id)],
+                },
+            ]
+        },
+        format="json",
+    )
+
+    na_ticket.ticket.refresh_from_db()
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert na_ticket_with_withdrawn_duplicate.ticket.unicef_id in str(response.data)
+    assert na_ticket.ticket.status == GrievanceTicket.STATUS_NEW

--- a/tests/unit/apps/household/test_models.py
+++ b/tests/unit/apps/household/test_models.py
@@ -304,7 +304,7 @@ def test_mark_as_distinct_raise_errors(program) -> None:
 
     with pytest.raises(
         ValidationError,
-        match="Individual IND-333 cannot be marked as distinct: document 123456ABC is already valid",
+        match="Individual IND-333 cannot be marked as distinct: document 123456ABC conflicts",
     ):
         ind.mark_as_distinct()
 

--- a/tests/unit/apps/household/test_models.py
+++ b/tests/unit/apps/household/test_models.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 from django.db import IntegrityError
 from django.utils import timezone
 import pytest
+from rest_framework.exceptions import ValidationError
 
 from extras.test_utils.factories import (
     AreaFactory,
@@ -301,7 +302,10 @@ def test_mark_as_distinct_raise_errors(program) -> None:
     doc_2.document_number = "123456ABC"
     doc_2.save()
 
-    with pytest.raises(Exception, match="IND-333: Valid Document already exists: 123456ABC."):
+    with pytest.raises(
+        ValidationError,
+        match="Individual IND-333 cannot be marked as distinct: document 123456ABC is already valid",
+    ):
         ind.mark_as_distinct()
 
 


### PR DESCRIPTION
[AB#305854](https://unicef.visualstudio.com/4e044e8d-bc28-4768-8074-f80ff6e4a0e5/_workitems/edit/305854)

## Error handling

If two individuals share a document number and you mark both as distinct, the request failed with a 500. The user saw unlclear error. This happens when closing a single ticket too, not just batches.

And when one ticket in a batch failed, the whole batch was cancelled without saying which ticket caused it.

- The document clash now returns a clear message instead of a 500:
  `Individual IND-26-0000.0157 cannot be marked as distinct: document 1354917433 conflicts with an existing valid document.`
- Every batch error now starts with `Ticket GRV-0000029: `.

## Speed

Finalizing more than one ticket took about 8 seconds locally, for any number of tickets. The tickets were loaded with 18 tables joined in one query, which made Postgres expect a huge result and switch on JIT compilation — 8 seconds to prepare a query returning a handful of rows.

Now the detail tables load in separate small queries. Same data, still no N+1.

Bulk close used the same query, so it is faster too.