### PR TITLE
Disable deduplication tresholds for CW flow

### DIFF
--- a/src/hope/admin/business_area.py
+++ b/src/hope/admin/business_area.py
@@ -207,14 +207,15 @@ class BusinessAreaAdmin(
         """Make the biographic deduplication thresholds read only for Country Workspace only business areas.
 
         If some properties of RDI are above the values defined by one of
-        BIOGRAPHIC_DEDUPLICATION_THRESHOLD_FIELDS HOPE DROPS the RDI.
+        BIOGRAPHIC_DEDUPLICATION_THRESHOLD_FIELDS HOPE marks RDI as DEDUPLICATION_FAILED,
+        where it waits for erase / rerun.
 
         Intent:
         In Country Workspace - Automerge flow we'd like to have AUTOMERGE
-        on the first place and HOPE MUST NOT take the initative in that process.
+        on the first place and HOPE MUST NOT take the initiative in that process.
         That's why those fields are NOT respected (and read only)
         when Country Workspace flow is enabled.
-        For other RDI upload paths like XLSX, Kobo, Aurora tresholds ARE RESPECTED.
+        For other RDI upload paths like XLSX, Kobo, Aurora thresholds ARE RESPECTED.
         """
         read_only_fields = super().get_readonly_fields(request, obj)
         if obj and obj.is_rdi_ingest_source_country_workspace_only:

--- a/src/hope/admin/business_area.py
+++ b/src/hope/admin/business_area.py
@@ -36,7 +36,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Read only by DeduplicateTask.deduplicate_pending_individuals, which the Country Workspace flow never calls.
 BIOGRAPHIC_DEDUPLICATION_THRESHOLD_FIELDS = (
     "deduplication_batch_duplicates_percentage",
     "deduplication_batch_duplicates_allowed",
@@ -205,6 +204,18 @@ class BusinessAreaAdmin(
     filter_horizontal = ("countries", "payment_countries")
 
     def get_readonly_fields(self, request: HttpRequest, obj: Any | None = None) -> Any:
+        """Make the biographic deduplication thresholds read only for Country Workspace only business areas.
+
+        If some properties of RDI are above the values defined by one of
+        BIOGRAPHIC_DEDUPLICATION_THRESHOLD_FIELDS HOPE DROPS the RDI.
+
+        Intent:
+        In Country Workspace - Automerge flow we'd like to have AUTOMERGE
+        on the first place and HOPE MUST NOT take the initative in that process.
+        That's why those fields are NOT respected (and read only)
+        when Country Workspace flow is enabled.
+        For other RDI upload paths like XLSX, Kobo, Aurora tresholds ARE RESPECTED.
+        """
         read_only_fields = super().get_readonly_fields(request, obj)
         if obj and obj.is_rdi_ingest_source_country_workspace_only:
             return tuple(read_only_fields) + ("ingest_source", *BIOGRAPHIC_DEDUPLICATION_THRESHOLD_FIELDS)

--- a/src/hope/admin/business_area.py
+++ b/src/hope/admin/business_area.py
@@ -36,6 +36,18 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Read only by DeduplicateTask.deduplicate_pending_individuals, which the Country Workspace flow never calls.
+BIOGRAPHIC_DEDUPLICATION_THRESHOLD_FIELDS = (
+    "deduplication_batch_duplicates_percentage",
+    "deduplication_batch_duplicates_allowed",
+    "deduplication_golden_record_duplicates_percentage",
+    "deduplication_golden_record_duplicates_allowed",
+)
+BIOGRAPHIC_DEDUPLICATION_NOT_SUPPORTED_HELP_TEXT = (
+    "Not supported for Country Workspace only business areas - biographic duplicate thresholds "
+    "are not evaluated in this flow."
+)
+
 
 class XLSImportForm(forms.Form):
     xls_file = forms.FileField()
@@ -194,9 +206,16 @@ class BusinessAreaAdmin(
 
     def get_readonly_fields(self, request: HttpRequest, obj: Any | None = None) -> Any:
         read_only_fields = super().get_readonly_fields(request, obj)
-        if obj and obj.ingest_source == BusinessArea.IngestSource.COUNTRY_WORKSPACE_ONLY:
-            return tuple(read_only_fields) + ("ingest_source",)
+        if obj and obj.is_rdi_ingest_source_country_workspace_only:
+            return tuple(read_only_fields) + ("ingest_source", *BIOGRAPHIC_DEDUPLICATION_THRESHOLD_FIELDS)
         return read_only_fields
+
+    def get_form(self, request: HttpRequest, obj: Any | None = None, change: bool = False, **kwargs: Any) -> Any:
+        if obj and obj.is_rdi_ingest_source_country_workspace_only:
+            kwargs["help_texts"] = dict.fromkeys(
+                BIOGRAPHIC_DEDUPLICATION_THRESHOLD_FIELDS, BIOGRAPHIC_DEDUPLICATION_NOT_SUPPORTED_HELP_TEXT
+            )
+        return super().get_form(request, obj, change=change, **kwargs)
 
     def document_types_valid_for_deduplication(self, obj: Any) -> list:
         return list(DocumentType.objects.filter(valid_for_deduplication=True).values_list("label", flat=True))

--- a/tests/unit/apps/core/test_business_area_ingest_source.py
+++ b/tests/unit/apps/core/test_business_area_ingest_source.py
@@ -98,14 +98,15 @@ def business_area_editor():
     ],
 )
 def test_business_area_admin_deduplication_thresholds_readonly_state(
-    ingest_source, expected_readonly_thresholds, business_area_editor
+    ingest_source, expected_readonly_thresholds, business_area_editor, django_assert_num_queries
 ):
     ba = BusinessAreaFactory(ingest_source=ingest_source)
     admin = BusinessAreaAdmin(model=BusinessArea, admin_site=AdminSite())
     request = RequestFactory().get("/")
     request.user = business_area_editor
 
-    readonly = admin.get_readonly_fields(request, ba)
+    with django_assert_num_queries(0):
+        readonly = admin.get_readonly_fields(request, ba)
 
     assert (
         set(readonly)
@@ -129,14 +130,17 @@ def test_business_area_admin_deduplication_thresholds_readonly_state(
     ],
 )
 def test_business_area_admin_deduplication_threshold_help_text_for_country_workspace_only(
-    field_name, business_area_editor
+    field_name, business_area_editor, django_assert_num_queries
 ):
     ba = BusinessAreaFactory(ingest_source=BusinessArea.IngestSource.COUNTRY_WORKSPACE_ONLY)
     admin = BusinessAreaAdmin(model=BusinessArea, admin_site=AdminSite())
     request = RequestFactory().get("/")
     request.user = business_area_editor
 
-    form = admin.get_form(request, ba, change=True)(instance=ba)
+    with django_assert_num_queries(4):
+        form_class = admin.get_form(request, ba, change=True)
+
+    form = form_class(instance=ba)
     readonly_field = AdminReadonlyField(form, field_name, is_first=False, model_admin=admin)
 
     assert readonly_field.field["help_text"] == (
@@ -155,13 +159,14 @@ def test_business_area_admin_deduplication_threshold_help_text_for_country_works
     ],
 )
 def test_business_area_admin_deduplication_threshold_help_text_for_legacy_ingest_source(
-    field_name, business_area_editor
+    field_name, business_area_editor, django_assert_num_queries
 ):
     ba = BusinessAreaFactory(ingest_source=BusinessArea.IngestSource.ALL_EXCEPT_COUNTRY_WORKSPACE)
     admin = BusinessAreaAdmin(model=BusinessArea, admin_site=AdminSite())
     request = RequestFactory().get("/")
     request.user = business_area_editor
 
-    form = admin.get_form(request, ba, change=True)
+    with django_assert_num_queries(4):
+        form = admin.get_form(request, ba, change=True)
 
     assert form.base_fields[field_name].help_text == BusinessArea._meta.get_field(field_name).help_text

--- a/tests/unit/apps/core/test_business_area_ingest_source.py
+++ b/tests/unit/apps/core/test_business_area_ingest_source.py
@@ -1,4 +1,6 @@
+from django.contrib.admin.helpers import AdminReadonlyField
 from django.contrib.admin.sites import AdminSite
+from django.contrib.auth.models import Permission
 from django.core.exceptions import ValidationError
 from django.test import RequestFactory
 import pytest
@@ -71,3 +73,95 @@ def test_business_area_admin_ingest_source_readonly_state(ingest_source, expecte
         readonly = admin.get_readonly_fields(request, ba)
 
     assert ("ingest_source" in readonly) is expected_readonly
+
+
+@pytest.fixture
+def business_area_editor():
+    user = UserFactory(is_staff=True)
+    user.user_permissions.add(Permission.objects.get(content_type__app_label="core", codename="change_businessarea"))
+    return user
+
+
+@pytest.mark.parametrize(
+    ("ingest_source", "expected_readonly_thresholds"),
+    [
+        (BusinessArea.IngestSource.ALL_EXCEPT_COUNTRY_WORKSPACE, set()),
+        (
+            BusinessArea.IngestSource.COUNTRY_WORKSPACE_ONLY,
+            {
+                "deduplication_batch_duplicates_percentage",
+                "deduplication_batch_duplicates_allowed",
+                "deduplication_golden_record_duplicates_percentage",
+                "deduplication_golden_record_duplicates_allowed",
+            },
+        ),
+    ],
+)
+def test_business_area_admin_deduplication_thresholds_readonly_state(
+    ingest_source, expected_readonly_thresholds, business_area_editor
+):
+    ba = BusinessAreaFactory(ingest_source=ingest_source)
+    admin = BusinessAreaAdmin(model=BusinessArea, admin_site=AdminSite())
+    request = RequestFactory().get("/")
+    request.user = business_area_editor
+
+    readonly = admin.get_readonly_fields(request, ba)
+
+    assert (
+        set(readonly)
+        & {
+            "deduplication_batch_duplicates_percentage",
+            "deduplication_batch_duplicates_allowed",
+            "deduplication_golden_record_duplicates_percentage",
+            "deduplication_golden_record_duplicates_allowed",
+        }
+        == expected_readonly_thresholds
+    )
+
+
+@pytest.mark.parametrize(
+    "field_name",
+    [
+        "deduplication_batch_duplicates_percentage",
+        "deduplication_batch_duplicates_allowed",
+        "deduplication_golden_record_duplicates_percentage",
+        "deduplication_golden_record_duplicates_allowed",
+    ],
+)
+def test_business_area_admin_deduplication_threshold_help_text_for_country_workspace_only(
+    field_name, business_area_editor
+):
+    ba = BusinessAreaFactory(ingest_source=BusinessArea.IngestSource.COUNTRY_WORKSPACE_ONLY)
+    admin = BusinessAreaAdmin(model=BusinessArea, admin_site=AdminSite())
+    request = RequestFactory().get("/")
+    request.user = business_area_editor
+
+    form = admin.get_form(request, ba, change=True)(instance=ba)
+    readonly_field = AdminReadonlyField(form, field_name, is_first=False, model_admin=admin)
+
+    assert readonly_field.field["help_text"] == (
+        "Not supported for Country Workspace only business areas - biographic duplicate thresholds "
+        "are not evaluated in this flow."
+    )
+
+
+@pytest.mark.parametrize(
+    "field_name",
+    [
+        "deduplication_batch_duplicates_percentage",
+        "deduplication_batch_duplicates_allowed",
+        "deduplication_golden_record_duplicates_percentage",
+        "deduplication_golden_record_duplicates_allowed",
+    ],
+)
+def test_business_area_admin_deduplication_threshold_help_text_for_legacy_ingest_source(
+    field_name, business_area_editor
+):
+    ba = BusinessAreaFactory(ingest_source=BusinessArea.IngestSource.ALL_EXCEPT_COUNTRY_WORKSPACE)
+    admin = BusinessAreaAdmin(model=BusinessArea, admin_site=AdminSite())
+    request = RequestFactory().get("/")
+    request.user = business_area_editor
+
+    form = admin.get_form(request, ba, change=True)
+
+    assert form.base_fields[field_name].help_text == BusinessArea._meta.get_field(field_name).help_text


### PR DESCRIPTION
## Context

During the demo I was able to upload data from the same XLSX using country workspace TWICE. It means, that tresholds for dropping RDI due to too many duplicates are NOT respected in HOPE in CW flow.

## Problem statement

Following BA attributes are not respected in HOPE in CW flow:
```
    "deduplication_batch_duplicates_percentage",
    "deduplication_batch_duplicates_allowed",
    "deduplication_golden_record_duplicates_percentage",
    "deduplication_golden_record_duplicates_allowed",
```

## Solution

Make them read only. Add help text, that will inform the user that these are NOT respected in CW flow.