### PR TITLE
AB#340074 Add clear_celery_locks management command for deploys

### DIFF
--- a/docs/guide-adm/maintenance.md
+++ b/docs/guide-adm/maintenance.md
@@ -89,3 +89,30 @@ they still have no KAB stored.
 
 The `backfill_kab` command was introduced by
 [AB#326718: Calculate Gender and Age disaggregated group ALSO for Partial Data collecting Type](https://dev.azure.com/unicef/ICTD-HCT-MIS/_workitems/edit/326718).
+
+## Celery locks
+
+Celery tasks that must not run twice (payment plan rebuilds, RDI import and merge, PDU merge, universal
+update, dashboard reports) hold a lock in the Redis cache for the whole task, with a TTL of hours. A worker
+pod killed on deploy leaves its locks behind, and the redelivered job then fails or skips its work until
+the TTL runs out.
+
+`clear_celery_locks` removes every celery task lock and nothing else from the cache.
+
+!!! danger "Run it only while no celery worker is running"
+    A running worker may hold a live lock. Removing it lets a second instance of the same task start.
+
+Deployment order:
+
+1. Stop all old worker pods.
+2. Run the command once, with the same environment as the workers (it needs `CACHE_LOCATION`):
+
+    ```bash
+    python manage.py clear_celery_locks
+    ```
+
+3. Start the new worker pods.
+
+The command matches keys by prefix. The list lives in
+`src/hope/apps/core/management/commands/clear_celery_locks.py` and must be extended when a task gets a
+lock with a new key.

--- a/src/hope/apps/core/management/commands/clear_celery_locks.py
+++ b/src/hope/apps/core/management/commands/clear_celery_locks.py
@@ -1,0 +1,42 @@
+from typing import Any
+
+from django.core.cache import cache
+from django.core.management import BaseCommand
+
+# One prefix per lock site in celery tasks, whatever the mechanism (cache.lock, cache.add, locked_cache, get/set guard).
+# When you add a lock to a task, add its key prefix here.
+LOCK_KEY_PREFIXES = (
+    # cache.lock
+    "export_payment_plan_group_delivery_xlsx_",
+    "payment_plan_generate_token_and_order_numbers_",
+    "payment_plan_rebuild_stats_",
+    "payment_plan_full_rebuild_",
+    "send_western_union_report_email_notifications_",
+    "send_payment_plan_reconciliation_overdue_email_",
+    "pdu_online_edit_merge",
+    "lock:run_universal_individual_update_async_task:",
+    "lock:generate_universal_individual_update_template_async_task:",
+    # cache.add
+    "dash_report_task_running_",
+    # locked_cache, which is cache.get_or_set
+    "registration_xlsx_import_async_task-",
+    "registration_program_population_import_async_task-",
+    "registration_kobo_import_async_task-",
+    "merge_registration_data_import_async_task-",
+    "classify_findings_and_schedule_merge_async_task-",
+    "process_generic_import_async_task-",
+    "automate_rdi_creation_async_task-",
+    "deduplicate_documents",
+    # cache.get / cache.set guards with hashed params
+    "prepare_payment_plan_async_task_",
+    "enroll_households_to_program_async_task_",
+)
+
+
+class Command(BaseCommand):
+    help = "Remove every celery task lock from the cache. Run only while no celery worker is running (deploy)."
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        lock_keys = [key for key in cache.keys("*") if key.startswith(LOCK_KEY_PREFIXES)]
+        cache.delete_many(lock_keys)
+        self.stdout.write(f"Removed {len(lock_keys)} celery task locks")

--- a/src/hope/apps/core/management/commands/clear_celery_locks.py
+++ b/src/hope/apps/core/management/commands/clear_celery_locks.py
@@ -37,6 +37,5 @@ class Command(BaseCommand):
     help = "Remove every celery task lock from the cache. Run only while no celery worker is running (deploy)."
 
     def handle(self, *args: Any, **options: Any) -> None:
-        lock_keys = [key for key in cache.keys("*") if key.startswith(LOCK_KEY_PREFIXES)]
-        cache.delete_many(lock_keys)
-        self.stdout.write(f"Removed {len(lock_keys)} celery task locks")
+        removed = sum(cache.delete_pattern(f"{prefix}*") for prefix in LOCK_KEY_PREFIXES)
+        self.stdout.write(f"Removed {removed} celery task locks")

--- a/src/hope/apps/core/memcache.py
+++ b/src/hope/apps/core/memcache.py
@@ -32,6 +32,10 @@ class SimpleCacheLock:
 
 
 class LocMemCache(DjangoLocMemCache):
+    def keys(self, pattern: str = "*") -> list[str]:
+        """All keys without the version prefix, like django-redis."""
+        return [key.split(":", 2)[2] for key in list(self._cache)]
+
     def delete_pattern(self, pattern: str) -> None:
         regex_pattern = re.escape(pattern).replace("\\*", "(.*)")
         key_pattern = self.make_key(regex_pattern)

--- a/src/hope/apps/core/memcache.py
+++ b/src/hope/apps/core/memcache.py
@@ -32,16 +32,14 @@ class SimpleCacheLock:
 
 
 class LocMemCache(DjangoLocMemCache):
-    def keys(self, pattern: str = "*") -> list[str]:
-        """All keys without the version prefix, like django-redis."""
-        return [key.split(":", 2)[2] for key in list(self._cache)]
-
-    def delete_pattern(self, pattern: str) -> None:
+    def delete_pattern(self, pattern: str) -> int:
         regex_pattern = re.escape(pattern).replace("\\*", "(.*)")
         key_pattern = self.make_key(regex_pattern)
-        for key in self._cache:
-            if re.match(key_pattern, key):
-                self.delete(key)
+        matching = [key for key in self._cache if re.match(key_pattern, key)]
+        with self._lock:
+            for key in matching:
+                self._delete(key)
+        return len(matching)
 
     def expire(self, key: str, timeout: float | None = None) -> bool:
         """Set expiration time on an existing key."""

--- a/src/hope/apps/household/celery_tasks.py
+++ b/src/hope/apps/household/celery_tasks.py
@@ -183,7 +183,7 @@ def enroll_households_to_program_async_task_action(job: AsyncJob) -> None:
         "program_for_enroll_id": program_for_enroll_id,
     }
     task_params_str = json.dumps(task_params, sort_keys=True)
-    cache_key = hashlib.sha256(task_params_str.encode()).hexdigest()
+    cache_key = "enroll_households_to_program_async_task_" + hashlib.sha256(task_params_str.encode()).hexdigest()
     if cache.get(cache_key):
         logger.info("Task enroll_households_to_program_async_task with this data is already running.")
         return

--- a/src/hope/apps/payment/utils.py
+++ b/src/hope/apps/payment/utils.py
@@ -348,7 +348,7 @@ def get_payment_delivered_quantity_status_and_value(
 
 def generate_cache_key(data: dict[str, Any]) -> str:
     task_params_str = json.dumps(data)
-    return hashlib.sha256(task_params_str.encode()).hexdigest()
+    return "prepare_payment_plan_async_task_" + hashlib.sha256(task_params_str.encode()).hexdigest()
 
 
 def get_link(api_url: str) -> str:

--- a/tests/unit/apps/core/test_clear_celery_locks_command.py
+++ b/tests/unit/apps/core/test_clear_celery_locks_command.py
@@ -1,0 +1,41 @@
+from io import StringIO
+
+from django.core.cache import cache
+from django.core.management import call_command
+import pytest
+
+from hope.apps.core.management.commands.clear_celery_locks import LOCK_KEY_PREFIXES
+from hope.apps.payment.utils import generate_cache_key
+
+
+@pytest.fixture
+def lock_keys() -> list[str]:
+    keys = [f"{prefix}1" for prefix in LOCK_KEY_PREFIXES] + [
+        generate_cache_key({"task_name": "prepare_payment_plan_async_task", "payment_plan_id": "1"}),
+    ]
+    for key in keys:
+        cache.set(key, True)
+    yield keys
+    cache.clear()
+
+
+@pytest.fixture
+def other_key() -> str:
+    cache.set("count_afghanistan_HouseholdNodeConnection_1", 5)
+    yield "count_afghanistan_HouseholdNodeConnection_1"
+    cache.clear()
+
+
+def test_removes_every_lock_key(lock_keys: list[str]) -> None:
+    out = StringIO()
+
+    call_command("clear_celery_locks", stdout=out)
+
+    assert [key for key in lock_keys if cache.get(key) is not None] == []
+    assert out.getvalue().strip() == f"Removed {len(lock_keys)} celery task locks"
+
+
+def test_leaves_other_cache_keys(lock_keys: list[str], other_key: str) -> None:
+    call_command("clear_celery_locks")
+
+    assert cache.get(other_key) == 5

--- a/tests/unit/apps/program/test_program_utils.py
+++ b/tests/unit/apps/program/test_program_utils.py
@@ -405,7 +405,7 @@ def test_enroll_households_to_program_task_already_running(
         "program_for_enroll_id": str(enrollment_test_data["program2"].pk),
     }
     task_params_str = json.dumps(task_params, sort_keys=True)
-    cache_key = hashlib.sha256(task_params_str.encode()).hexdigest()
+    cache_key = "enroll_households_to_program_async_task_" + hashlib.sha256(task_params_str.encode()).hexdigest()
     cache.set(cache_key, True, timeout=24 * 60 * 60)
 
     with django_capture_on_commit_callbacks(execute=True):


### PR DESCRIPTION
[AB#340074](https://unicef.visualstudio.com/4e044e8d-bc28-4768-8074-f80ff6e4a0e5/_workitems/edit/340074)

Celery workers replaced on deploy leave their task locks in Redis for hours, so redelivered jobs fail or skip their work. This adds `python manage.py clear_celery_locks`, to be run once per deploy after the old worker pods are stopped and before the new ones start.

- Command holds an explicit list of lock key prefixes, one per lock site (`cache.lock`, `cache.add`, `locked_cache`, hand-rolled `cache.get`/`cache.set` guards), and deletes only keys starting with one of them. The rest of the cache is untouched.
- The `prepare_payment_plan` and `enroll_households_to_program` guards used a bare SHA256 of the params as the key, so nothing could tell them apart from other cache entries. Their keys now start with the task name; the hashing itself is unchanged.
- Test `LocMemCache.delete_pattern` re-prefixed the key on delete and never removed anything; fixed so the command can be tested.
- Docs: "Celery locks" section in `guide-adm/maintenance.md` with the deployment order.