### PR TITLE
fix: raise HSTS max-age default to one year

### DIFF
--- a/src/hope/config/env.py
+++ b/src/hope/config/env.py
@@ -80,7 +80,7 @@ DEFAULTS = {
     "SECURE_CONTENT_TYPE_NOSNIFF": (bool, True),
     "SECURE_REFERRER_POLICY": (str, "same-origin"),
     "SESSION_COOKIE_NAME": (str, "sessionid"),
-    "SECURE_HSTS_SECONDS": (int, 3600),
+    "SECURE_HSTS_SECONDS": (int, 31536000),
     "FLOWER_ADDRESS": (str, "https://hope.unicef.org/flower"),
     "CACHE_ENABLED": (bool, True),
     "CACHE_LOCATION": (str, "redis://redis:6379/1"),


### PR DESCRIPTION
Bump the default `SECURE_HSTS_SECONDS` from 3600 seconds to 31536000 seconds (1 year).

A one-year max-age is the industry-standard recommended by [OWASP](https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Strict_Transport_Security_Cheat_Sheet.html) and Mozilla, and is the minimum required for browser HSTS preload list submission.