### PR TITLE
340040_Vision_Integration_share_exchange_rate_when_creating_payment_p…

### DIFF
--- a/src/hope/apps/payment/services/payment_plan_services.py
+++ b/src/hope/apps/payment/services/payment_plan_services.py
@@ -246,7 +246,7 @@ class PaymentPlanService:
             self.payment_plan,
             PaymentPlan.Action.REVIEW.value,
             release_user_id,
-            f"{timezone.now():%-d %B %Y}",
+            timezone.now().isoformat(),
         )
         return self.payment_plan
 

--- a/src/hope/contrib/api/serializers/vision.py
+++ b/src/hope/contrib/api/serializers/vision.py
@@ -114,6 +114,7 @@ class PaymentPlanPayloadSerializer(serializers.Serializer):
     currency = serializers.CharField(source="currency.code")
     auth_amt = serializers.CharField(source="total_entitled_quantity")
     auth_amt_usd = serializers.CharField(source="total_entitled_quantity_usd")
+    exchange_rate = serializers.DecimalField(max_digits=15, decimal_places=8, allow_null=True)
     status = serializers.CharField()
     head_vendor = serializers.CharField(source="financial_service_provider.name")
     creation_date = serializers.SerializerMethodField()

--- a/src/hope/contrib/api/serializers/vision.py
+++ b/src/hope/contrib/api/serializers/vision.py
@@ -4,7 +4,6 @@ from rest_framework import serializers
 
 from hope.apps.core.utils import to_camel_case
 from hope.contrib.vision.models import FundsCommitmentItem
-from hope.models import PaymentPlan
 
 VISION_CALLBACK_FIELD_OVERRIDES = {
     "vision_payplanSno": "vision_payplan_sno",
@@ -115,12 +114,7 @@ class PaymentPlanPayloadSerializer(serializers.Serializer):
     auth_amt = serializers.CharField(source="total_entitled_quantity")
     auth_amt_usd = serializers.CharField(source="total_entitled_quantity_usd")
     exchange_rate = serializers.DecimalField(max_digits=15, decimal_places=8, allow_null=True)
-    status = serializers.CharField()
     head_vendor = serializers.CharField(source="financial_service_provider.name")
-    creation_date = serializers.SerializerMethodField()
-
-    def get_creation_date(self, obj: PaymentPlan) -> str:
-        return obj.created_at.strftime("%Y%m%d")
 
     def to_representation(self, instance: Any) -> dict[str, Any]:
         data = super().to_representation(instance)

--- a/tests/unit/contrib/vision/test_services.py
+++ b/tests/unit/contrib/vision/test_services.py
@@ -1,4 +1,5 @@
-from unittest.mock import ANY, MagicMock, PropertyMock, patch
+from datetime import datetime
+from unittest.mock import MagicMock, PropertyMock, patch
 
 from flags.models import FlagState
 import pytest
@@ -731,12 +732,13 @@ def test_release_from_vision_uses_payment_plan_creator(
     assert vision_payment_plan.status == PaymentPlan.Status.ACCEPTED
     assert release.created_by == vision_payment_plan.created_by
     assert release.comment is None
-    mock_notification.assert_called_once_with(
+    assert mock_notification.call_count == 1
+    assert mock_notification.call_args.args[:3] == (
         vision_payment_plan,
         PaymentPlan.Action.REVIEW.value,
         str(vision_payment_plan.created_by_id),
-        ANY,
     )
+    assert datetime.fromisoformat(mock_notification.call_args.args[3]).tzinfo is not None
 
 
 def test_release_from_vision_rejects_non_review_plan(

--- a/tests/unit/contrib/vision/test_vision_api.py
+++ b/tests/unit/contrib/vision/test_vision_api.py
@@ -1,5 +1,6 @@
 from collections.abc import Callable
 from datetime import datetime, timedelta
+from decimal import Decimal
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -11,6 +12,7 @@ from extras.test_utils.factories import (
     PaymentPlanFactory,
 )
 from hope.apps.core.api.mixins import BaseAPI
+from hope.contrib.api.serializers.vision import PaymentPlanPayloadSerializer
 from hope.contrib.vision.api import VisionAPI, VisionAPIError, VisionAPIMissingCredentialsError
 from hope.contrib.vision.choices import VisionLogEntryType, VisionStatus
 from hope.contrib.vision.services import VisionService
@@ -33,6 +35,7 @@ def vision_api_payment_plan_factory(db) -> Callable[..., PaymentPlan]:
         unicef_id: str = "PP001",
         currency_code: str = "USD",
         created_at: datetime = datetime(2025, 1, 1),
+        exchange_rate: Decimal | None = Decimal("1.25000000"),
     ) -> PaymentPlan:
         business_area = BusinessAreaFactory(code="FI01")
         currency = CurrencyFactory(code=currency_code)
@@ -50,12 +53,18 @@ def vision_api_payment_plan_factory(db) -> Callable[..., PaymentPlan]:
             financial_service_provider=financial_service_provider,
             total_entitled_quantity="10000.00",
             total_entitled_quantity_usd="10000.00",
+            exchange_rate=exchange_rate,
         )
         PaymentPlan.objects.filter(pk=payment_plan.pk).update(created_at=created_at)
         payment_plan.created_at = created_at
         return payment_plan
 
     return create_payment_plan
+
+
+@pytest.fixture
+def payment_plan_without_exchange_rate(vision_api_payment_plan_factory) -> PaymentPlan:
+    return vision_api_payment_plan_factory(exchange_rate=None)
 
 
 def test_missing_vision_url_raises_error(settings) -> None:
@@ -165,11 +174,22 @@ def test_send_payment_plan(mock_post, mock_acquire_token, vision_api_payment_pla
             "currency": "USD",
             "authAmt": "10000.00",
             "authAmtUsd": "10000.00",
+            "exchangeRate": "1.25000000",
             "status": PaymentPlan.Status.IN_REVIEW,
             "headVendor": "Head Vendor Name",
             "creationDate": "20250101",
         },
     )
+
+
+def test_payment_plan_payload_includes_null_exchange_rate(
+    payment_plan_without_exchange_rate,
+    django_assert_num_queries,
+) -> None:
+    with django_assert_num_queries(0):
+        payload = PaymentPlanPayloadSerializer(payment_plan_without_exchange_rate).data
+
+    assert payload["exchangeRate"] is None
 
 
 @patch("hope.contrib.vision.api.VisionAPI._acquire_token")
@@ -197,6 +217,7 @@ def test_send_payment_plan_with_creation_date(
             "currency": "USD",
             "authAmt": "10000.00",
             "authAmtUsd": "10000.00",
+            "exchangeRate": "1.25000000",
             "status": PaymentPlan.Status.IN_REVIEW,
             "headVendor": "Head Vendor Name",
             "creationDate": "20250615",
@@ -230,6 +251,7 @@ def test_send_payment_plan_with_different_currency(
             "currency": "EUR",
             "authAmt": "10000.00",
             "authAmtUsd": "10000.00",
+            "exchangeRate": "1.25000000",
             "status": PaymentPlan.Status.IN_REVIEW,
             "headVendor": "Head Vendor Name",
             "creationDate": "20250301",

--- a/tests/unit/contrib/vision/test_vision_api.py
+++ b/tests/unit/contrib/vision/test_vision_api.py
@@ -175,9 +175,7 @@ def test_send_payment_plan(mock_post, mock_acquire_token, vision_api_payment_pla
             "authAmt": "10000.00",
             "authAmtUsd": "10000.00",
             "exchangeRate": "1.25000000",
-            "status": PaymentPlan.Status.IN_REVIEW,
             "headVendor": "Head Vendor Name",
-            "creationDate": "20250101",
         },
     )
 
@@ -194,39 +192,6 @@ def test_payment_plan_payload_includes_null_exchange_rate(
 
 @patch("hope.contrib.vision.api.VisionAPI._acquire_token")
 @patch("hope.contrib.vision.api.VisionAPI._post")
-def test_send_payment_plan_with_creation_date(
-    mock_post,
-    mock_acquire_token,
-    vision_api_payment_plan_factory,
-) -> None:
-    mock_post.return_value = ({"status": "ok"}, 200)
-    api = VisionAPI()
-    pp = vision_api_payment_plan_factory(
-        unicef_id="PP002",
-        created_at=datetime(2025, 6, 15, 10, 30, 0),
-    )
-    result = api.send_payment_plan(pp)
-    assert result == {"status": "ok"}
-    mock_post.assert_called_once_with(
-        "https://test.example.com/ps/ezcash/PaymentPlan",
-        {
-            "businessArea": "FI01",
-            "vendorNumber": "V100004",
-            "payplanSno": "PP002",
-            "payplanDesc": "Monthly payment plan testing the content length",
-            "currency": "USD",
-            "authAmt": "10000.00",
-            "authAmtUsd": "10000.00",
-            "exchangeRate": "1.25000000",
-            "status": PaymentPlan.Status.IN_REVIEW,
-            "headVendor": "Head Vendor Name",
-            "creationDate": "20250615",
-        },
-    )
-
-
-@patch("hope.contrib.vision.api.VisionAPI._acquire_token")
-@patch("hope.contrib.vision.api.VisionAPI._post")
 def test_send_payment_plan_with_different_currency(
     mock_post,
     mock_acquire_token,
@@ -237,7 +202,6 @@ def test_send_payment_plan_with_different_currency(
     pp = vision_api_payment_plan_factory(
         unicef_id="PP003",
         currency_code="EUR",
-        created_at=datetime(2025, 3, 1),
     )
     result = api.send_payment_plan(pp)
     assert result == {"status": "ok"}
@@ -252,9 +216,7 @@ def test_send_payment_plan_with_different_currency(
             "authAmt": "10000.00",
             "authAmtUsd": "10000.00",
             "exchangeRate": "1.25000000",
-            "status": PaymentPlan.Status.IN_REVIEW,
             "headVendor": "Head Vendor Name",
-            "creationDate": "20250301",
         },
     )
 


### PR DESCRIPTION
…lan_in_vision

[AB#340040](https://unicef.visualstudio.com/4e044e8d-bc28-4768-8074-f80ff6e4a0e5/_workitems/edit/340040)

  - Add the Payment Plan’s stored exchange rate to the Vision payload as exchangeRate.
  - Serialize the rate with eight decimal places and return null when unavailable.
  - Send an ISO-formatted, timezone-aware action date for automatic Vision release notifications.
  - Update tests for the new payload field, null exchange rates, and timestamp format.